### PR TITLE
Feature: add .with_limit() method to AggregateBuilder

### DIFF
--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -195,7 +195,10 @@ def test_aggregate_data_with_just_limit(client):
     result = client.query.aggregate("Ship").with_fields("name{count}").with_limit(2).do()
 
     objects = get_objects_from_aggregate_result(result)
-    assert objects == [{'name': {'count': len(SHIPS)}}], f"Expected only meta count for {len(SHIPS)} results"
+    assert objects == [
+        {"name": {"count": len(SHIPS)}}
+    ], f"Expected only meta count for {len(SHIPS)} results"
+
 
 def get_objects_from_result(result):
     return result["data"]["Get"]["Ship"]

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -176,12 +176,37 @@ def test_aggregate_data(client):
     assert "name" in aggregation, "Missing name property"
 
 
+def test_aggregate_data_with_group_by_and_limit(client):
+    """Test GraphQL's Aggregate clause with group_by and limit."""
+    result = (
+        client.query.aggregate("Ship")
+        .with_fields("name{count}")
+        .with_limit(2)
+        .with_group_by_filter(["name"])
+        .do()
+    )
+
+    objects = get_objects_from_aggregate_result(result)
+    assert len(objects) == 2, "Expected 2 results"
+
+
+def test_aggregate_data_with_just_limit(client):
+    """Test GraphQL's Aggregate clause with only limit. It's idempotent."""
+    result = client.query.aggregate("Ship").with_fields("name{count}").with_limit(2).do()
+
+    objects = get_objects_from_aggregate_result(result)
+    assert objects == [{'name': {'count': len(SHIPS)}}], f"Expected only meta count for {len(SHIPS)} results"
+
 def get_objects_from_result(result):
     return result["data"]["Get"]["Ship"]
 
 
 def get_aggregation_from_aggregate_result(result):
     return result["data"]["Aggregate"]["Ship"][0]
+
+
+def get_objects_from_aggregate_result(result):
+    return result["data"]["Aggregate"]["Ship"]
 
 
 @pytest.mark.parametrize("query", ["sponges", "sponges\n"])

--- a/test/gql/test_aggregate.py
+++ b/test/gql/test_aggregate.py
@@ -58,6 +58,22 @@ class TestAggregateBuilder(unittest.TestCase):
             '{Aggregate{Object(groupBy: ["name"]){groupedBy { value }name { count }}}}', query
         )
 
+    def test_with_limit(self):
+        """
+        Test the `with_limit` method.
+        """
+
+        query = (
+            self.aggregate.with_meta_count()
+            .with_where({"operator": "Equal", "valueString": "B", "path": ["name"]})
+            .with_limit(10)
+            .build()
+        )
+        self.assertEqual(
+            '{Aggregate{Object(where: {path: ["name"] operator: Equal valueString: "B"} limit: 10){meta{count}}}}',
+            query,
+        )
+
     def test_do(self):
         """
         Test the `do` method.

--- a/weaviate/gql/aggregate.py
+++ b/weaviate/gql/aggregate.py
@@ -69,7 +69,8 @@ class AggregateBuilder(GraphQL):
 
     def with_object_limit(self, limit: int) -> "AggregateBuilder":
         """
-        Set objectLimit to limit vector search results only when with near<MEDIA> filter.
+        Set objectLimit to limit vector search results used within the aggregation query
+        only when with near<MEDIA> filter.
 
         Parameters
         ----------
@@ -87,7 +88,7 @@ class AggregateBuilder(GraphQL):
 
     def with_limit(self, limit: int) -> "AggregateBuilder":
         """
-        Set limit to limit the number of returned results.
+        Set limit to limit the number of returned results from the aggregation query.
 
         Parameters
         ----------

--- a/weaviate/gql/aggregate.py
+++ b/weaviate/gql/aggregate.py
@@ -43,6 +43,7 @@ class AggregateBuilder(GraphQL):
         self._uses_filter: bool = False
         self._near: Optional[Filter] = None
         self._tenant: Optional[str] = None
+        self._limit: Optional[int] = None
 
     def with_tenant(self, tenant: str) -> "AggregateBuilder":
         """Sets a tenant for the query."""
@@ -82,6 +83,24 @@ class AggregateBuilder(GraphQL):
         """
 
         self._object_limit = limit
+        return self
+
+    def with_limit(self, limit: int) -> "AggregateBuilder":
+        """
+        Set limit to limit the number of returned results.
+
+        Parameters
+        ----------
+        limit : int
+            The limit.
+
+        Returns
+        -------
+        weaviate.gql.aggregate.AggregateBuilder
+            Updated AggregateBuilder.
+        """
+
+        self._limit = limit
         return self
 
     def with_fields(self, field: str) -> "AggregateBuilder":
@@ -422,6 +441,8 @@ class AggregateBuilder(GraphQL):
                 query += f"objectLimit: {self._object_limit}"
             if self._tenant is not None:
                 query += f'tenant: "{self._tenant}"'
+            if self._limit is not None:
+                query += f"limit: {self._limit}"
 
             query += ")"
 


### PR DESCRIPTION
This PR adds support for using the `limit` argument on `Aggregate` queries through the `.with_limit()` builder method of the `AggregateBuilder` class as requested in https://github.com/weaviate/weaviate-python-client/issues/361.

Since its function is dependent on the presence of other filters, it is only included when they are also. Unit and integration tests are added to handle the new features. There are no client-side data validation checks so that any user mishap will be reported as as errors from Weaviate itself, as per the rest of the codebase.

@dirkkul, let me know if this is inline with your thoughts on the feature and whether further changes are required!