### PR TITLE
[bugfix] Add spaces around string output of AdditionalProperties

### DIFF
--- a/weaviate/gql/get.py
+++ b/weaviate/gql/get.py
@@ -124,7 +124,7 @@ class AdditionalProperties:
                         name = "id"
                     additional_props.append(name)
         if len(additional_props) > 0:
-            return "_additional{" + " ".join(additional_props) + "}"
+            return " _additional{" + " ".join(additional_props) + "} "
         else:
             return ""
 


### PR DESCRIPTION
Proposed bugfix

## Problem:

The below is not parsed properly into GraphQL, I believe as there isn't a space at the start of the returned string in:

`return "_additional{" + " ".join(additional_props) + "}"` (`get.py`, L127)

```
from weaviate import AdditionalProperties

results = (
    client.query.get("Article", ['title'])
    .with_additional(
        AdditionalProperties(
            vector=True,
            uuid=True,
        )
    )
    .with_limit(2)
    .do()
)
```

The proposed fix prepends a space - similarly to L1419.