### PR TITLE
Add generative openai support

### DIFF
--- a/ci/docker-compose_openai.yml
+++ b/ci/docker-compose_openai.yml
@@ -1,0 +1,23 @@
+---
+version: '3.4'
+services:
+  weaviate_openai:
+    command:
+      - --host
+      - 0.0.0.0
+      - --port
+      - '8086'
+      - --scheme
+      - http
+    image:
+      semitechnologies/weaviate:1.17.4
+    ports:
+      - 8086:8086
+    restart: on-failure:0
+    environment:
+      QUERY_DEFAULTS_LIMIT: 25
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEFAULT_VECTORIZER_MODULE: 'text2vec-openai'
+      ENABLE_MODULES: 'text2vec-openai,generative-openai'
+      CLUSTER_HOSTNAME: 'node1'

--- a/ci/start_weaviate.sh
+++ b/ci/start_weaviate.sh
@@ -6,3 +6,4 @@ nohup docker-compose -f ci/docker-compose-azure.yml up -d
 nohup docker-compose -f ci/docker-compose-okta-cc.yml up -d
 nohup docker-compose -f ci/docker-compose-okta-users.yml up -d
 nohup docker-compose -f ci/docker-compose-wcs.yml up -d
+nohup docker-compose -f ci/docker-compose_openai.yml up -d

--- a/ci/stop_weaviate.sh
+++ b/ci/stop_weaviate.sh
@@ -5,3 +5,4 @@ docker-compose -f ci/docker-compose-azure.yml down --remove-orphans
 docker-compose -f ci/docker-compose-okta-cc.yml down --remove-orphans
 docker-compose -f ci/docker-compose-okta-users.yml down --remove-orphans
 docker-compose -f ci/docker-compose-wcs.yml down --remove-orphans
+docker-compose -f ci/docker-compose_openai.yml down --remove-orphans

--- a/mock_tests/test_graphql.py
+++ b/mock_tests/test_graphql.py
@@ -1,0 +1,24 @@
+from http.server import HTTPServer
+
+import pytest as pytest
+
+import weaviate
+from mock_tests.conftest import MOCK_SERVER_URL
+
+
+@pytest.mark.parametrize(
+    "version,warning", [("1.16.0", True), ("1.17.2", True), ("1.17.3", False), ("1.18.0", False)]
+)
+def test_warning_old_weaviate(recwarn, ready_mock: HTTPServer, version: str, warning: bool):
+    ready_mock.expect_request("/v1/meta").respond_with_json({"version": version})
+    client = weaviate.Client(url=MOCK_SERVER_URL)
+
+    client.query.get("Class", ["Property"]).with_generate(single_prompt="something")
+
+    if warning:
+        assert len(recwarn) == 1
+        w = recwarn.pop()
+        assert issubclass(w.category, DeprecationWarning)
+        assert str(w.message).startswith("Dep003")
+    else:
+        assert len(recwarn) == 0

--- a/test/gql/test_get.py
+++ b/test/gql/test_get.py
@@ -7,6 +7,9 @@ import pytest
 from test.util import check_error_message
 from weaviate.gql.get import GetBuilder, BM25, Hybrid
 
+mock_connection_v117 = Mock()
+mock_connection_v117.server_version = "1.17.4"
+
 
 @pytest.mark.parametrize(
     "query,properties,expected",
@@ -63,7 +66,11 @@ def test_hybrid(query: str, vector: Optional[List[float]], alpha: Optional[float
     ],
 )
 def test_generative(single_prompt: str, grouped_task: str, expected: str):
-    query = GetBuilder("Person", "name", None).with_generate(single_prompt, grouped_task).build()
+    query = (
+        GetBuilder("Person", "name", mock_connection_v117)
+        .with_generate(single_prompt, grouped_task)
+        .build()
+    )
     expected_query = "{Get{Person{name _additional {" + expected + "}}}}"
     assert query == expected_query
 
@@ -71,7 +78,9 @@ def test_generative(single_prompt: str, grouped_task: str, expected: str):
 @pytest.mark.parametrize("single_prompt,grouped_task", [(123, None), (None, None), (None, 123)])
 def test_generative_type(single_prompt: str, grouped_task: str):
     with pytest.raises(TypeError):
-        GetBuilder("Person", "name", None).with_generate(single_prompt, grouped_task).build()
+        GetBuilder("Person", "name", mock_connection_v117).with_generate(
+            single_prompt, grouped_task
+        ).build()
 
 
 class TestGetBuilder(unittest.TestCase):

--- a/test/gql/test_get.py
+++ b/test/gql/test_get.py
@@ -42,6 +42,38 @@ def test_hybrid(query: str, vector: Optional[List[float]], alpha: Optional[float
     assert str(hybrid) == expected
 
 
+@pytest.mark.parametrize(
+    "single_prompt,grouped_task,expected",
+    [
+        (
+            "What is the meaning of life?",
+            None,
+            """generate(singleResult:{prompt:"What is the meaning of life?"}){error singleResult} """,
+        ),
+        (
+            None,
+            "Explain why these magazines or newspapers are about finance",
+            """generate(groupedResult:{task:"Explain why these magazines or newspapers are about finance"}){error groupedResult} """,
+        ),
+        (
+            "What is the meaning of life?",
+            "Explain why these magazines or newspapers are about finance",
+            """generate(singleResult:{prompt:"What is the meaning of life?"}groupedResult:{task:"Explain why these magazines or newspapers are about finance"}){error singleResult groupedResult} """,
+        ),
+    ],
+)
+def test_generative(single_prompt: str, grouped_task: str, expected: str):
+    query = GetBuilder("Person", "name", None).with_generate(single_prompt, grouped_task).build()
+    expected_query = "{Get{Person{name _additional {" + expected + "}}}}"
+    assert query == expected_query
+
+
+@pytest.mark.parametrize("single_prompt,grouped_task", [(123, None), (None, None), (None, 123)])
+def test_generative_type(single_prompt: str, grouped_task: str):
+    with pytest.raises(TypeError):
+        GetBuilder("Person", "name", None).with_generate(single_prompt, grouped_task).build()
+
+
 class TestGetBuilder(unittest.TestCase):
     def test___init__(self):
         """

--- a/weaviate/data/replication/replication.py
+++ b/weaviate/data/replication/replication.py
@@ -1,21 +1,6 @@
-from enum import Enum, EnumMeta, auto
+from enum import auto
 
-
-# MetaEnum and BaseEnum are required to support `in` statements:
-#    'ALL' in ConsistencyLevel == True
-#    12345 in ConsistencyLevel == False
-class MetaEnum(EnumMeta):
-    def __contains__(cls, item):
-        try:
-            # when item is type ConsistencyLevel
-            return item.name in cls.__members__.keys()
-        except AttributeError:
-            # when item is type str
-            return item in cls.__members__.keys()
-
-
-class BaseEnum(Enum, metaclass=MetaEnum):
-    pass
+from weaviate.util import BaseEnum
 
 
 class ConsistencyLevel(str, BaseEnum):

--- a/weaviate/gql/get.py
+++ b/weaviate/gql/get.py
@@ -19,6 +19,7 @@ from weaviate.gql.filter import (
     Sort,
 )
 from weaviate.util import image_encoder_b64, _capitalize_first_letter, BaseEnum
+from weaviate.warnings import _Warnings
 
 
 @dataclass
@@ -956,6 +957,9 @@ class GetBuilder(GraphQL):
             grouped_task is not None and not isinstance(grouped_task, str)
         ):
             raise TypeError("prompts and tasks must be of type str.")
+
+        if self._connection.server_version < "1.17.3":
+            _Warnings.weaviate_too_old_for_openai(self._connection.server_version)
 
         results: List[str] = ["error"]
         task_and_prompt = ""

--- a/weaviate/gql/get.py
+++ b/weaviate/gql/get.py
@@ -2,8 +2,11 @@
 GraphQL `Get` command.
 """
 from dataclasses import dataclass
+from enum import auto
 from json import dumps
 from typing import List, Union, Optional, Dict, Tuple
+
+from weaviate.connect import Connection
 from weaviate.gql.filter import (
     Where,
     NearText,
@@ -15,8 +18,7 @@ from weaviate.gql.filter import (
     NearImage,
     Sort,
 )
-from weaviate.connect import Connection
-from weaviate.util import image_encoder_b64, _capitalize_first_letter
+from weaviate.util import image_encoder_b64, _capitalize_first_letter, BaseEnum
 
 
 @dataclass
@@ -46,6 +48,11 @@ class Hybrid:
             ret += f", alpha: {self.alpha}"
 
         return "hybrid:{" + ret + "}"
+
+
+class GenerativeType(str, BaseEnum):
+    SINGLE = auto()
+    GROUPED = auto()
 
 
 class GetBuilder(GraphQL):
@@ -922,10 +929,45 @@ class GetBuilder(GraphQL):
             Vector that is searched for. If 'None', weaviate will use the configured text-to-vector module to create a
             vector from the "query" field.
             By default, None
-
         """
         self._hybrid = Hybrid(query, alpha, vector)
         self._contains_filter = True
+        return self
+
+    def with_generate(
+        self, single_prompt: Optional[str] = None, grouped_task: Optional[str] = None
+    ) -> "GetBuilder":
+        """Generate responses using the OpenAI generative search.
+
+        At least one of the two parameters must be set.
+
+        Parameters
+        ----------
+        grouped_task: Optional[str]
+            The task to generate a grouped response. One
+        single_prompt: Optional[str]
+            The prompt to generate a single response.
+        """
+        if single_prompt is None and grouped_task is None:
+            raise TypeError(
+                "Either parameter grouped_result_task or single_result_prompt must be not None."
+            )
+        if (single_prompt is not None and not isinstance(single_prompt, str)) or (
+            grouped_task is not None and not isinstance(grouped_task, str)
+        ):
+            raise TypeError("prompts and tasks must be of type str.")
+
+        results: List[str] = ["error"]
+        task_and_prompt = ""
+        if single_prompt is not None:
+            results.append("singleResult")
+            task_and_prompt += f'singleResult:{{prompt:"{single_prompt}"}}'
+        if grouped_task is not None:
+            results.append("groupedResult")
+            task_and_prompt += f'groupedResult:{{task:"{grouped_task}"}}'
+
+        self._additional["__one_level"].add(f'generate({task_and_prompt}){{{" ".join(results)}}}')
+
         return self
 
     def build(self) -> str:

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -5,6 +5,7 @@ import base64
 import json
 import os
 import uuid as uuid_lib
+from enum import Enum, EnumMeta
 from io import BufferedReader
 from numbers import Real
 from typing import Union, Sequence, Any, Optional, List, Dict
@@ -13,6 +14,23 @@ import requests
 import validators
 
 from weaviate.exceptions import SchemaValidationException
+
+
+# MetaEnum and BaseEnum are required to support `in` statements:
+#    'ALL' in ConsistencyLevel == True
+#    12345 in ConsistencyLevel == False
+class MetaEnum(EnumMeta):
+    def __contains__(cls, item):
+        try:
+            # when item is type ConsistencyLevel
+            return item.name in cls.__members__.keys()
+        except AttributeError:
+            # when item is type str
+            return item in cls.__members__.keys()
+
+
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass
 
 
 def image_encoder_b64(image_or_image_path: Union[str, BufferedReader]) -> str:

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -81,3 +81,12 @@ class _Warnings:
             category=DeprecationWarning,
             stacklevel=1,
         )
+
+    @staticmethod
+    def weaviate_too_old_for_openai(server_version: str):
+        warnings.warn(
+            message=f"""Dep003: You are trying to use the generative search, but you are connected to Weaviate {server_version}.
+            Support for generative search was added in weaviate version 1.17.3.""",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )


### PR DESCRIPTION
Adds support for generative search via openai

usage:

```
    result = (
        client.query.get(*Class* [*Props*])
        .with_generate(
            single_prompt="Some prompt",
            grouped_task="Some task",
        )
        .do()
    )
```
At least one of the two parameters has be given
