### PR TITLE
Add sort, order and offset to client.data_object.get()

### DIFF
--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -4,7 +4,7 @@ import time
 import uuid
 from datetime import datetime
 from datetime import timezone
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import pytest
 
@@ -192,7 +192,7 @@ def test_query_get_with_offset(people_schema, offset: Optional[int]):
         ({"properties": ["description", "size", "name"]}, ["name10", "name15", "name11", "name16"]),
     ],
 )
-def test_query_get_with_sort(sort: Optional[tuple], expected: List[str]):
+def test_query_get_with_sort(sort: Optional[Dict], expected: List[str]):
     client = weaviate.Client("http://localhost:8080")
     client.schema.delete_all()
     client.schema.create(SHIP_SCHEMA)

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -165,7 +165,6 @@ def test_query_get_with_sort(sort_and_ascending: Optional[tuple]):
         }
     ]
 }
-
     client = weaviate.Client("http://localhost:8080")
     client.schema.delete_all()
     client.schema.create(ship_schema)
@@ -175,8 +174,6 @@ def test_query_get_with_sort(sort_and_ascending: Optional[tuple]):
             batch.add_data_object({"name": f"name{i}", "size": i%5+5, "description": "Super long description"}, "Ship")
             batch.add_data_object({"name": f"name{i+10}", "size": i%5+5, "description": "Short description"}, "Ship")
         batch.flush()
-
-
 
     result = client.data_object.get(class_name="Ship", sort = sort, ascending = ascending)
     if sort_and_ascending == ("name",True):

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -4,7 +4,7 @@ import time
 import uuid
 from datetime import datetime
 from datetime import timezone
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Union
 
 import pytest
 
@@ -192,7 +192,9 @@ def test_query_get_with_offset(people_schema, offset: Optional[int]):
         ({"properties": ["description", "size", "name"]}, ["name10", "name15", "name11", "name16"]),
     ],
 )
-def test_query_get_with_sort(sort: Optional[Dict], expected: List[str]):
+def test_query_get_with_sort(
+    sort: Optional[Dict[str, Union[str, bool, List[bool], List[str]]]], expected: List[str]
+):
     client = weaviate.Client("http://localhost:8080")
     client.schema.delete_all()
     client.schema.create(SHIP_SCHEMA)

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -124,7 +124,7 @@ def test_query_get_with_limit(people_schema, limit: Optional[int]):
         assert len(result["objects"]) == limit
     client.schema.delete_all()
     
-@pytest.mark.parametrize("offset", [None, 1, 5, 20, 50])
+@pytest.mark.parametrize("offset", [None,0, 1, 5, 20, 50])
 def test_query_get_with_offset(people_schema, offset: Optional[int]):
     client = weaviate.Client("http://localhost:8080")
     client.schema.delete_all()

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -148,7 +148,7 @@ def test_query_get_with_offset(people_schema, offset: Optional[int]):
 
 
 
-@pytest.mark.parametrize("sort_and_ascending",[("name",True),("name",False),(["description","size","name"],[False,True,False]),(["description","size","name"],False),(["description","size","name"],True)])
+@pytest.mark.parametrize("sort_and_ascending",[("name",True),("name",False),(["name"],[False]),(["description","size","name"],[False,True,False]),(["description","size","name"],False),(["description","size","name"],True)])
 def test_query_get_with_sort(sort_and_ascending: Optional[tuple]):
     sort = sort_and_ascending[0]
     ascending = sort_and_ascending[1]
@@ -178,7 +178,7 @@ def test_query_get_with_sort(sort_and_ascending: Optional[tuple]):
     result = client.data_object.get(class_name="Ship", sort = sort, ascending = ascending)
     if sort_and_ascending == ("name",True):
         assert result["objects"][0]["properties"]["name"] == "name0"
-    elif sort_and_ascending == ("name",False):
+    elif sort_and_ascending == ("name",False) or sort_and_ascending == (["name"],[False]):
         assert result["objects"][0]["properties"]["name"] == "name9"
     elif sort_and_ascending == (["description","size","name"],[False,True,False]):
         assert result["objects"][0]["properties"]["name"] == "name5"

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -165,21 +165,18 @@ def test_query_get_with_offset(people_schema, offset: Optional[int]):
 @pytest.mark.parametrize(
     "sort,expected",
     [
-        (["name", True], ["name" + "{:02d}".format(i) for i in range(0,20)]),
-        (["name", False], ["name" + "{:02d}".format(i) for i in range(19,-1,-1)]),
-        ([["name"], [False]], ["name" + "{:02d}".format(i) for i in range(19,-1,-1)]),
+        (["name", True], ["name" + "{:02d}".format(i) for i in range(0, 20)]),
+        (["name", False], ["name" + "{:02d}".format(i) for i in range(19, -1, -1)]),
+        ([["name"], [False]], ["name" + "{:02d}".format(i) for i in range(19, -1, -1)]),
         (
-            [["description", "size", "name"],
-            [False, True, False]],
+            [["description", "size", "name"], [False, True, False]],
             ["name05", "name00", "name06", "name01"],
         ),
         ([["description", "size", "name"], False], ["name09", "name04", "name08", "name03"]),
         ([["description", "size", "name"], True], ["name10", "name15", "name11", "name16"]),
     ],
 )
-def test_query_get_with_sort(
-    sort: Optional[tuple], expected: List[str]
-):
+def test_query_get_with_sort(sort: Optional[tuple], expected: List[str]):
     client = weaviate.Client("http://localhost:8080")
     client.schema.delete_all()
     client.schema.create(SHIP_SCHEMA)
@@ -188,11 +185,19 @@ def test_query_get_with_sort(
     for i in range(num_objects):
         with client.batch as batch:
             batch.add_data_object(
-                {"name": f"name" + "{:02d}".format(i), "size": i % 5 + 5, "description": "Super long description"},
+                {
+                    "name": f"name" + "{:02d}".format(i),
+                    "size": i % 5 + 5,
+                    "description": "Super long description",
+                },
                 "Ship",
             )
             batch.add_data_object(
-                {"name": f"name" + "{:02d}".format(i+10), "size": i % 5 + 5, "description": "Short description"},
+                {
+                    "name": f"name" + "{:02d}".format(i + 10),
+                    "size": i % 5 + 5,
+                    "description": "Short description",
+                },
                 "Ship",
             )
         batch.flush()

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -4,7 +4,7 @@ import time
 import uuid
 from datetime import datetime
 from datetime import timezone
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import pytest
 
@@ -186,7 +186,7 @@ def test_query_get_with_sort(sort: Optional[tuple], expected: List[str]):
         with client.batch as batch:
             batch.add_data_object(
                 {
-                    "name": f"name" + "{:02d}".format(i),
+                    "name": "name" + "{:02d}".format(i),
                     "size": i % 5 + 5,
                     "description": "Super long description",
                 },
@@ -194,7 +194,7 @@ def test_query_get_with_sort(sort: Optional[tuple], expected: List[str]):
             )
             batch.add_data_object(
                 {
-                    "name": f"name" + "{:02d}".format(i + 10),
+                    "name": "name" + "{:02d}".format(i + 10),
                     "size": i % 5 + 5,
                     "description": "Short description",
                 },

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -165,15 +165,31 @@ def test_query_get_with_offset(people_schema, offset: Optional[int]):
 @pytest.mark.parametrize(
     "sort,expected",
     [
-        (["name", True], ["name" + "{:02d}".format(i) for i in range(0, 20)]),
-        (["name", False], ["name" + "{:02d}".format(i) for i in range(19, -1, -1)]),
-        ([["name"], [False]], ["name" + "{:02d}".format(i) for i in range(19, -1, -1)]),
         (
-            [["description", "size", "name"], [False, True, False]],
+            {"properties": "name", "order_asc": True},
+            ["name" + "{:02d}".format(i) for i in range(0, 20)],
+        ),
+        (
+            {"properties": "name", "order_asc": False},
+            ["name" + "{:02d}".format(i) for i in range(19, -1, -1)],
+        ),
+        (
+            {"properties": ["name"], "order_asc": [False]},
+            ["name" + "{:02d}".format(i) for i in range(19, -1, -1)],
+        ),
+        (
+            {"properties": ["description", "size", "name"], "order_asc": [False, True, False]},
             ["name05", "name00", "name06", "name01"],
         ),
-        ([["description", "size", "name"], False], ["name09", "name04", "name08", "name03"]),
-        ([["description", "size", "name"], True], ["name10", "name15", "name11", "name16"]),
+        (
+            {"properties": ["description", "size", "name"], "order_asc": False},
+            ["name09", "name04", "name08", "name03"],
+        ),
+        (
+            {"properties": ["description", "size", "name"], "order_asc": True},
+            ["name10", "name15", "name11", "name16"],
+        ),
+        ({"properties": ["description", "size", "name"]}, ["name10", "name15", "name11", "name16"]),
     ],
 )
 def test_query_get_with_sort(sort: Optional[tuple], expected: List[str]):

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -23,7 +23,6 @@ from weaviate.util import (
     _check_positive_num,
 )
 
-
 class DataObject:
     """
     DataObject class used to manipulate object to/from weaviate.
@@ -439,6 +438,8 @@ class DataObject:
         consistency_level: Optional[ConsistencyLevel] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        sort: Union[str,List[str],None] = None,
+        ascending: Union[bool,List[bool]] = True,
     ) -> List[dict]:
         """
         Gets objects from weaviate, the maximum number of objects returned is 100.
@@ -534,7 +535,31 @@ class DataObject:
         if offset is not None:
             _check_positive_num(offset, "offset", int, include_zero = True)
             params["offset"] = offset
-        
+
+        if isinstance(ascending, bool):
+            ascending = [ascending]
+        else:
+            if len(sort) != len(ascending):
+                raise SyntaxError(f"'ascending' must be the same length as 'sort' or a boolean. Current length is sort:{len(sort)} and ascending:{len(ascending)}.")
+        if sort is not None:
+            if isinstance(sort,str):
+                params["sort"] = sort
+            else:
+                sort = ','.join(sort)
+                params["sort"] = sort
+            #else:
+            #    raise TypeError(f"'sort' must be of type str or list[str]. Given type: {type(sort)}.")
+
+        if not isinstance(ascending, list):
+            raise TypeError(f"'ascending' must be of type boolean or list. Given type: {type(ascending)}.")
+
+        if len(ascending) == 0:
+            raise ValueError("'ascending' cannot be an empty list.")
+
+        order = ["asc" if x else "desc" for x in ascending]
+        order = ','.join(order)
+        params["order"] = order
+
         try:
             response = self._connection.get(
                 path=path,

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -3,7 +3,7 @@ DataObject class definition.
 """
 import uuid as uuid_lib
 import warnings
-from typing import Union, Optional, List, Sequence
+from typing import Union, Optional, List, Sequence, Dict
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
@@ -439,7 +439,7 @@ class DataObject:
         consistency_level: Optional[ConsistencyLevel] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        sort: Optional[dict[str, List, bool]] = None,
+        sort: Optional[Dict] = None,
     ) -> List[dict]:
         """
         Gets objects from weaviate, the maximum number of objects returned is 100.
@@ -473,7 +473,7 @@ class DataObject:
         offset: Optional[int], optional
             The offset of objects returned, i.e. the starting index of the returned objects. Should be
             used in conjunction with the 'limit' parameter.
-        sort: Optional[dict]
+        sort: Optional[Dict]
             A dictionary for sorting objects.
             sort['properties']: str, List[str]
                 By which properties the returned objects should be sorted. When more than one property is given, the objects are sorted in order of the list.
@@ -551,7 +551,7 @@ class DataObject:
                 raise ValueError("The sort clause is missing the required field: 'properties'.")
             if "order_asc" not in sort:
                 sort["order_asc"] = True
-            if not isinstance(sort, dict):
+            if not isinstance(sort, Dict):
                 raise TypeError(f"'sort' must be of type dict. Given type: {type(sort)}.")
             if isinstance(sort["properties"], str):
                 sort["properties"] = [sort["properties"]]

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -545,7 +545,7 @@ class DataObject:
             _check_positive_num(offset, "offset", int, include_zero=True)
             params["offset"] = offset
 
-        if sort is not None: 
+        if sort is not None:
             if not isinstance(sort, List):
                 raise TypeError(f"'sort' must be of type list. Given type: {type(sort)}.")
             if not len(sort) == 2:

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -536,29 +536,27 @@ class DataObject:
             _check_positive_num(offset, "offset", int, include_zero = True)
             params["offset"] = offset
 
-        if isinstance(ascending, bool):
-            ascending = [ascending]
-        else:
-            if len(sort) != len(ascending):
-                raise SyntaxError(f"'ascending' must be the same length as 'sort' or a boolean. Current length is sort:{len(sort)} and ascending:{len(ascending)}.")
         if sort is not None:
+            if isinstance(ascending, bool):
+                ascending = [ascending]*len(sort)
+            elif not isinstance(ascending, list):
+                raise TypeError(f"'ascending' must be of type boolean or list. Given type: {type(ascending)}.")
+            elif len(sort) != len(ascending):
+                raise SyntaxError(f"'ascending' must be the same length as 'sort' or a boolean (not in a list). Current length is sort:{len(sort)} and ascending:{len(ascending)}.")
+            elif len(ascending) == 0:
+                raise ValueError("'ascending' cannot be an empty list.")
+        
             if isinstance(sort,str):
                 params["sort"] = sort
             else:
                 sort = ','.join(sort)
                 params["sort"] = sort
             #else:
-            #    raise TypeError(f"'sort' must be of type str or list[str]. Given type: {type(sort)}.")
+            #   raise TypeError(f"'sort' must be of type str or list[str]. Given type: {type(sort)}.")
 
-        if not isinstance(ascending, list):
-            raise TypeError(f"'ascending' must be of type boolean or list. Given type: {type(ascending)}.")
-
-        if len(ascending) == 0:
-            raise ValueError("'ascending' cannot be an empty list.")
-
-        order = ["asc" if x else "desc" for x in ascending]
-        order = ','.join(order)
-        params["order"] = order
+            order = ["asc" if x else "desc" for x in ascending]
+            order = ','.join(order)
+            params["order"] = order
 
         try:
             response = self._connection.get(

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -469,6 +469,9 @@ class DataObject:
         limit: Optional[int], optional
             The maximum number of data objects to return.
             by default None, which uses the weaviate default of 100 entries
+        offset: Optional[int], optional
+            The offset of objects returned, i.e. the starting index of the returned objects. Should be
+            used in conjunction with the "limit" parameter.
 
         Returns
         -------
@@ -525,11 +528,11 @@ class DataObject:
             params["node_name"] = node_name
 
         if limit is not None:
-            _check_positive_num(limit, "limit", int)
+            _check_positive_num(limit, "limit", int, include_zero = False)
             params["limit"] = limit
-            
+
         if offset is not None:
-            _check_positive_num(offset, "offset", int)
+            _check_positive_num(offset, "offset", int, include_zero = True)
             params["offset"] = offset
         
         try:

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -474,12 +474,12 @@ class DataObject:
             The offset of objects returned, i.e. the starting index of the returned objects. Should be
             used in conjunction with the 'limit' parameter.
          sort: str, List[str] or None, optional
-            The path(s) of the properties that should be sorted. When a list of paths is given the objects are sorted in order of the list. 
+            The path(s) of the properties that should be sorted. When a list of paths is given, the objects are sorted in order of the list. 
             The order of the sorting can be given by using 'ascending'.
         ascending: bool, List[bool]
-            The order the paramters given in 'sort' should be returned in. When a single boolean is used, all parameters are sorted in the same order.
-             If a list is used, it needs to have the same length as 'sort'. Each parameters order is then decided individually. 
-             If 'ascending' is True, the parameters are sorted in ascending order. If it is False, they are sorted in descending order.
+            The order the properties given in 'sort' should be returned in. When a single boolean is used, all properties are sorted in the same order.
+             If a list is used, it needs to have the same length as 'sort'. Each properties order is then decided individually. 
+             If 'ascending' is True, the properties are sorted in ascending order. If it is False, they are sorted in descending order.
 
         Returns
         -------
@@ -552,8 +552,7 @@ class DataObject:
                 raise ValueError("'sort' cannot be an empty list.")
 
             if isinstance(ascending, bool):
-                if isinstance(sort, list):
-                    ascending = [ascending]*len(sort)
+                ascending = [ascending]*len(sort)
             if not isinstance(ascending, list) or not all(isinstance(x,bool) for x in ascending):
                 raise TypeError(f"'ascending' must be of type boolean or list[bool]. Given type: {type(ascending)}.")
             if len(sort) != len(ascending):

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -439,7 +439,7 @@ class DataObject:
         consistency_level: Optional[ConsistencyLevel] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        sort: Optional[Dict] = None,
+        sort: Optional[Dict[str, Union[str, bool, List[bool], List[str]]]] = None,
     ) -> List[dict]:
         """
         Gets objects from weaviate, the maximum number of objects returned is 100.

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -438,6 +438,7 @@ class DataObject:
         node_name: Optional[str] = None,
         consistency_level: Optional[ConsistencyLevel] = None,
         limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[dict]:
         """
         Gets objects from weaviate, the maximum number of objects returned is 100.
@@ -526,7 +527,11 @@ class DataObject:
         if limit is not None:
             _check_positive_num(limit, "limit", int)
             params["limit"] = limit
-
+            
+        if offset is not None:
+            _check_positive_num(offset, "offset", int)
+            params["offset"] = offset
+        
         try:
             response = self._connection.get(
                 path=path,

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -23,6 +23,7 @@ from weaviate.util import (
     _check_positive_num,
 )
 
+
 class DataObject:
     """
     DataObject class used to manipulate object to/from weaviate.
@@ -438,8 +439,8 @@ class DataObject:
         consistency_level: Optional[ConsistencyLevel] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        sort: Union[str,List[str],None] = None,
-        ascending: Union[bool,List[bool]] = True,
+        sort: Union[str, List[str], None] = None,
+        ascending: Union[bool, List[bool]] = True,
     ) -> List[dict]:
         """
         Gets objects from weaviate, the maximum number of objects returned is 100.
@@ -474,11 +475,11 @@ class DataObject:
             The offset of objects returned, i.e. the starting index of the returned objects. Should be
             used in conjunction with the 'limit' parameter.
          sort: str, List[str] or None, optional
-            The path(s) of the properties that should be sorted. When a list of paths is given, the objects are sorted in order of the list. 
+            The path(s) of the properties that should be sorted. When a list of paths is given, the objects are sorted in order of the list.
             The order of the sorting can be given by using 'ascending'.
         ascending: bool, List[bool]
             The order the properties given in 'sort' should be returned in. When a single boolean is used, all properties are sorted in the same order.
-             If a list is used, it needs to have the same length as 'sort'. Each properties order is then decided individually. 
+             If a list is used, it needs to have the same length as 'sort'. Each properties order is then decided individually.
              If 'ascending' is True, the properties are sorted in ascending order. If it is False, they are sorted in descending order.
 
         Returns
@@ -536,34 +537,40 @@ class DataObject:
             params["node_name"] = node_name
 
         if limit is not None:
-            _check_positive_num(limit, "limit", int, include_zero = False)
+            _check_positive_num(limit, "limit", int, include_zero=False)
             params["limit"] = limit
 
         if offset is not None:
-            _check_positive_num(offset, "offset", int, include_zero = True)
+            _check_positive_num(offset, "offset", int, include_zero=True)
             params["offset"] = offset
 
         if sort is not None:
-            if isinstance(sort,str):
+            if isinstance(sort, str):
                 sort = [sort]
-            if not isinstance(sort, list) or not all(isinstance(x,str) for x in sort):
-                raise TypeError(f"'sort' must be of type str or list[str]. Given type: {type(sort)}.")
+            if not isinstance(sort, list) or not all(isinstance(x, str) for x in sort):
+                raise TypeError(
+                    f"'sort' must be of type str or list[str]. Given type: {type(sort)}."
+                )
             if len(sort) == 0:
                 raise ValueError("'sort' cannot be an empty list.")
 
             if isinstance(ascending, bool):
-                ascending = [ascending]*len(sort)
-            if not isinstance(ascending, list) or not all(isinstance(x,bool) for x in ascending):
-                raise TypeError(f"'ascending' must be of type boolean or list[bool]. Given type: {type(ascending)}.")
+                ascending = [ascending] * len(sort)
+            if not isinstance(ascending, list) or not all(isinstance(x, bool) for x in ascending):
+                raise TypeError(
+                    f"'ascending' must be of type boolean or list[bool]. Given type: {type(ascending)}."
+                )
             if len(sort) != len(ascending):
-                raise ValueError(f"'ascending' must be the same length as 'sort' or a boolean (not in a list). Current length is sort:{len(sort)} and ascending:{len(ascending)}.")
+                raise ValueError(
+                    f"'ascending' must be the same length as 'sort' or a boolean (not in a list). Current length is sort:{len(sort)} and ascending:{len(ascending)}."
+                )
             if len(ascending) == 0:
                 raise ValueError("'ascending' cannot be an empty list.")
-        
-            sort = ','.join(sort)
+
+            sort = ",".join(sort)
             params["sort"] = sort
             order = ["asc" if x else "desc" for x in ascending]
-            order = ','.join(order)
+            order = ",".join(order)
             params["order"] = order
 
         try:

--- a/weaviate/data/crud_data.py
+++ b/weaviate/data/crud_data.py
@@ -472,7 +472,14 @@ class DataObject:
             by default None, which uses the weaviate default of 100 entries
         offset: Optional[int], optional
             The offset of objects returned, i.e. the starting index of the returned objects. Should be
-            used in conjunction with the "limit" parameter.
+            used in conjunction with the 'limit' parameter.
+         sort: str, List[str] or None, optional
+            The path(s) of the properties that should be sorted. When a list of paths is given the objects are sorted in order of the list. 
+            The order of the sorting can be given by using 'ascending'.
+        ascending: bool, List[bool]
+            The order the paramters given in 'sort' should be returned in. When a single boolean is used, all parameters are sorted in the same order.
+             If a list is used, it needs to have the same length as 'sort'. Each parameters order is then decided individually. 
+             If 'ascending' is True, the parameters are sorted in ascending order. If it is False, they are sorted in descending order.
 
         Returns
         -------
@@ -537,23 +544,25 @@ class DataObject:
             params["offset"] = offset
 
         if sort is not None:
+            if isinstance(sort,str):
+                sort = [sort]
+            if not isinstance(sort, list) or not all(isinstance(x,str) for x in sort):
+                raise TypeError(f"'sort' must be of type str or list[str]. Given type: {type(sort)}.")
+            if len(sort) == 0:
+                raise ValueError("'sort' cannot be an empty list.")
+
             if isinstance(ascending, bool):
-                ascending = [ascending]*len(sort)
-            elif not isinstance(ascending, list):
-                raise TypeError(f"'ascending' must be of type boolean or list. Given type: {type(ascending)}.")
-            elif len(sort) != len(ascending):
-                raise SyntaxError(f"'ascending' must be the same length as 'sort' or a boolean (not in a list). Current length is sort:{len(sort)} and ascending:{len(ascending)}.")
-            elif len(ascending) == 0:
+                if isinstance(sort, list):
+                    ascending = [ascending]*len(sort)
+            if not isinstance(ascending, list) or not all(isinstance(x,bool) for x in ascending):
+                raise TypeError(f"'ascending' must be of type boolean or list[bool]. Given type: {type(ascending)}.")
+            if len(sort) != len(ascending):
+                raise ValueError(f"'ascending' must be the same length as 'sort' or a boolean (not in a list). Current length is sort:{len(sort)} and ascending:{len(ascending)}.")
+            if len(ascending) == 0:
                 raise ValueError("'ascending' cannot be an empty list.")
         
-            if isinstance(sort,str):
-                params["sort"] = sort
-            else:
-                sort = ','.join(sort)
-                params["sort"] = sort
-            #else:
-            #   raise TypeError(f"'sort' must be of type str or list[str]. Given type: {type(sort)}.")
-
+            sort = ','.join(sort)
+            params["sort"] = sort
             order = ["asc" if x else "desc" for x in ascending]
             order = ','.join(order)
             params["order"] = order

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -494,7 +494,7 @@ def check_batch_result(
                 print(result["result"]["errors"])
 
 
-def _check_positive_num(value: Real, arg_name: str, data_type: type) -> None:
+def _check_positive_num(value: Real, arg_name: str, data_type: type, include_zero: bool = False) -> None:
     """
     Check if the `value` of the `arg_name` is a positive number.
 
@@ -506,6 +506,8 @@ def _check_positive_num(value: Real, arg_name: str, data_type: type) -> None:
         The name of the variable from the original function call. Used for error message.
     data_type : type
         The data type to check for.
+    include_zero : bool
+        Wether zero counts as positive or not. by default False.
 
     Raises
     ------
@@ -517,5 +519,10 @@ def _check_positive_num(value: Real, arg_name: str, data_type: type) -> None:
 
     if not isinstance(value, data_type) or isinstance(value, bool):
         raise TypeError(f"'{arg_name}' must be of type {data_type}.")
-    if value <= 0:
-        raise ValueError(f"'{arg_name}' must be positive, i.e. greater that zero (>0).")
+    if include_zero:
+        if value < 0:
+            raise ValueError(f"'{arg_name}' must be positive, i.e. greater or equal to zero (>=0).")
+    else:
+        if value <= 0:
+            raise ValueError(f"'{arg_name}' must be positive, i.e. greater that zero (>0).")
+    

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -507,7 +507,7 @@ def _check_positive_num(value: Real, arg_name: str, data_type: type, include_zer
     data_type : type
         The data type to check for.
     include_zero : bool
-        Wether zero counts as positive or not. by default False.
+        Wether zero counts as positive or not. By default False.
 
     Raises
     ------

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -525,4 +525,3 @@ def _check_positive_num(value: Real, arg_name: str, data_type: type, include_zer
     else:
         if value <= 0:
             raise ValueError(f"'{arg_name}' must be positive, i.e. greater that zero (>0).")
-    

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -494,7 +494,9 @@ def check_batch_result(
                 print(result["result"]["errors"])
 
 
-def _check_positive_num(value: Real, arg_name: str, data_type: type, include_zero: bool = False) -> None:
+def _check_positive_num(
+    value: Real, arg_name: str, data_type: type, include_zero: bool = False
+) -> None:
     """
     Check if the `value` of the `arg_name` is a positive number.
 


### PR DESCRIPTION
Close https://github.com/semi-technologies/weaviate-python-client/issues/188.
Adds the missing parameters sort, order and offset to the function client.data_object.get().