### PR TITLE
Increase Requests Upper Bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.28.0,<2.29.0
+requests>=2.28.0,<2.31
 validators>=0.18.2,<0.20.0
 tqdm>=4.59.0,<5.0.0
 authlib>=1.1.0


### PR DESCRIPTION
Increase the upper bound to 2.31.0 to be compatible with other projects.

I'm assuming this bound was set to maintain py 2.7 compatibility?

https://requests.readthedocs.io/en/latest/community/updates/#id6

Related comment: https://github.com/hwchase17/langchain/pull/5184#issuecomment-1561098475

I agree with the Contributor License Agreement