### PR TITLE
Add dataclass as schema

### DIFF
--- a/test/schema/properties/test_properties.py
+++ b/test/schema/properties/test_properties.py
@@ -8,7 +8,7 @@ from weaviate.exceptions import (
     UnexpectedStatusCodeException,
     SchemaValidationException,
 )
-from weaviate.schema.properties import Property
+from weaviate.schema.properties import CrudProperty
 
 
 class TestCRUDProperty(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestCRUDProperty(unittest.TestCase):
         Test `create` method.
         """
 
-        prop = Property(Mock())
+        prop = CrudProperty(Mock())
 
         # invalid calls
         error_message = "Class name must be of type str but is "
@@ -33,19 +33,21 @@ class TestCRUDProperty(unittest.TestCase):
             prop.create("Class", {})
         check_error_message(self, error, check_property_error_message)
 
-        prop = Property(mock_connection_func("post", side_effect=RequestsConnectionError("Test!")))
+        prop = CrudProperty(
+            mock_connection_func("post", side_effect=RequestsConnectionError("Test!"))
+        )
         with self.assertRaises(RequestsConnectionError) as error:
             prop.create("Class", {"name": "test", "dataType": ["test_type"]})
         check_error_message(self, error, requests_error_message)
 
-        prop = Property(mock_connection_func("post", status_code=404))
+        prop = CrudProperty(mock_connection_func("post", status_code=404))
         with self.assertRaises(UnexpectedStatusCodeException) as error:
             prop.create("Class", {"name": "test", "dataType": ["test_type"]})
         check_startswith_error_message(self, error, "Add property to class")
 
         # valid calls
         connection_mock = mock_connection_func("post")  # Mock calling weaviate
-        prop = Property(connection_mock)
+        prop = CrudProperty(connection_mock)
 
         test_prop = {
             "dataType": ["string"],

--- a/test/schema/test_schema_dataclass.py
+++ b/test/schema/test_schema_dataclass.py
@@ -1,0 +1,31 @@
+from typing import Dict, Any
+
+import pytest as pytest
+
+from weaviate.types import Class, Property, DataType
+
+
+@pytest.mark.parametrize(
+    "schema_class, expected",
+    [
+        (Class(name="ClassName"), {"class": "ClassName"}),
+        (
+            Class(
+                name="ClassName",
+                properties=[
+                    Property(name="Prop1", dataType=DataType.UUID),
+                    Property(name="Prop2", dataType=DataType.TEXT_ARRAY),
+                ],
+            ),
+            {
+                "class": "ClassName",
+                "properties": [
+                    {"name": "Prop1", "dataType": ["uuid"]},
+                    {"name": "Prop2", "dataType": ["text[]"]},
+                ],
+            },
+        ),
+    ],
+)
+def test_schema_dataclass(schema_class: Class, expected: Dict[str, Any]):
+    assert schema_class.to_dict() == expected

--- a/weaviate/__init__.py
+++ b/weaviate/__init__.py
@@ -50,6 +50,20 @@ __all__ = [
     "ConnectionConfig",
     "AdditionalProperties",
     "LinkTo",
+    "Class",
+    "Property",
+    "InvertedIndexConfig",
+    "Stopwords",
+    "BM25config",
+    "ReplicationConfig",
+    "ShardingConfig",
+    "VectorIndexConfig",
+    "StopwordsPreset",
+    "VectorDistance",
+    "Vectorizer",
+    "Tokenization",
+    "VectorIndexType",
+    "DataType",
 ]
 
 import sys
@@ -75,6 +89,22 @@ from .exceptions import (
 )
 from .config import Config, ConnectionConfig
 from .gql.get import AdditionalProperties, LinkTo
+from .types import (
+    Class,
+    Property,
+    InvertedIndexConfig,
+    Stopwords,
+    BM25config,
+    ReplicationConfig,
+    ShardingConfig,
+    VectorIndexConfig,
+    StopwordsPreset,
+    VectorDistance,
+    Vectorizer,
+    Tokenization,
+    VectorIndexType,
+    DataType,
+)
 
 if not sys.warnoptions:
     import warnings

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -7,13 +7,14 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.connect import Connection
 from weaviate.exceptions import UnexpectedStatusCodeException
-from weaviate.schema.properties import Property
+from weaviate.schema.properties import CrudProperty
 from weaviate.schema.validate_schema import (
     validate_schema,
     check_class,
     CLASS_KEYS,
     PROPERTY_KEYS,
 )
+from weaviate.types import Class
 from weaviate.util import _get_dict_from_object, _is_sub_schema, _capitalize_first_letter
 
 _PRIMITIVE_WEAVIATE_TYPES_SET = {
@@ -43,7 +44,7 @@ class Schema:
 
     Attributes
     ----------
-    property : weaviate.schema.properties.Property
+    property : weaviate.schema.properties.CrudProperty
         A Property object to create new schema property/ies.
     """
 
@@ -58,9 +59,9 @@ class Schema:
         """
 
         self._connection = connection
-        self.property = Property(self._connection)
+        self.property = CrudProperty(self._connection)
 
-    def create(self, schema: Union[dict, str]) -> None:
+    def create(self, schema: Union[dict, str, Class]) -> None:
         """
         Create the schema of the Weaviate instance, with all classes at once.
 

--- a/weaviate/schema/properties/__init__.py
+++ b/weaviate/schema/properties/__init__.py
@@ -2,6 +2,6 @@
 Module used to manipulate schema properties.
 """
 
-__all__ = ["Property"]
+__all__ = ["CrudProperty"]
 
-from .crud_properties import Property
+from .crud_properties import CrudProperty

--- a/weaviate/schema/properties/crud_properties.py
+++ b/weaviate/schema/properties/crud_properties.py
@@ -9,7 +9,7 @@ from weaviate.schema.validate_schema import check_property
 from weaviate.util import _get_dict_from_object, _capitalize_first_letter
 
 
-class Property:
+class CrudProperty:
     """
     Property class used to create object properties.
     """

--- a/weaviate/types.py
+++ b/weaviate/types.py
@@ -1,5 +1,195 @@
 import uuid
+from dataclasses import dataclass, fields, Field
+from enum import EnumMeta, Enum
+from typing import Optional, List, Dict, Any, Tuple
 from typing import Union
+
+
+# MetaEnum and BaseEnum are required to support `in` statements:
+#    'ALL' in ConsistencyLevel == True
+#    12345 in ConsistencyLevel == False
+class MetaEnum(EnumMeta):
+    def __contains__(cls, item: Any) -> bool:
+        try:
+            # when item is type ConsistencyLevel
+            return item.name in cls.__members__.keys()
+        except AttributeError:
+            # when item is type str
+            return item in cls.__members__.keys()
+
+
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass
+
 
 UUID = Union[str, uuid.UUID]
 NUMBERS = Union[int, float]
+
+
+class DataType(str, BaseEnum):
+    TEXT = "text"
+    TEXT_ARRAY = "text[]"
+    INT = "int"
+    INT_ARRAY = "int[]"
+    BOOL = "boolean"
+    BOOL_ARRAY = "boolean[]"
+    NUMBER = "number"
+    NUMBER_ARRAY = "number[]"
+    DATE = "date"
+    DATE_ARRAY = "date[]"
+    UUID = "uuid"
+    UUID_ARRAY = "uuid[]"
+    GEO_COORDINATES = "geoCoordinates"
+    BLOB = "blob"
+    PHONE_NUMBER = "phoneNumber"
+
+
+class VectorIndexType(str, BaseEnum):
+    HNSW = "hnsw"
+
+
+class Tokenization(str, BaseEnum):
+    WORD = "word"
+    WHITESPACE = "whitespace"
+    LOWERCASE = "lowercase"
+    FIELD = "field"
+
+
+class Vectorizer(str, BaseEnum):
+    NONE = "none"
+    TEXT2VEC_OPENAI = "text2vec-openai"
+    TEXT2VEC_COHERE = "text2vec-cohere"
+    TEXT2VEC_PALM = "text2vec-palm"
+    TEXT2VEC_HUGGINGFACE = "text2vec-huggingface"
+    TEXT2VEC_TRANSFORMERS = "text2vec-transformers"
+    TEXT2VEC_CONTEXTIONARY = "text2vec-contextionary"
+    IMG2VEC_NEURAL = "img2vec-neural"
+    MULTI2VEC_CLIP = "multi2vec-clip"
+    REF2VEC_CENTROID = "ref2vec_centroid"
+
+
+class VectorDistance(str, BaseEnum):
+    COSINE = "cosine"
+    DOT = "dot"
+    L2_SQUARED = "l2-squared"
+    HAMMING = "hamming"
+    MANHATTAN = "manhattan"
+
+
+class StopwordsPreset(str, BaseEnum):
+    NONE = "none"
+    EN = "en"
+
+
+ModuleConfig = Dict[Vectorizer, Dict[str, Any]]
+
+
+@dataclass
+class BaseSchema:
+    def to_dict(self) -> Dict[str, Any]:
+        ret_dict = {}
+        cls_fields: Tuple[Field, ...] = fields(self.__class__)
+        for cls_field in cls_fields:
+            val = getattr(self, cls_field.name)
+            if val is None:
+                continue
+            if isinstance(val, Enum):
+                ret_dict[cls_field.name] = str(val.value)
+            else:
+                ret_dict[cls_field.name] = val
+
+        return ret_dict
+
+
+@dataclass
+class VectorIndexConfig(BaseSchema):
+    distance: VectorDistance = VectorDistance.COSINE
+    efConstruction: int = 128
+    maxConnections: int = 64
+
+
+@dataclass
+class ShardingConfig(BaseSchema):
+    virtualPerPhysical: Optional[int] = None
+    desiredCount: Optional[int] = None
+    actualCount: Optional[int] = None
+    desiredVirtualCount: Optional[int] = None
+    actualVirtualCount: Optional[int] = None
+    key: Optional[str] = None
+    strategy: Optional[str] = None
+    function: Optional[str] = None
+
+
+@dataclass
+class ReplicationConfig(BaseSchema):
+    factor: Optional[int] = None
+
+
+@dataclass
+class BM25config(BaseSchema):
+    b: float = 0.75
+    k1: float = 1.2
+
+
+@dataclass
+class Stopwords(BaseSchema):
+    preset: StopwordsPreset = StopwordsPreset.EN
+    additions: Optional[List[str]] = None
+    removals: Optional[List[str]] = None
+
+
+@dataclass
+class InvertedIndexConfig(BaseSchema):
+    bm25: Optional[BM25config] = None
+    stopwords: Optional[Stopwords] = None
+    indexTimestamps: bool = False
+    indexPropertyLength: bool = False
+    indexNullState: bool = False
+
+
+@dataclass
+class Property(BaseSchema):
+    name: str
+    dataType: DataType
+    indexFilterable: Optional[bool] = None
+    indexSearchable: Optional[bool] = None
+    tokenization: Optional[Tokenization] = None
+    description: Optional[str] = None
+    moduleConfig: Optional[ModuleConfig] = None
+
+    def to_dict(self):
+        ret_dict = super().to_dict()
+        ret_dict["dataType"] = [ret_dict["dataType"]]
+        return ret_dict
+
+
+@dataclass
+class Class:
+    name: str
+    properties: Optional[List[Property]] = None
+    vectorIndexType: Optional[VectorIndexType] = None
+    vectorizer: Optional[Vectorizer] = None
+    vectorIndexConfig: Optional[VectorIndexConfig] = None
+    description: Optional[str] = None
+    shardingConfig: Optional[ShardingConfig] = None
+    replicationConfig: Optional[ReplicationConfig] = None
+    invertedIndexConfig: Optional[InvertedIndexConfig] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        ret_dict = {"class": self.name}
+        if self.properties is not None and len(self.properties) > 0:
+            ret_dict["properties"] = [x.to_dict() for x in self.properties]
+
+        cls_fields: Tuple[Field, ...] = fields(self.__class__)
+        for cls_field in cls_fields:
+            val = getattr(self, cls_field.name)
+            if cls_field.name in ["name", "properties"] or val is None:
+                continue
+            if isinstance(val, Enum):
+                ret_dict[cls_field.name] = str(val.value)
+            elif isinstance(val, (bool, float, str, int)):
+                ret_dict[cls_field.name] = str(val)
+            else:
+                ret_dict[cls_field.name] = val.to_dict()
+
+        return ret_dict


### PR DESCRIPTION
Example:

```
Class(
                name="testClass",
                properties=[
                    Property(name="Prop1", dataType=DataType.UUID),
                    Property(name="Prop2", dataType=DataType.TEXT_ARRAY),
                ],
            )
```

is equivalent to

```
            {
                "class": "TestClass",
                "properties": [
                    {"name": "prop1", "dataType": ["uuid"]},
                    {"name": "prop2", "dataType": ["text[]"]},
                ],
            },
```

the class object can be passed to `client.schema.create_class(*class*)` just the existing dict-schema