### PR TITLE
add moduleConfig to test class

### DIFF
--- a/ci/docker-compose-azure.yml
+++ b/ci/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     restart: on-failure:0
     ports:
       - "8087:8080"

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-openai.yml
+++ b/ci/docker-compose-openai.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.19.0
+    image: semitechnologies/weaviate:1.19.2
     ports:
       - "8080:8080"
       - "50051:50051"

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -2,8 +2,8 @@ import pytest
 
 import weaviate
 
-GIT_HASH = "48456a1"
-SERVER_VERSION = "1.19.0"
+GIT_HASH = "44d10b2"
+SERVER_VERSION = "1.19.2"
 NODE_NAME = "node1"
 NUM_OBJECT = 10
 

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -314,6 +314,9 @@ def test_generative_openai(single: str, grouped: str):
             {"name": "name", "dataType": ["string"]},
             {"name": "review", "dataType": ["string"]},
         ],
+        "moduleConfig": {
+            "generative-openai": {}
+        }
     }
     client.schema.create_class(wine_class)
     client.data_object.create(

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -314,9 +314,7 @@ def test_generative_openai(single: str, grouped: str):
             {"name": "name", "dataType": ["string"]},
             {"name": "review", "dataType": ["string"]},
         ],
-        "moduleConfig": {
-            "generative-openai": {}
-        }
+        "moduleConfig": {"generative-openai": {}},
     }
     client.schema.create_class(wine_class)
     client.data_object.create(


### PR DESCRIPTION
Weaviate v1.19.2 added a more restrictive check for adding class arguments to the GQL schema, like `generate`. As a result, all classes which need to use a generative module need to have a module config, even if empty.

This PR bumps the sever version to the latest patch, and updates the generative test class to contain a moduleConfig.