### PR TITLE
add embedded weaviate

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -45,6 +45,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=False,
                 additional_headers=None,
                 startup_period=None,
+                embedded=False,
             )
 
         with patch(
@@ -66,6 +67,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=False,
                 additional_headers={"Test": True},
                 startup_period=None,
+                embedded=False,
             )
 
         with patch(
@@ -83,6 +85,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=False,
                 additional_headers=None,
                 startup_period=None,
+                embedded=False,
             )
 
         with patch(
@@ -106,6 +109,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=True,
                 additional_headers=None,
                 startup_period=None,
+                embedded=False,
             )
 
     @patch("weaviate.client.Client.get_meta", return_value={"version": "1.13.2"})

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -114,13 +114,11 @@ class TestWeaviateClient(unittest.TestCase):
             )
 
         with patch(
-                "weaviate.client.Connection",
-                Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
+            "weaviate.client.Connection",
+            Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             with patch("weaviate.embedded.EmbeddedDB.start") as mocked_start:
-                Client(
-                    embedded_options=EmbeddedOptions()
-                )
+                Client(embedded_options=EmbeddedOptions())
                 args, kwargs = mock_obj.call_args_list[0]
                 self.assertEqual(kwargs["url"], "http://localhost:6666")
                 self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -45,7 +45,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=False,
                 additional_headers=None,
                 startup_period=None,
-                embedded=False,
+                embedded_db=None,
             )
 
         with patch(
@@ -67,7 +67,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=False,
                 additional_headers={"Test": True},
                 startup_period=None,
-                embedded=False,
+                embedded_db=None,
             )
 
         with patch(
@@ -85,7 +85,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=False,
                 additional_headers=None,
                 startup_period=None,
-                embedded=False,
+                embedded_db=None,
             )
 
         with patch(
@@ -109,7 +109,7 @@ class TestWeaviateClient(unittest.TestCase):
                 trust_env=True,
                 additional_headers=None,
                 startup_period=None,
-                embedded=False,
+                embedded_db=None,
             )
 
     @patch("weaviate.client.Client.get_meta", return_value={"version": "1.13.2"})

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -26,7 +26,8 @@ class TestEmbeddedEndToEnd(unittest.TestCase):
 
     def tearDown(self) -> None:
         file = pathlib.Path(embedded.weaviate_binary_path)
-        file.unlink(missing_ok=True)
+        if file.exists():
+            file.unlink()
         self.embedded_db.stop()
 
     def test_end_to_end_all(self):

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -1,23 +1,37 @@
 import unittest
+from unittest.mock import patch
+import pathlib
 
-from weaviate.embedded import EmbeddedDB, Singleton
+
+from weaviate import embedded
+from weaviate.embedded import EmbeddedDB
+from weaviate.exceptions import WeaviateStartUpError
 
 
 class TestWeaviateClient(unittest.TestCase):
 
+    def setUp(self) -> None:
+        embedded.weaviate_binary_path = "./weaviate-embedded-unitests-delete-me"
+
     def tearDown(self) -> None:
-        Singleton.clear()
+        file = pathlib.Path(embedded.weaviate_binary_path)
+        file.unlink(missing_ok=True)
 
     def test__init__(self):
         self.assertEqual(EmbeddedDB(url="embedded").port, 6666)
 
-        # should still be 6666 since it's a singleton
-        embedded_db = EmbeddedDB(url="embedded?port=30666")
-        self.assertEqual(embedded_db.port, 6666)
-
-    def test__init__non_default(self):
+    def test__init__non_default_port(self):
         self.assertEqual(EmbeddedDB(url="embedded?port=30666").port, 30666)
 
-        # should still be 6666 since it's a singleton
+    def test_end_to_end(self):
         embedded_db = EmbeddedDB(url="embedded")
-        self.assertEqual(embedded_db.port, 30666)
+        self.assertFalse(embedded_db.is_running())
+        self.assertFalse(embedded_db.is_listening())
+        with self.assertRaises(WeaviateStartUpError):
+            with patch("time.sleep") as mocked_sleep:
+                embedded_db.wait_till_listening()
+                mocked_sleep.assert_has_calls([0.1] * 3000)
+
+        embedded_db.ensure_running()
+        self.assertTrue(embedded_db.is_running())
+        self.assertTrue(embedded_db.is_listening())

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -31,7 +31,7 @@ def test_embedded_end_to_end(options, embedded_db_binary_path):
     with pytest.raises(WeaviateStartUpError):
         with patch("time.sleep") as mocked_sleep:
             embedded_db.wait_till_listening()
-            mocked_sleep.assert_has_calls([0.1] * 3000)
+            mocked_sleep.assert_has_calls([0.1] * 300)
 
     embedded_db.ensure_running()
     assert embedded_db.is_listening() is True

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 import time
 import os
@@ -15,6 +16,14 @@ def test_embedded__init__():
 
 def test_embedded__init__non_default_port():
     assert EmbeddedDB(EmbeddedOptions(port=30666)).port == 30666
+
+
+def test_embedded_ensure_binary_exists(tmp_path):
+    bin_path = tmp_path / "notcreated-yet/bin/weaviate-embedded"
+    assert bin_path.is_file, False
+    embedded_db = EmbeddedDB(EmbeddedOptions(binary_path=str(bin_path)))
+    embedded_db.ensure_weaviate_binary_exists()
+    assert Path(embedded_db.options.binary_path).is_file, True
 
 
 @pytest.fixture(scope="session")

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -19,7 +19,6 @@ class TestEmbeddedBasics(unittest.TestCase):
 
 
 class TestEmbeddedEndToEnd(unittest.TestCase):
-
     def setUp(self) -> None:
         embedded.weaviate_binary_path = "./weaviate-embedded-unitests-delete-me"
         self.embedded_db: EmbeddedDB = None

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -62,7 +62,6 @@ def test_embedded_multiple_instances(embedded_db_binary_path, tmp_path):
         )
     )
     embedded_db.ensure_running()
-    print("db1 is running")
     assert embedded_db.is_listening() is True
     embedded_db2.ensure_running()
     assert embedded_db2.is_listening() is True

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -26,6 +26,14 @@ def test_embedded_ensure_binary_exists(tmp_path):
     assert Path(embedded_db.options.binary_path).is_file, True
 
 
+def test_embedded_ensure_binary_exists_same_as_tar_binary_name(tmp_path):
+    bin_path = tmp_path / "notcreated-yet/bin/weaviate"
+    assert bin_path.is_file, False
+    embedded_db = EmbeddedDB(EmbeddedOptions(binary_path=str(bin_path)))
+    embedded_db.ensure_weaviate_binary_exists()
+    assert Path(embedded_db.options.binary_path).is_file, True
+
+
 @pytest.fixture(scope="session")
 def embedded_db_binary_path(tmp_path_factory):
     embedded.weaviate_binary_path = (

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -1,0 +1,23 @@
+import unittest
+
+from weaviate.embedded import EmbeddedDB, Singleton
+
+
+class TestWeaviateClient(unittest.TestCase):
+
+    def tearDown(self) -> None:
+        Singleton.clear()
+
+    def test__init__(self):
+        self.assertEqual(EmbeddedDB(url="embedded").port, 6666)
+
+        # should still be 6666 since it's a singleton
+        embedded_db = EmbeddedDB(url="embedded?port=30666")
+        self.assertEqual(embedded_db.port, 6666)
+
+    def test__init__non_default(self):
+        self.assertEqual(EmbeddedDB(url="embedded?port=30666").port, 30666)
+
+        # should still be 6666 since it's a singleton
+        embedded_db = EmbeddedDB(url="embedded")
+        self.assertEqual(embedded_db.port, 30666)

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -48,7 +48,7 @@ class TestEmbeddedEndToEnd(unittest.TestCase):
         self.assertTrue(embedded_db.is_listening())
         with patch("builtins.print") as mocked_print:
             embedded_db.start()
-            mocked_print.assert_called_once_with("weaviate is already running")
+            mocked_print.assert_called_once_with("embedded weaviate is already running")
 
         # killing the process should restart it again when ensure running is called
         os.kill(embedded_db.pid, signal.SIGTERM)

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -1,60 +1,52 @@
-import unittest
+import pytest
 import time
 import os
 import signal
 from unittest.mock import patch
-import pathlib
 
 from weaviate import embedded
 from weaviate.embedded import EmbeddedDB
 from weaviate.exceptions import WeaviateStartUpError
 
 
-class TestEmbeddedBasics(unittest.TestCase):
-    def test__init__(self):
-        self.assertEqual(EmbeddedDB(url="embedded").port, 6666)
-
-    def test__init__non_default_port(self):
-        self.assertEqual(EmbeddedDB(url="embedded?port=30666").port, 30666)
+def test_embedded__init__():
+    assert EmbeddedDB(url="embedded").port == 6666
 
 
-class TestEmbeddedEndToEnd(unittest.TestCase):
-    def setUp(self) -> None:
-        embedded.weaviate_binary_path = "./weaviate-embedded-unitests-delete-me"
-        self.embedded_db: EmbeddedDB = None
+def test_embedded__init__non_default_port():
+    assert EmbeddedDB(url="embedded?port=30666").port == 30666
 
-    def tearDown(self) -> None:
-        file = pathlib.Path(embedded.weaviate_binary_path)
-        if file.exists():
-            file.unlink()
-        self.embedded_db.stop()
 
-    def test_end_to_end_all(self):
-        for url in ["embedded", "embedded?port=30666"]:
-            print(f"Running test case for EmbeddedDB(url={url}")
-            self.end_to_end_test(url)
+@pytest.fixture(scope="session")
+def embedded_db_binary_path(tmp_path_factory):
+    embedded.weaviate_binary_path = (
+        tmp_path_factory.mktemp("embedded-test") / "weaviate-embedded-binary"
+    )
 
-    def end_to_end_test(self, url):
-        self.embedded_db = embedded_db = EmbeddedDB(url=url)
-        self.assertFalse(embedded_db.is_running())
-        self.assertFalse(embedded_db.is_listening())
-        with self.assertRaises(WeaviateStartUpError):
-            with patch("time.sleep") as mocked_sleep:
-                embedded_db.wait_till_listening()
-                mocked_sleep.assert_has_calls([0.1] * 3000)
 
-        embedded_db.ensure_running()
-        self.assertTrue(embedded_db.is_running())
-        self.assertTrue(embedded_db.is_listening())
-        with patch("builtins.print") as mocked_print:
-            embedded_db.start()
-            mocked_print.assert_called_once_with("embedded weaviate is already running")
+@pytest.mark.parametrize("url", ["embedded", "embedded?port=30666"])
+def test_embedded_end_to_end(url, embedded_db_binary_path):
+    embedded_db = EmbeddedDB(url=url)
+    assert embedded_db.is_running() is False
+    assert embedded_db.is_listening() is False
+    with pytest.raises(WeaviateStartUpError):
+        with patch("time.sleep") as mocked_sleep:
+            embedded_db.wait_till_listening()
+            mocked_sleep.assert_has_calls([0.1] * 3000)
 
-        # killing the process should restart it again when ensure running is called
-        os.kill(embedded_db.pid, signal.SIGTERM)
-        time.sleep(0.2)
-        self.assertFalse(embedded_db.is_running())
-        self.assertFalse(embedded_db.is_listening())
-        embedded_db.ensure_running()
-        self.assertTrue(embedded_db.is_running())
-        self.assertTrue(embedded_db.is_listening())
+    embedded_db.ensure_running()
+    assert embedded_db.is_running() is True
+    assert embedded_db.is_listening() is True
+    with patch("builtins.print") as mocked_print:
+        embedded_db.start()
+        mocked_print.assert_called_once_with("embedded weaviate is already running")
+
+    # killing the process should restart it again when ensure running is called
+    os.kill(embedded_db.pid, signal.SIGTERM)
+    time.sleep(0.2)
+    assert embedded_db.is_running() is False
+    assert embedded_db.is_listening() is False
+    embedded_db.ensure_running()
+    assert embedded_db.is_running() is True
+    assert embedded_db.is_listening() is True
+    embedded_db.stop()

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -6,25 +6,31 @@ import pathlib
 from weaviate import embedded
 from weaviate.embedded import EmbeddedDB
 from weaviate.exceptions import WeaviateStartUpError
+from weaviate.util import is_port_available
 
 
-class TestWeaviateClient(unittest.TestCase):
-
-    def setUp(self) -> None:
-        embedded.weaviate_binary_path = "./weaviate-embedded-unitests-delete-me"
-
-    def tearDown(self) -> None:
-        file = pathlib.Path(embedded.weaviate_binary_path)
-        file.unlink(missing_ok=True)
-
+class TestEmbeddedBasics(unittest.TestCase):
     def test__init__(self):
         self.assertEqual(EmbeddedDB(url="embedded").port, 6666)
 
     def test__init__non_default_port(self):
         self.assertEqual(EmbeddedDB(url="embedded?port=30666").port, 30666)
 
+
+class TestEmbeddedEndToEnd(unittest.TestCase):
+
+    def setUp(self) -> None:
+        embedded.weaviate_binary_path = "./weaviate-embedded-unitests-delete-me"
+        self.embedded_db: EmbeddedDB = None
+
+    def tearDown(self) -> None:
+        file = pathlib.Path(embedded.weaviate_binary_path)
+        file.unlink(missing_ok=True)
+        self.embedded_db.stop()
+
     def test_end_to_end(self):
-        embedded_db = EmbeddedDB(url="embedded")
+        self.embedded_db = embedded_db = EmbeddedDB(url="embedded")
+        self.assertTrue(is_port_available(embedded_db.port))
         self.assertFalse(embedded_db.is_running())
         self.assertFalse(embedded_db.is_listening())
         with self.assertRaises(WeaviateStartUpError):
@@ -35,3 +41,6 @@ class TestWeaviateClient(unittest.TestCase):
         embedded_db.ensure_running()
         self.assertTrue(embedded_db.is_running())
         self.assertTrue(embedded_db.is_listening())
+        with patch("builtins.print") as mocked_print:
+            embedded_db.start()
+            mocked_print.assert_called_once_with("weaviate is already running")

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -50,13 +50,13 @@ class Client:
     def __init__(
         self,
         url: Optional[str] = None,
-        embedded_options: Optional[EmbeddedOptions] = None,
         auth_client_secret: Optional[AuthCredentials] = None,
         timeout_config: Union[Tuple[Real, Real], Real] = (10, 60),
         proxies: Union[dict, str, None] = None,
         trust_env: bool = False,
         additional_headers: Optional[dict] = None,
         startup_period: Optional[int] = 5,
+        embedded_options: Optional[EmbeddedOptions] = None,
     ):
         """
         Initialize a Client class instance.
@@ -94,7 +94,10 @@ class Client:
         startup_period : int or None
             How long the client will wait for weaviate to start before raising a RequestsConnectionError.
             If None the client will not wait at all. Default timeout is 5s.
-
+        embedded_options : weaviate.embedded.EmbeddedOptions or None, optional
+            Create an embedded Weaviate cluster inside the client
+            - You can pass weaviate.embedded.EmbeddedOptions() with default values
+            - Take a look at the attributes of weaviate.embedded.EmbeddedOptions to see what is configurable
         Examples
         --------
         Without Auth.
@@ -114,6 +117,11 @@ class Client:
         ...     url = 'http://localhost:8080',
         ...     auth_client_secret = my_credentials
         ... )
+
+        Creating a client with an embedded database:
+
+        >>> from weaviate.embedded import EmbeddedOptions
+        >>> client = Client(embedded_options=EmbeddedOptions())
 
         Raises
         ------

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -132,7 +132,9 @@ class Client:
         if embedded_options is None and not isinstance(url, str):
             raise TypeError(f"URL is expected to be string but is {type(url)}")
         if embedded_options is not None and isinstance(url, str) and len(url) > 0:
-            raise TypeError(f"URL is not expected to be set when using embedded_options but URL was {url}")
+            raise TypeError(
+                f"URL is not expected to be set when using embedded_options but URL was {url}"
+            )
         if embedded_options is not None:
             embedded_db = EmbeddedDB(options=embedded_options)
             embedded_db.start()

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -127,8 +127,10 @@ class Client:
             db.start()
             # TODO Make port configurable
             url = "http://localhost:8080"
+            embedded = True
         else:
             url = url.strip("/")
+            embedded = False
 
         self._connection = Connection(
             url=url,
@@ -138,6 +140,7 @@ class Client:
             trust_env=trust_env,
             additional_headers=additional_headers,
             startup_period=startup_period,
+            embedded=embedded,
         )
         self.classification = Classification(self._connection)
         self.schema = Schema(self._connection)

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -121,8 +121,10 @@ class Client:
             If arguments are of a wrong data type.
         """
 
-        if not isinstance(url, str):
+        if embedded_options is None and not isinstance(url, str):
             raise TypeError(f"URL is expected to be string but is {type(url)}")
+        if embedded_options is not None and isinstance(url, str) and len(url) > 0:
+            raise TypeError(f"URL is not expected to be set when using embedded_options but URL was {url}")
         if embedded_options is not None:
             embedded_db = EmbeddedDB(options=embedded_options)
             embedded_db.start()

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -123,14 +123,12 @@ class Client:
         if not isinstance(url, str):
             raise TypeError(f"URL is expected to be string but is {type(url)}")
         if url.startswith("embedded"):
-            db = EmbeddedDB()
-            db.start()
-            # TODO Make port configurable
-            url = "http://localhost:8080"
-            embedded = True
+            embedded_db = EmbeddedDB(url=url)
+            embedded_db.start()
+            url = f"http://localhost:{embedded_db.port}"
         else:
             url = url.strip("/")
-            embedded = False
+            embedded_db = None
 
         self._connection = Connection(
             url=url,
@@ -140,7 +138,7 @@ class Client:
             trust_env=trust_env,
             additional_headers=additional_headers,
             startup_period=startup_period,
-            embedded=embedded,
+            embedded_db=embedded_db,
         )
         self.classification = Classification(self._connection)
         self.schema = Schema(self._connection)

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -14,6 +14,7 @@ from .cluster import Cluster
 from .connect.connection import Connection
 from .contextionary import Contextionary
 from .data import DataObject
+from .embedded import EmbeddedDB
 from .exceptions import UnexpectedStatusCodeException
 from .gql import Query
 from .schema import Schema
@@ -121,7 +122,13 @@ class Client:
 
         if not isinstance(url, str):
             raise TypeError(f"URL is expected to be string but is {type(url)}")
-        url = url.strip("/")
+        if url.startswith("embedded"):
+            db = EmbeddedDB()
+            db.start()
+            # TODO Make port configurable
+            url = "http://localhost:8080"
+        else:
+            url = url.strip("/")
 
         self._connection = Connection(
             url=url,

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -14,7 +14,7 @@ from .cluster import Cluster
 from .connect.connection import Connection
 from .contextionary import Contextionary
 from .data import DataObject
-from .embedded import EmbeddedDB
+from .embedded import EmbeddedDB, EmbeddedOptions
 from .exceptions import UnexpectedStatusCodeException
 from .gql import Query
 from .schema import Schema
@@ -49,7 +49,8 @@ class Client:
 
     def __init__(
         self,
-        url: str,
+        url: Optional[str] = None,
+        embedded_options: Optional[EmbeddedOptions] = None,
         auth_client_secret: Optional[AuthCredentials] = None,
         timeout_config: Union[Tuple[Real, Real], Real] = (10, 60),
         proxies: Union[dict, str, None] = None,
@@ -122,8 +123,8 @@ class Client:
 
         if not isinstance(url, str):
             raise TypeError(f"URL is expected to be string but is {type(url)}")
-        if url.startswith("embedded"):
-            embedded_db = EmbeddedDB(url=url)
+        if embedded_options is not None:
+            embedded_db = EmbeddedDB(options=embedded_options)
             embedded_db.start()
             url = f"http://localhost:{embedded_db.port}"
         else:

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -19,6 +19,7 @@ from authlib.integrations.requests_client import OAuth2Session
 
 from weaviate.auth import AuthCredentials, AuthClientCredentials
 from weaviate.connect.authentication import _Auth
+from weaviate.embedded import ensure_embedded_db_running
 from weaviate.exceptions import (
     AuthenticationFailedException,
     UnexpectedStatusCodeException,
@@ -45,6 +46,7 @@ class BaseConnection:
         trust_env: bool,
         additional_headers: Optional[Dict[str, Any]],
         startup_period: Optional[int],
+        embedded: bool = False,
     ):
         """
         Initialize a Connection class instance.
@@ -88,6 +90,7 @@ class BaseConnection:
         self._api_version_path = "/v1"
         self.url = url  # e.g. http://localhost:80
         self.timeout_config = timeout_config  # this uses the setter
+        self.embedded = embedded
 
         self._headers = {"content-type": "application/json"}
         if additional_headers is not None:
@@ -250,7 +253,8 @@ class BaseConnection:
         requests.ConnectionError
             If the DELETE request could not be made.
         """
-
+        if self.embedded:
+            ensure_embedded_db_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.delete(
@@ -287,7 +291,8 @@ class BaseConnection:
         requests.ConnectionError
             If the PATCH request could not be made.
         """
-
+        if self.embedded:
+            ensure_embedded_db_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.patch(
@@ -325,6 +330,8 @@ class BaseConnection:
         requests.ConnectionError
             If the POST request could not be made.
         """
+        if self.embedded:
+            ensure_embedded_db_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.post(
@@ -361,7 +368,8 @@ class BaseConnection:
         requests.ConnectionError
             If the PUT request could not be made.
         """
-
+        if self.embedded:
+            ensure_embedded_db_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.put(
@@ -394,7 +402,8 @@ class BaseConnection:
         requests.ConnectionError
             If the GET request could not be made.
         """
-
+        if self.embedded:
+            ensure_embedded_db_running()
         if params is None:
             params = {}
 
@@ -431,7 +440,8 @@ class BaseConnection:
         requests.ConnectionError
             If the HEAD request could not be made.
         """
-
+        if self.embedded:
+            ensure_embedded_db_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.head(
@@ -517,6 +527,7 @@ class Connection(BaseConnection):
         trust_env: bool,
         additional_headers: Optional[Dict[str, Any]],
         startup_period: Optional[int],
+        embedded: bool = False,
     ):
         super().__init__(
             url,
@@ -526,6 +537,7 @@ class Connection(BaseConnection):
             trust_env,
             additional_headers,
             startup_period,
+            embedded,
         )
         self._server_version = self.get_meta()["version"]
         if self._server_version < "1.14":

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -253,7 +253,7 @@ class BaseConnection:
         requests.ConnectionError
             If the DELETE request could not be made.
         """
-        if self.embedded_db:
+        if self.embedded_db is not None:
             self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
@@ -291,7 +291,7 @@ class BaseConnection:
         requests.ConnectionError
             If the PATCH request could not be made.
         """
-        if self.embedded_db:
+        if self.embedded_db is not None:
             self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
@@ -330,7 +330,7 @@ class BaseConnection:
         requests.ConnectionError
             If the POST request could not be made.
         """
-        if self.embedded_db:
+        if self.embedded_db is not None:
             self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
@@ -368,7 +368,7 @@ class BaseConnection:
         requests.ConnectionError
             If the PUT request could not be made.
         """
-        if self.embedded_db:
+        if self.embedded_db is not None:
             self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
@@ -402,7 +402,7 @@ class BaseConnection:
         requests.ConnectionError
             If the GET request could not be made.
         """
-        if self.embedded_db:
+        if self.embedded_db is not None:
             self.embedded_db.ensure_running()
         if params is None:
             params = {}
@@ -440,7 +440,7 @@ class BaseConnection:
         requests.ConnectionError
             If the HEAD request could not be made.
         """
-        if self.embedded_db:
+        if self.embedded_db is not None:
             self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -19,7 +19,7 @@ from authlib.integrations.requests_client import OAuth2Session
 
 from weaviate.auth import AuthCredentials, AuthClientCredentials
 from weaviate.connect.authentication import _Auth
-from weaviate.embedded import ensure_embedded_db_running
+from weaviate.embedded import EmbeddedDB
 from weaviate.exceptions import (
     AuthenticationFailedException,
     UnexpectedStatusCodeException,
@@ -46,7 +46,7 @@ class BaseConnection:
         trust_env: bool,
         additional_headers: Optional[Dict[str, Any]],
         startup_period: Optional[int],
-        embedded: bool = False,
+        embedded_db: EmbeddedDB = None,
     ):
         """
         Initialize a Connection class instance.
@@ -90,7 +90,7 @@ class BaseConnection:
         self._api_version_path = "/v1"
         self.url = url  # e.g. http://localhost:80
         self.timeout_config = timeout_config  # this uses the setter
-        self.embedded = embedded
+        self.embedded_db = embedded_db
 
         self._headers = {"content-type": "application/json"}
         if additional_headers is not None:
@@ -253,8 +253,8 @@ class BaseConnection:
         requests.ConnectionError
             If the DELETE request could not be made.
         """
-        if self.embedded:
-            ensure_embedded_db_running()
+        if self.embedded_db:
+            self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.delete(
@@ -291,8 +291,8 @@ class BaseConnection:
         requests.ConnectionError
             If the PATCH request could not be made.
         """
-        if self.embedded:
-            ensure_embedded_db_running()
+        if self.embedded_db:
+            self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.patch(
@@ -330,8 +330,8 @@ class BaseConnection:
         requests.ConnectionError
             If the POST request could not be made.
         """
-        if self.embedded:
-            ensure_embedded_db_running()
+        if self.embedded_db:
+            self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.post(
@@ -368,8 +368,8 @@ class BaseConnection:
         requests.ConnectionError
             If the PUT request could not be made.
         """
-        if self.embedded:
-            ensure_embedded_db_running()
+        if self.embedded_db:
+            self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.put(
@@ -402,8 +402,8 @@ class BaseConnection:
         requests.ConnectionError
             If the GET request could not be made.
         """
-        if self.embedded:
-            ensure_embedded_db_running()
+        if self.embedded_db:
+            self.embedded_db.ensure_running()
         if params is None:
             params = {}
 
@@ -440,8 +440,8 @@ class BaseConnection:
         requests.ConnectionError
             If the HEAD request could not be made.
         """
-        if self.embedded:
-            ensure_embedded_db_running()
+        if self.embedded_db:
+            self.embedded_db.ensure_running()
         request_url = self.url + self._api_version_path + path
 
         return self._session.head(
@@ -527,7 +527,7 @@ class Connection(BaseConnection):
         trust_env: bool,
         additional_headers: Optional[Dict[str, Any]],
         startup_period: Optional[int],
-        embedded: bool = False,
+        embedded_db: EmbeddedDB = None,
     ):
         super().__init__(
             url,
@@ -537,7 +537,7 @@ class Connection(BaseConnection):
             trust_env,
             additional_headers,
             startup_period,
-            embedded,
+            embedded_db,
         )
         self._server_version = self.get_meta()["version"]
         if self._server_version < "1.14":

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -15,7 +15,9 @@ from weaviate.exceptions import WeaviateStartUpError
 class EmbeddedOptions:
     persistence_data_path: str = Path.home() / ".local/share/weaviate"
     binary_path: str = Path.home() / ".local/bin/weaviate-embedded"
-    binary_url: str = "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
+    binary_url: str = (
+        "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
+    )
     port: int = 6666
     cluster_hostname: str = "embedded"
 

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -90,7 +90,10 @@ class EmbeddedDB:
         my_env.setdefault("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
         my_env.setdefault("PERSISTENCE_DATA_PATH", weaviate_persistence_data_path)
         my_env.setdefault("CLUSTER_HOSTNAME", "embedded")
-        my_env.setdefault("ENABLE_MODULES", "text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,text2vec-transformers,generative-openai,qna-openai")
+        my_env.setdefault(
+            "ENABLE_MODULES",
+            "text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,generative-openai,qna-openai",
+        )
         process = subprocess.Popen(
             [
                 f"{weaviate_binary_path}",

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -14,8 +14,8 @@ from weaviate.exceptions import WeaviateStartUpError
 
 @dataclass
 class EmbeddedOptions:
-    persistence_data_path: str = Path.home() / ".local/share/weaviate"
-    binary_path: str = Path.home() / ".local/bin/weaviate-embedded"
+    persistence_data_path: str = str((Path.home() / ".local/share/weaviate"))
+    binary_path: str = str((Path.home() / ".local/bin/weaviate-embedded"))
     binary_url: str = (
         "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
     )
@@ -38,10 +38,15 @@ class EmbeddedDB:
         self.data_bind_port = get_random_port()
         self.options = options
         self.pid = 0
+        self.ensure_paths_exist()
         self.check_supported_platform()
 
     def __del__(self):
         self.stop()
+
+    def ensure_paths_exist(self):
+        Path(self.options.binary_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(self.options.persistence_data_path).mkdir(parents=True, exist_ok=True)
 
     def ensure_weaviate_binary_exists(self):
         file = Path(self.options.binary_path)

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -1,0 +1,31 @@
+import subprocess
+import os
+import stat
+import urllib.request
+from pathlib import Path
+
+
+class EmbeddedDB:
+    weaviate_binary_path = "./weaviate-server-embedded"
+    weaviate_binary_url = "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
+    weaviate_persistence_data_path = "./weaviate-data"
+
+    def ensure_weaviate_binary_exists(self):
+        # TODO implement binary verification
+        file = Path(self.weaviate_binary_path)
+        if not file.exists():
+            print(f"Binary {self.weaviate_binary_path} did not exist. "
+                  f"Downloading binary from {self.weaviate_binary_url}")
+            urllib.request.urlretrieve(self.weaviate_binary_url, self.weaviate_binary_path)
+        # Ensuring weaviate binary is executable
+        file.chmod(file.stat().st_mode | stat.S_IEXEC)
+
+    def start(self):
+        self.ensure_weaviate_binary_exists()
+        my_env = os.environ.copy()
+        my_env.setdefault("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
+        my_env.setdefault("PERSISTENCE_DATA_PATH", self.weaviate_persistence_data_path)
+        subprocess.Popen(
+            ["./weaviate-server-embedded", "--host", "127.0.0.1", "--port", "8080", "--scheme", "http"],
+            env=my_env
+        )

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -18,8 +18,8 @@ class EmbeddedDB:
             print(f"Binary {self.weaviate_binary_path} did not exist. "
                   f"Downloading binary from {self.weaviate_binary_url}")
             urllib.request.urlretrieve(self.weaviate_binary_url, self.weaviate_binary_path)
-        # Ensuring weaviate binary is executable
-        file.chmod(file.stat().st_mode | stat.S_IEXEC)
+            # Ensuring weaviate binary is executable
+            file.chmod(file.stat().st_mode | stat.S_IEXEC)
 
     def is_running(self) -> bool:
         binary_name = os.path.basename(self.weaviate_binary_path)

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -21,7 +21,7 @@ default_persistence_data_path = str((Path.home() / ".local/share/weaviate"))
 class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", default_persistence_data_path)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", default_binary_path)
-    binary_url: str = "https://github.com/weaviate/weaviate/releases/download/v1.18.0/weaviate-v1.18.0-linux-amd64.tar.gz"
+    version: str = "https://github.com/weaviate/weaviate/releases/download/v1.18.0/weaviate-v1.18.0-linux-amd64.tar.gz"
     port: int = 6666
     cluster_hostname: str = "embedded"
 
@@ -55,9 +55,9 @@ class EmbeddedDB:
         if not file.exists():
             print(
                 f"Binary {self.options.binary_path} did not exist. "
-                f"Downloading binary from {self.options.binary_url}"
+                f"Downloading binary from {self.options.version}"
             )
-            urllib.request.urlretrieve(self.options.binary_url, self.options.binary_path + ".tgz")
+            urllib.request.urlretrieve(self.options.version, self.options.binary_path + ".tgz")
             binary_tar = tarfile.open(self.options.binary_path + ".tgz")
             binary_tar.extract("weaviate", path=Path(self.options.binary_path).parent)
             (Path(self.options.binary_path).parent / "weaviate").rename(

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -12,7 +12,9 @@ import socket
 from weaviate.exceptions import WeaviateStartUpError
 
 weaviate_binary_path = "./weaviate-server-embedded"
-weaviate_binary_url = "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
+weaviate_binary_url = (
+    "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
+)
 weaviate_persistence_data_path = "./weaviate-data"
 weaviate_binary_md5 = "38b8ac3c77cc8707999569ae3fe34c71"
 
@@ -31,18 +33,23 @@ class EmbeddedDB:
     def ensure_weaviate_binary_exists(self):
         file = Path(weaviate_binary_path)
         if not file.exists():
-            print(f"Binary {weaviate_binary_path} did not exist. "
-                  f"Downloading binary from {weaviate_binary_url}")
+            print(
+                f"Binary {weaviate_binary_path} did not exist. "
+                f"Downloading binary from {weaviate_binary_url}"
+            )
             urllib.request.urlretrieve(weaviate_binary_url, weaviate_binary_path)
             # Ensuring weaviate binary is executable
             file.chmod(file.stat().st_mode | stat.S_IEXEC)
             with open(file, "rb") as f:
-                assert hashlib.md5(f.read()).hexdigest() == weaviate_binary_md5, \
-                    f"md5 of binary {weaviate_binary_path} did not match {weaviate_binary_md5}"
+                assert (
+                    hashlib.md5(f.read()).hexdigest() == weaviate_binary_md5
+                ), f"md5 of binary {weaviate_binary_path} did not match {weaviate_binary_md5}"
 
     def is_running(self) -> bool:
         binary_name = os.path.basename(weaviate_binary_path)
-        result = subprocess.run(f'ps aux | grep {binary_name} | grep -v grep', shell=True, capture_output=True)
+        result = subprocess.run(
+            f"ps aux | grep {binary_name} | grep -v grep", shell=True, capture_output=True
+        )
         if result.returncode == 1:
             return False
         else:
@@ -84,8 +91,16 @@ class EmbeddedDB:
         my_env.setdefault("PERSISTENCE_DATA_PATH", weaviate_persistence_data_path)
         my_env.setdefault("CLUSTER_HOSTNAME", "embedded")
         process = subprocess.Popen(
-            [f"{weaviate_binary_path}", "--host", "127.0.0.1", "--port", str(self.port), "--scheme", "http"],
-            env=my_env
+            [
+                f"{weaviate_binary_path}",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(self.port),
+                "--scheme",
+                "http",
+            ],
+            env=my_env,
         )
         self.pid = process.pid
         print(f"Started {weaviate_binary_path}: process ID {self.pid}")
@@ -96,8 +111,10 @@ class EmbeddedDB:
             try:
                 os.kill(self.pid, signal.SIGTERM)
             except ProcessLookupError:
-                print(f"Tried to stop embedded weaviate process {self.pid}. Process {self.pid} "
-                      f"was not found. So not doing anything")
+                print(
+                    f"Tried to stop embedded weaviate process {self.pid}. Process {self.pid} "
+                    f"was not found. So not doing anything"
+                )
 
     def ensure_running(self):
         if not self.is_running():

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -80,6 +80,7 @@ class EmbeddedDB:
         self.ensure_weaviate_binary_exists()
         my_env = os.environ.copy()
         my_env.setdefault("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
+        my_env.setdefault("QUERY_DEFAULTS_LIMIT", "20")
         my_env.setdefault("PERSISTENCE_DATA_PATH", self.options.persistence_data_path)
         my_env.setdefault("CLUSTER_HOSTNAME", self.options.cluster_hostname)
         # Bug with weaviate requires setting gossip and data bind port

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -57,7 +57,7 @@ class EmbeddedDB:
             s.connect(("127.0.0.1", self.port))
             s.close()
             return True
-        except socket.error as e:
+        except socket.error:
             s.close()
             return False
 

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -22,12 +22,14 @@ class EmbeddedDB:
 
     def is_running(self) -> bool:
         binary_name = os.path.basename(self.weaviate_binary_path)
-        output = subprocess.check_output(f'ps aux | grep {binary_name} | grep -v grep', shell=True)
-        output = output.decode("ascii")
-        if binary_name in output:
-            return True
-        else:
+        result = subprocess.run(f'ps aux | grep {binary_name} | grep -v grep', shell=True, capture_output=True)
+        if result.returncode == 1:
             return False
+        else:
+            output = result.stdout.decode("ascii")
+            if binary_name in output:
+                return True
+        return False
 
     def start(self):
         if self.is_running():

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -1,6 +1,7 @@
 import subprocess
 import os
 import stat
+import time
 import urllib.request
 from pathlib import Path
 
@@ -44,3 +45,12 @@ class EmbeddedDB:
             ["./weaviate-server-embedded", "--host", "127.0.0.1", "--port", "8080", "--scheme", "http"],
             env=my_env
         )
+
+
+def ensure_embedded_db_running():
+    embedded_db = EmbeddedDB()
+    if not embedded_db.is_running():
+        print("Embedded weaviate wasn't running, so starting embedded weaviate again")
+        embedded_db.start()
+        # TODO remove the sleep and check every 0.1 seconds if it's ready
+        time.sleep(1)

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -90,6 +90,7 @@ class EmbeddedDB:
         my_env.setdefault("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
         my_env.setdefault("PERSISTENCE_DATA_PATH", weaviate_persistence_data_path)
         my_env.setdefault("CLUSTER_HOSTNAME", "embedded")
+        my_env.setdefault("ENABLE_MODULES", "text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,text2vec-transformers,generative-openai,qna-openai")
         process = subprocess.Popen(
             [
                 f"{weaviate_binary_path}",

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -1,7 +1,8 @@
-import subprocess
 import os
+import platform
 import signal
 import stat
+import subprocess
 import time
 from dataclasses import dataclass
 import urllib.request
@@ -37,6 +38,7 @@ class EmbeddedDB:
         self.data_bind_port = get_random_port()
         self.options = options
         self.pid = 0
+        self.check_supported_platform()
 
     def __del__(self):
         self.stop()
@@ -72,6 +74,13 @@ class EmbeddedDB:
         if retries == 0:
             raise WeaviateStartUpError(
                 f"Embedded DB did not start listening on port {self.port} within {seconds} seconds"
+            )
+
+    def check_supported_platform(self):
+        if platform.system() in ["Darwin", "Windows"]:
+            raise WeaviateStartUpError(
+                f"{platform.system()} is not supported with EmbeddedDB. Please upvote the feature request if "
+                f"you want this: https://github.com/weaviate/weaviate-python-client/issues/239"
             )
 
     def start(self):

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -3,6 +3,7 @@ import platform
 import signal
 import stat
 import subprocess
+import tarfile
 import time
 from dataclasses import dataclass
 import urllib.request
@@ -20,9 +21,7 @@ default_persistence_data_path = str((Path.home() / ".local/share/weaviate"))
 class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", default_persistence_data_path)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", default_binary_path)
-    binary_url: str = (
-        "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
-    )
+    binary_url: str = "https://github.com/weaviate/weaviate/releases/download/v1.18.0/weaviate-v1.18.0-linux-amd64.tar.gz"
     port: int = 6666
     cluster_hostname: str = "embedded"
 
@@ -58,7 +57,13 @@ class EmbeddedDB:
                 f"Binary {self.options.binary_path} did not exist. "
                 f"Downloading binary from {self.options.binary_url}"
             )
-            urllib.request.urlretrieve(self.options.binary_url, self.options.binary_path)
+            urllib.request.urlretrieve(self.options.binary_url, self.options.binary_path + ".tgz")
+            binary_tar = tarfile.open(self.options.binary_path + ".tgz")
+            binary_tar.extract("weaviate", path=Path(self.options.binary_path).parent)
+            (Path(self.options.binary_path).parent / "weaviate").rename(
+                Path(self.options.binary_path)
+            )
+
             # Ensuring weaviate binary is executable
             file.chmod(file.stat().st_mode | stat.S_IEXEC)
 

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -1,3 +1,4 @@
+import hashlib
 import subprocess
 import os
 import stat
@@ -11,9 +12,9 @@ class EmbeddedDB:
     weaviate_binary_path = "./weaviate-server-embedded"
     weaviate_binary_url = "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
     weaviate_persistence_data_path = "./weaviate-data"
+    weaviate_binary_md5 = "38b8ac3c77cc8707999569ae3fe34c71"
 
     def ensure_weaviate_binary_exists(self):
-        # TODO implement binary verification
         file = Path(self.weaviate_binary_path)
         if not file.exists():
             print(f"Binary {self.weaviate_binary_path} did not exist. "
@@ -21,6 +22,9 @@ class EmbeddedDB:
             urllib.request.urlretrieve(self.weaviate_binary_url, self.weaviate_binary_path)
             # Ensuring weaviate binary is executable
             file.chmod(file.stat().st_mode | stat.S_IEXEC)
+            with open(file, "rb") as f:
+                assert (hashlib.md5(f.read()).hexdigest() == self.weaviate_binary_md5,
+                        f"md5 of binary {self.weaviate_binary_path} did not match {self.weaviate_binary_md5}")
 
     def is_running(self) -> bool:
         binary_name = os.path.basename(self.weaviate_binary_path)

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -12,10 +12,14 @@ import socket
 from weaviate.exceptions import WeaviateStartUpError
 
 
+default_binary_path = str((Path.home() / ".cache/weaviate-embedded"))
+default_persistence_data_path = str((Path.home() / ".local/share/weaviate"))
+
+
 @dataclass
 class EmbeddedOptions:
-    persistence_data_path: str = str((Path.home() / ".local/share/weaviate"))
-    binary_path: str = str((Path.home() / ".local/bin/weaviate-embedded"))
+    persistence_data_path: str = os.environ.get("XDG_DATA_HOME", default_persistence_data_path)
+    binary_path: str = os.environ.get("XDG_CACHE_HOME", default_binary_path)
     binary_url: str = (
         "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
     )

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -32,7 +32,6 @@ def get_random_port() -> int:
 
 
 class EmbeddedDB:
-    # TODO add a stop function that gets called when python process exits
     def __init__(self, options: EmbeddedOptions):
         self.port = options.port
         self.data_bind_port = get_random_port()

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -3,31 +3,52 @@ import subprocess
 import os
 import stat
 import time
+from urllib.parse import urlparse, parse_qsl
 import urllib.request
 from pathlib import Path
 import socket
 
 
-class EmbeddedDB:
-    weaviate_binary_path = "./weaviate-server-embedded"
-    weaviate_binary_url = "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
-    weaviate_persistence_data_path = "./weaviate-data"
-    weaviate_binary_md5 = "38b8ac3c77cc8707999569ae3fe34c71"
+weaviate_binary_path = "./weaviate-server-embedded"
+weaviate_binary_url = "https://github.com/samos123/weaviate/releases/download/v1.17.3/weaviate-server"
+weaviate_persistence_data_path = "./weaviate-data"
+weaviate_binary_md5 = "38b8ac3c77cc8707999569ae3fe34c71"
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+    @staticmethod
+    def clear():
+        Singleton._instances = {}
+
+
+class EmbeddedDB(metaclass=Singleton):
+    # TODO add a stop function that gets called when python process exits
+    def __init__(self, url: str = ""):
+        parsed = parse_qsl(urlparse(url).query)
+        parsed = dict(parsed)
+        self.port = int(parsed.get("port", 6666))
 
     def ensure_weaviate_binary_exists(self):
-        file = Path(self.weaviate_binary_path)
+        file = Path(weaviate_binary_path)
         if not file.exists():
-            print(f"Binary {self.weaviate_binary_path} did not exist. "
-                  f"Downloading binary from {self.weaviate_binary_url}")
-            urllib.request.urlretrieve(self.weaviate_binary_url, self.weaviate_binary_path)
+            print(f"Binary {weaviate_binary_path} did not exist. "
+                  f"Downloading binary from {weaviate_binary_url}")
+            urllib.request.urlretrieve(weaviate_binary_url, weaviate_binary_path)
             # Ensuring weaviate binary is executable
             file.chmod(file.stat().st_mode | stat.S_IEXEC)
             with open(file, "rb") as f:
-                assert (hashlib.md5(f.read()).hexdigest() == self.weaviate_binary_md5,
-                        f"md5 of binary {self.weaviate_binary_path} did not match {self.weaviate_binary_md5}")
+                assert hashlib.md5(f.read()).hexdigest() == weaviate_binary_md5, \
+                    f"md5 of binary {weaviate_binary_path} did not match {weaviate_binary_md5}"
 
     def is_running(self) -> bool:
-        binary_name = os.path.basename(self.weaviate_binary_path)
+        binary_name = os.path.basename(weaviate_binary_path)
         result = subprocess.run(f'ps aux | grep {binary_name} | grep -v grep', shell=True, capture_output=True)
         if result.returncode == 1:
             return False
@@ -40,14 +61,15 @@ class EmbeddedDB:
     def is_listening(self) -> bool:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            s.connect(("127.0.0.1", 8080))
+            s.connect(("127.0.0.1", self.port))
             s.close()
             return True
         except socket.error as e:
+            s.close()
             return False
 
     def wait_till_listening(self):
-        retries = 20
+        retries = 10 * 30
         while self.is_listening() is False and retries > 0:
             time.sleep(0.1)
             retries -= 1
@@ -60,16 +82,15 @@ class EmbeddedDB:
         self.ensure_weaviate_binary_exists()
         my_env = os.environ.copy()
         my_env.setdefault("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
-        my_env.setdefault("PERSISTENCE_DATA_PATH", self.weaviate_persistence_data_path)
+        my_env.setdefault("PERSISTENCE_DATA_PATH", weaviate_persistence_data_path)
+        my_env.setdefault("CLUSTER_HOSTNAME", "embedded")
         subprocess.Popen(
-            ["./weaviate-server-embedded", "--host", "127.0.0.1", "--port", "8080", "--scheme", "http"],
+            ["./weaviate-server-embedded", "--host", "127.0.0.1", "--port", str(self.port), "--scheme", "http"],
             env=my_env
         )
         self.wait_till_listening()
 
-
-def ensure_embedded_db_running():
-    embedded_db = EmbeddedDB()
-    if not embedded_db.is_running():
-        print("Embedded weaviate wasn't running, so starting embedded weaviate again")
-        embedded_db.start()
+    def ensure_running(self):
+        if not self.is_running():
+            print("Embedded weaviate wasn't running, so starting embedded weaviate again")
+            self.start()

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -9,9 +9,9 @@ from dataclasses import dataclass
 import urllib.request
 from pathlib import Path
 import socket
+import warnings
 
 from weaviate.exceptions import WeaviateStartUpError
-
 
 default_binary_path = str((Path.home() / ".cache/weaviate-embedded"))
 default_persistence_data_path = str((Path.home() / ".local/share/weaviate"))
@@ -113,6 +113,8 @@ class EmbeddedDB:
             "ENABLE_MODULES",
             "text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,generative-openai,qna-openai",
         )
+
+        warnings.simplefilter("ignore", ResourceWarning)
         process = subprocess.Popen(
             [
                 f"{self.options.binary_path}",

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -20,7 +20,20 @@ class EmbeddedDB:
         # Ensuring weaviate binary is executable
         file.chmod(file.stat().st_mode | stat.S_IEXEC)
 
+    def is_running(self) -> bool:
+        binary_name = os.path.basename(self.weaviate_binary_path)
+        output = subprocess.check_output(f'ps aux | grep {binary_name} | grep -v grep', shell=True)
+        output = output.decode("ascii")
+        if binary_name in output:
+            return True
+        else:
+            return False
+
     def start(self):
+        if self.is_running():
+            print("weaviate is already running")
+            return
+
         self.ensure_weaviate_binary_exists()
         my_env = os.environ.copy()
         my_env.setdefault("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -72,7 +72,7 @@ class EmbeddedDB:
     def wait_till_listening(self):
         seconds = 30
         sleep_interval = 0.1
-        retries = int(10 * (seconds / sleep_interval))
+        retries = int(seconds / sleep_interval)
         while self.is_listening() is False and retries > 0:
             time.sleep(sleep_interval)
             retries -= 1

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -2,10 +2,8 @@
 Helper functions!
 """
 import base64
-import errno
 import json
 import os
-import socket
 import uuid as uuid_lib
 from io import BufferedReader
 from numbers import Real

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -529,14 +529,3 @@ def _check_positive_num(
     else:
         if value <= 0:
             raise ValueError(f"'{arg_name}' must be positive, i.e. greater that zero (>0).")
-
-
-def is_port_available(port: int) -> bool:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", port))
-        s.close()
-        return True
-    except socket.error as e:
-        s.close()
-        return False

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -2,8 +2,10 @@
 Helper functions!
 """
 import base64
+import errno
 import json
 import os
+import socket
 import uuid as uuid_lib
 from io import BufferedReader
 from numbers import Real
@@ -527,3 +529,14 @@ def _check_positive_num(
     else:
         if value <= 0:
             raise ValueError(f"'{arg_name}' must be positive, i.e. greater that zero (>0).")
+
+
+def is_port_available(port: int) -> bool:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", port))
+        s.close()
+        return True
+    except socket.error as e:
+        s.close()
+        return False


### PR DESCRIPTION
Demo: https://www.kaggle.com/code/samosx/weaviate-embedded-in-a-notebook/

This removes the need to launch weaviate separately and makes the UX of data science notebook experiments much better

you can use it like this:
```
from weaviate import Client
from weaviate.embedded import EmbeddedOptions

# Create the embedded client which automatically launches a weaviate database in the background
client = Client(embedded_options=EmbeddedOptions())

# You can now directly start importing data
uuid = client.data_object.create(
    data_object = {'name': 'Neil Gaiman', 'age': 60},
    class_name = 'Author',
)

```

