### PR TITLE
Rename reference dataclass

### DIFF
--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Dict, Union
 import pytest
 
 import weaviate
-from weaviate.gql.get import Reference
+from weaviate.gql.get import LinkTo
 
 
 def get_query_for_group(name):
@@ -503,7 +503,7 @@ def test_beacon_refs(people_schema):
         "Call",
         [
             "start",
-            Reference(reference_property="caller", linked_class="Person", properties=["name"]),
+            LinkTo(link_on="caller", linked_class="Person", properties=["name"]),
         ],
     ).do()
     callers = result["data"]["Get"]["Call"][0]["caller"]
@@ -563,12 +563,8 @@ def test_beacon_refs_multiple(people_schema):
     result = client.query.get(
         "Call",
         [
-            Reference(
-                reference_property="caller", linked_class="Person", properties=["name", "age"]
-            ),
-            Reference(
-                reference_property="recipient", linked_class="Person", properties=["born_in", "age"]
-            ),
+            LinkTo(link_on="caller", linked_class="Person", properties=["name", "age"]),
+            LinkTo(link_on="recipient", linked_class="Person", properties=["born_in", "age"]),
         ],
     ).do()
     call1 = result["data"]["Get"]["Call"][0]
@@ -640,29 +636,27 @@ def test_beacon_refs_nested():
         "D",
         [
             "nonRef",
-            Reference(
-                reference_property="refC",
+            LinkTo(
+                link_on="refC",
                 linked_class="C",
                 properties=[
                     "nonRef",
-                    Reference(
-                        reference_property="refB",
+                    LinkTo(
+                        link_on="refB",
                         linked_class="B",
                         properties=[
                             "nonRef",
-                            Reference(
-                                reference_property="refA", linked_class="A", properties=["nonRef"]
-                            ),
+                            LinkTo(link_on="refA", linked_class="A", properties=["nonRef"]),
                         ],
                     ),
                 ],
             ),
-            Reference(
-                reference_property="refB",
+            LinkTo(
+                link_on="refB",
                 linked_class="B",
                 properties=[
                     "nonRef",
-                    Reference(reference_property="refA", linked_class="A", properties=["nonRef"]),
+                    LinkTo(link_on="refA", linked_class="A", properties=["nonRef"]),
                 ],
             ),
         ],

--- a/test/gql/test_get.py
+++ b/test/gql/test_get.py
@@ -6,7 +6,7 @@ import pytest
 
 from test.util import check_error_message
 from weaviate.data.replication import ConsistencyLevel
-from weaviate.gql.get import GetBuilder, BM25, Hybrid, Reference, GroupBy, AdditionalProperties
+from weaviate.gql.get import GetBuilder, BM25, Hybrid, LinkTo, GroupBy, AdditionalProperties
 
 mock_connection_v117 = Mock()
 mock_connection_v117.server_version = "1.17.4"
@@ -65,7 +65,7 @@ def test_bm25(query: str, properties: List[str], expected: str):
     ],
 )
 def test_get_references(property_name: str, in_class: str, properties: List[str], expected: str):
-    ref = Reference(property_name, in_class, properties)
+    ref = LinkTo(property_name, in_class, properties)
     assert str(ref) == expected
 
 

--- a/weaviate/__init__.py
+++ b/weaviate/__init__.py
@@ -49,7 +49,7 @@ __all__ = [
     "Config",
     "ConnectionConfig",
     "AdditionalProperties",
-    "Reference",
+    "LinkTo",
 ]
 
 import sys
@@ -74,7 +74,7 @@ from .exceptions import (
     WeaviateStartUpError,
 )
 from .config import Config, ConnectionConfig
-from .gql.get import AdditionalProperties, Reference
+from .gql.get import AdditionalProperties, LinkTo
 
 if not sys.warnoptions:
     import warnings

--- a/weaviate/gql/get.py
+++ b/weaviate/gql/get.py
@@ -75,17 +75,17 @@ class GroupBy:
 
 
 @dataclass
-class Reference:
-    reference_property: str
+class LinkTo:
+    link_on: str
     linked_class: str
-    properties: List[Union[str, "Reference"]]
+    properties: List[Union[str, "LinkTo"]]
 
     def __str__(self) -> str:
         props = " ".join(str(x) for x in self.properties)
-        return self.reference_property + "{... on " + self.linked_class + "{" + props + "}}"
+        return self.link_on + "{... on " + self.linked_class + "{" + props + "}}"
 
 
-PROPERTIES = Union[List[Union[str, Reference]], str]
+PROPERTIES = Union[List[Union[str, LinkTo]], str]
 
 
 @dataclass
@@ -153,9 +153,9 @@ class GetBuilder(GraphQL):
                 "properties must be of type str, " f"list of str or None but was {type(properties)}"
             )
 
-        self._properties: List[Union[str, Reference]] = []
+        self._properties: List[Union[str, LinkTo]] = []
         for prop in properties:
-            if not isinstance(prop, str) and not isinstance(prop, Reference):
+            if not isinstance(prop, str) and not isinstance(prop, LinkTo):
                 raise TypeError("All the `properties` must be of type `str` or Reference!")
             self._properties.append(prop)
 
@@ -1328,18 +1328,18 @@ class GetBuilder(GraphQL):
         return result
 
     def _convert_references_to_grpc(
-        self, properties: List[Union[Reference, str]]
+        self, properties: List[Union[LinkTo, str]]
     ) -> weaviate_pb2.Properties:
         return weaviate_pb2.Properties(
             non_ref_properties=[prop for prop in properties if isinstance(prop, str)],
             ref_properties=[
                 weaviate_pb2.RefProperties(
                     linked_class=prop.linked_class,
-                    reference_property=prop.reference_property,
+                    reference_property=prop.link_on,
                     linked_properties=self._convert_references_to_grpc(prop.properties),
                 )
                 for prop in properties
-                if isinstance(prop, Reference)
+                if isinstance(prop, LinkTo)
             ],
         )
 


### PR DESCRIPTION
was

```
Reference(reference_property="caller", linked_class="Person", properties=["name"])
```

is now
```
LinkTo(link_on="caller", linked_class="Person", properties=["name"])
```