### PR TITLE
allow authentification via 'additional_headers'

### DIFF
--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -132,6 +132,10 @@ class BaseConnection:
             self._session = requests.Session()
             return
 
+        if "authorization" in self._headers and auth_client_secret is None:
+            self._session = requests.Session()
+            return
+
         oidc_url = self.url + self._api_version_path + "/.well-known/openid-configuration"
         response = requests.get(
             oidc_url,


### PR DESCRIPTION
fixes https://github.com/weaviate/weaviate-python-client/issues/265

Test 'test_auth_header_with_catchall_proxy' was modified because the OIDC configuration endpoint is not called anymore when the authentication is provided via the 'additional_headers' parameter. Apart from 'ApiAuthKey' any other auth method can be used.