### PR TITLE
Fix erroneous docstring in Schema.exists

### DIFF
--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -239,7 +239,7 @@ class Schema:
         Parameters
         ----------
         class_name : str
-            The class that should be deleted from Weaviate.
+            The class whose existence is being checked.
 
         Examples
         --------


### PR DESCRIPTION
The parameter list for must've been copy-pasted from somewhere else, because it claims the class is "being deleted", but this function only checks for existence.