### PR TITLE
Extend embedded

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
 exclude = .git, venv, .venv, .pytest_cache, dist, .idea, docs/conf.py,
-ignore = E266, E501, E731, W503
+ignore = E203, E266, E501, E731, W503

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -7,6 +7,7 @@ from test.util import mock_connection_func, check_error_message
 from weaviate import Client
 from weaviate.embedded import EmbeddedOptions, EmbeddedDB
 from weaviate.exceptions import UnexpectedStatusCodeException
+from sys import platform
 
 
 @patch("weaviate.client.Connection", Mock)
@@ -113,18 +114,19 @@ class TestWeaviateClient(unittest.TestCase):
                 embedded_db=None,
             )
 
-        with patch(
-            "weaviate.client.Connection",
-            Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
-        ) as mock_obj:
-            with patch("weaviate.embedded.EmbeddedDB.start") as mocked_start:
-                Client(embedded_options=EmbeddedOptions())
-                args, kwargs = mock_obj.call_args_list[0]
-                self.assertEqual(kwargs["url"], "http://localhost:6666")
-                self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))
-                self.assertTrue(kwargs["embedded_db"] is not None)
-                self.assertEqual(kwargs["embedded_db"].port, 6666)
-                mocked_start.assert_called_once()
+        if platform == "linux":
+            with patch(
+                "weaviate.client.Connection",
+                Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
+            ) as mock_obj:
+                with patch("weaviate.embedded.EmbeddedDB.start") as mocked_start:
+                    Client(embedded_options=EmbeddedOptions())
+                    args, kwargs = mock_obj.call_args_list[0]
+                    self.assertEqual(kwargs["url"], "http://localhost:6666")
+                    self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))
+                    self.assertTrue(kwargs["embedded_db"] is not None)
+                    self.assertEqual(kwargs["embedded_db"].port, 6666)
+                    mocked_start.assert_called_once()
 
     @patch("weaviate.client.Client.get_meta", return_value={"version": "1.13.2"})
     def test_is_ready(self, mock_get_meta_method):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -125,7 +125,7 @@ class TestWeaviateClient(unittest.TestCase):
                     self.assertEqual(kwargs["url"], "http://localhost:6666")
                     self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))
                     self.assertTrue(kwargs["embedded_db"] is not None)
-                    self.assertEqual(kwargs["embedded_db"].port, 6666)
+                    self.assertEqual(kwargs["embedded_db"].options.port, 6666)
                     mocked_start.assert_called_once()
 
     @patch("weaviate.client.Client.get_meta", return_value={"version": "1.13.2"})

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -3,18 +3,17 @@ import signal
 import socket
 import tarfile
 import time
+import uuid
 from pathlib import Path
 from sys import platform
 from unittest.mock import patch
-import uuid
 
 import pytest
 from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
-
-from weaviate import embedded
 import weaviate
+from weaviate import embedded
 from weaviate.embedded import EmbeddedDB, EmbeddedOptions
 from weaviate.exceptions import WeaviateStartUpError
 
@@ -204,6 +203,7 @@ def test_weaviate_state(tmp_path: Path):
     assert sock.connect_ex(("127.0.0.1", port)) == 0  # running
     client._connection.embedded_db.stop()
     del client
+    time.sleep(5)  # give weaviate time to shut down
 
     assert sock.connect_ex(("127.0.0.1", port)) != 0  # not running anymore
 

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -1,13 +1,18 @@
-from pathlib import Path
-import pytest
-import time
 import os
 import signal
+import time
+from pathlib import Path
+from sys import platform
 from unittest.mock import patch
+
+import pytest
 
 from weaviate import embedded
 from weaviate.embedded import EmbeddedDB, EmbeddedOptions
 from weaviate.exceptions import WeaviateStartUpError
+
+if platform != "linux":
+    pytest.skip("Currently only supported on linux", allow_module_level=True)
 
 
 def test_embedded__init__():

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -32,6 +32,19 @@ def test_embedded_ensure_binary_exists(tmp_path):
     assert Path(embedded_db.options.binary_path).is_file, True
 
 
+def test_version_parsing(tmp_path):
+    embedded_db = EmbeddedDB(
+        EmbeddedOptions(
+            binary_path=str(tmp_path),
+            version="https://github.com/weaviate/weaviate/releases/download/v1.18.1/weaviate-v1.18.1-linux-amd64.tar.gz",
+        )
+    )
+    embedded_db.ensure_weaviate_binary_exists()
+    embedded_file_name = list(tmp_path.iterdir())
+    assert len(embedded_file_name) == 1  # .tgz file was deleted
+    assert "v1.18.1" in str(embedded_file_name[0])
+
+
 def test_embedded_ensure_binary_exists_same_as_tar_binary_name(tmp_path):
     bin_path = tmp_path / "notcreated-yet/bin/weaviate"
     assert bin_path.is_file, False

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -138,7 +138,7 @@ class Client:
         if embedded_options is not None:
             embedded_db = EmbeddedDB(options=embedded_options)
             embedded_db.start()
-            url = f"http://localhost:{embedded_db.port}"
+            url = f"http://localhost:{embedded_db.options.port}"
         else:
             url = url.strip("/")
             embedded_db = None

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -78,7 +78,7 @@ class EmbeddedDB:
             binary_tar = tarfile.open(tar_filename)
             binary_tar.extract("weaviate", path=Path(self.options.binary_path))
             (Path(self.options.binary_path) / "weaviate").rename(self._weaviate_binary_path)
-            os.remove(tar_filename)
+            tar_filename.unlink()
 
             # Ensuring weaviate binary is executable
             self._weaviate_binary_path.chmod(

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -15,7 +15,6 @@ from typing import Dict, Optional
 
 from weaviate.exceptions import WeaviateStartUpError
 
-
 DEFAULT_BINARY_PATH = str((Path.home() / ".cache/weaviate-embedded/"))
 DEFAULT_PERSISTENCE_DATA_PATH = str((Path.home() / ".local/share/weaviate"))
 GITHUB_RELEASE_DOWNLOAD_URL = "https://github.com/weaviate/weaviate/releases/download/"
@@ -122,9 +121,6 @@ class EmbeddedDB:
 
         self.ensure_weaviate_binary_exists()
         my_env = os.environ.copy()
-        if self.options.additional_env_vars is not None:
-            for key, value in self.options.additional_env_vars.items():
-                my_env.setdefault(key, value)
 
         my_env.setdefault("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
         my_env.setdefault("QUERY_DEFAULTS_LIMIT", "20")
@@ -136,6 +132,9 @@ class EmbeddedDB:
             "ENABLE_MODULES",
             "text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,generative-openai,qna-openai",
         )
+
+        if self.options.additional_env_vars is not None:
+            my_env.update(self.options.additional_env_vars)
 
         # filter warning about running processes.
         with warnings.catch_warnings():

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -18,6 +18,7 @@ from weaviate.exceptions import WeaviateStartUpError
 
 DEFAULT_BINARY_PATH = str((Path.home() / ".cache/weaviate-embedded/"))
 DEFAULT_PERSISTENCE_DATA_PATH = str((Path.home() / ".local/share/weaviate"))
+GITHUB_RELEASE_DOWNLOAD_URL = "https://github.com/weaviate/weaviate/releases/download/"
 
 
 @dataclass
@@ -47,12 +48,11 @@ class EmbeddedDB:
         self.ensure_paths_exist()
         self.check_supported_platform()
         self._parsed_weaviate_version = ""
-        if self.options.version.startswith(
-            "https://github.com/weaviate/weaviate/releases/download/"
-        ):
-            self._parsed_weaviate_version = self.options.version.removeprefix(
-                "https://github.com/weaviate/weaviate/releases/download/"
-            ).split("/")[0]
+        if self.options.version.startswith(GITHUB_RELEASE_DOWNLOAD_URL):
+            # replace with str.removeprefix() after 3.8 has been deprecated
+            self._parsed_weaviate_version = self.options.version[
+                len(GITHUB_RELEASE_DOWNLOAD_URL) :
+            ].split("/")[0]
 
     def __del__(self):
         self.stop()


### PR DESCRIPTION
- Run embedded tests only on Linux and skip otherwise 
- Create a "weavaite-embedded" folder in the binary path that contains all binaries
- Add the version and a hash to the filename to distinguish different weaviate versions
- Make env vars configurable through the client