### PR TITLE
Pydantic experiment align configs names

### DIFF
--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -25,7 +25,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.20.0-prealpha-628c8ff
+    image: semitechnologies/weaviate:preview-add-missing-features-to-grpc-112529d
     ports:
       - 8088:8080
       - 6061:6060

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -25,7 +25,7 @@ def client():
     client.schema.delete_all()
 
 
-def test_create_and_delete(client):
+def test_create_and_delete(client: weaviate.Client):
     name = "Something"
     collection_config = CollectionConfig(
         name=name,
@@ -50,7 +50,7 @@ def test_create_and_delete(client):
         (DataType.NUMBER_ARRAY, [1.0, 2.1]),
     ],
 )
-def test_types(client, dataType, value):
+def test_types(client: weaviate.Client, dataType, value):
     name = "name"
     client.collection.delete("Something")
 
@@ -68,7 +68,7 @@ def test_types(client, dataType, value):
     client.collection.delete("Something")
 
 
-def test_references(client):
+def test_references(client: weaviate.Client):
     ref_collection = client.collection.create(
         CollectionConfig(name="RefClass2", vectorizer=Vectorizer.NONE)
     )
@@ -100,7 +100,7 @@ def test_references(client):
 
 
 @pytest.mark.parametrize("fusion_type", [HybridFusion.RANKED, HybridFusion.RELATIVE_SCORE])
-def test_search_hybrid(client, fusion_type):
+def test_search_hybrid(client: weaviate.Client, fusion_type):
     collection = client.collection.create(
         CollectionConfig(
             name="Testing",
@@ -118,7 +118,7 @@ def test_search_hybrid(client, fusion_type):
 
 
 @pytest.mark.parametrize("limit", [1, 5])
-def test_search_limit(client, limit):
+def test_search_limit(client: weaviate.Client, limit):
     client.collection.delete("TestLimit")
     collection = client.collection.create(
         CollectionConfig(
@@ -134,7 +134,7 @@ def test_search_limit(client, limit):
 
 
 @pytest.mark.parametrize("offset", [0, 1, 5])
-def test_search_offset(client, offset):
+def test_search_offset(client: weaviate.Client, offset):
     client.collection.delete("TestOffset")
     collection = client.collection.create(
         CollectionConfig(
@@ -152,7 +152,7 @@ def test_search_offset(client, offset):
     assert len(objects) == nr_objects - offset
 
 
-def test_search_after(client):
+def test_search_after(client: weaviate.Client):
     client.collection.delete("TestOffset")
     collection = client.collection.create(
         CollectionConfig(
@@ -172,7 +172,7 @@ def test_search_after(client):
         assert len(objects_after) == nr_objects - 1 - i
 
 
-def test_autocut(client):
+def test_autocut(client: weaviate.Client):
     client.collection.delete("TestAutocut")
     collection = client.collection.create(
         CollectionConfig(
@@ -205,7 +205,7 @@ def test_autocut(client):
     assert len(objects) == 1 * 4
 
 
-def test_near_vector(client):
+def test_near_vector(client: weaviate.Client):
     client.collection.delete("TestNearVector")
     collection = client.collection.create(
         CollectionConfig(
@@ -237,7 +237,7 @@ def test_near_vector(client):
     assert len(objects_distance) == 3
 
 
-def test_near_object(client):
+def test_near_object(client: weaviate.Client):
     client.collection.delete("TestNearVector")
     collection = client.collection.create(
         CollectionConfig(
@@ -267,7 +267,7 @@ def test_near_object(client):
     assert len(objects_distance) == 3
 
 
-def test_references_grcp(client):
+def test_references_grcp(client: weaviate.Client):
     client.collection.delete("A")
     client.collection.delete("B")
     client.collection.delete("C")

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -9,11 +9,13 @@ import pytest as pytest
 import uuid
 
 import weaviate
-from weaviate.collection.collection_model import (
-    CollectionModelConfig,
+from weaviate.weaviate_classes import (
     BaseProperty,
+    CollectionModelConfig,
+    PropertyConfig,
+    ReferenceTo,
+    Vectorizer,
 )
-from weaviate.weaviate_classes import PropertyConfig, ReferenceTo, Vectorizer
 from weaviate.weaviate_types import UUIDS
 
 REF_TO_UUID = uuid.uuid4()

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -10,12 +10,10 @@ import uuid
 
 import weaviate
 from weaviate.collection.collection_model import (
-    CollectionConfigModel,
+    CollectionModelConfig,
     BaseProperty,
-    PropertyConfig,
-    ReferenceTo,
 )
-from weaviate.weaviate_classes import Vectorizer
+from weaviate.weaviate_classes import PropertyConfig, ReferenceTo, Vectorizer
 from weaviate.weaviate_types import UUIDS
 
 REF_TO_UUID = uuid.uuid4()
@@ -30,7 +28,7 @@ def client():
     client = weaviate.Client("http://localhost:8080")
     client.schema.delete_all()
     collection = client.collection_model.create(
-        CollectionConfigModel(vectorizer=Vectorizer.NONE), Group
+        CollectionModelConfig(name="Group", model=Group, vectorizer=Vectorizer.NONE)
     )
     collection.insert(obj=Group(name="Name", uuid=REF_TO_UUID))
 
@@ -50,16 +48,17 @@ def client():
     ],
 )
 @pytest.mark.parametrize("optional", [True, False])
-def test_types(client, member_type, value, optional: bool):
+def test_types(client: weaviate.Client, member_type, value, optional: bool):
     if optional:
         member_type = Optional[member_type]
 
     class ModelTypes(BaseProperty):
         name: member_type
 
-    client.collection_model.delete(ModelTypes)
+    name = "ModelTypes"
+    client.collection_model.delete(name)
     collection = client.collection_model.create(
-        CollectionConfigModel(vectorizer=Vectorizer.NONE), ModelTypes
+        CollectionModelConfig(name=name, model=ModelTypes, vectorizer=Vectorizer.NONE)
     )
     uuid_object = collection.insert(ModelTypes(name=value))
     object_get = collection.get_by_id(uuid_object)
@@ -79,27 +78,29 @@ def test_types(client, member_type, value, optional: bool):
         (Optional[UUIDS], ReferenceTo(Group), [str(REF_TO_UUID)], "Group"),
     ],
 )
-def test_types_annotates(client, member_type, annotation, value, expected: str):
+def test_types_annotates(client: weaviate.Client, member_type, annotation, value, expected: str):
     class ModelTypes(BaseProperty):
         name: Annotated[member_type, annotation]
 
-    client.collection_model.delete(ModelTypes)
+    name = "ModelTypes"
+    client.collection_model.delete(name)
     collection = client.collection_model.create(
-        CollectionConfigModel(vectorizer=Vectorizer.NONE), ModelTypes
+        CollectionModelConfig(name=name, model=ModelTypes, vectorizer=Vectorizer.NONE)
     )
     uuid_object = collection.insert(ModelTypes(name=value))
     object_get = collection.get_by_id(uuid_object)
     assert object_get.data.name == value
 
 
-@pytest.mark.parametrize("use_name", [True, False])
-def test_create_and_delete(client, use_name: bool):
+def test_create_and_delete(client: weaviate.Client):
     class DeleteModel(BaseProperty):
         name: int
 
-    client.collection_model.create(CollectionConfigModel(vectorizer=Vectorizer.NONE), DeleteModel)
-    model = DeleteModel.__name__ if use_name else DeleteModel
+    name = "DeleteModel"
+    client.collection_model.create(
+        CollectionModelConfig(name=name, model=DeleteModel, vectorizer=Vectorizer.NONE)
+    )
 
-    assert client.collection_model.exists(model)
-    client.collection_model.delete(model)
-    assert not client.collection_model.exists(model)
+    assert client.collection_model.exists(name)
+    client.collection_model.delete(name)
+    assert not client.collection_model.exists(name)

--- a/test/collection/test_collection_model.py
+++ b/test/collection/test_collection_model.py
@@ -8,7 +8,7 @@ else:
 
 import pytest as pytest
 
-from weaviate.collection.collection_model import BaseProperty, ReferenceTo, PropertyConfig
+from weaviate.weaviate_classes import BaseProperty, ReferenceTo, PropertyConfig
 from weaviate.weaviate_types import UUIDS
 
 

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -219,12 +219,11 @@ class CollectionObject(CollectionObjectBase):
 
 class Collection(CollectionBase):
     def create(self, config: CollectionConfig) -> CollectionObject:
-        name = super()._create(config)
+        super()._create(config)
+        return CollectionObject(self._connection, config.name)
 
+    def get(self, name: str) -> CollectionObject:
         return CollectionObject(self._connection, name)
-
-    def get(self, collection_name: str) -> CollectionObject:
-        return CollectionObject(self._connection, collection_name)
 
     def delete(self, name: str) -> None:
         self._delete(name)

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -219,7 +219,11 @@ class CollectionObject(CollectionObjectBase):
 
 class Collection(CollectionBase):
     def create(self, config: CollectionConfig) -> CollectionObject:
-        super()._create(config)
+        name = super()._create(config)
+        if config.name != name:
+            raise ValueError(
+                f"Name of created collection ({name}) does not match given name ({config.name})"
+            )
         return CollectionObject(self._connection, config.name)
 
     def get(self, name: str) -> CollectionObject:

--- a/weaviate/collection/collection_base.py
+++ b/weaviate/collection/collection_base.py
@@ -244,16 +244,9 @@ class CollectionBase:
 
     def _create(
         self,
-        model: CollectionConfigBase,
-        properties: Optional[List[Dict[str, Any]]] = None,
-        name: Optional[str] = None,
-    ) -> str:
-        weaviate_object = model.to_dict()
-        if properties is not None:
-            weaviate_object["properties"] = properties
-        if name is not None:
-            weaviate_object["class"] = name
-
+        config: CollectionConfigBase,
+    ) -> None:
+        weaviate_object = config.to_dict()
         try:
             response = self._connection.post(path="/schema", weaviate_object=weaviate_object)
         except RequestsConnectionError as conn_err:
@@ -261,12 +254,8 @@ class CollectionBase:
         if response.status_code != 200:
             raise UnexpectedStatusCodeException("Create class", response)
 
-        collection_name = response.json()["class"]
-        assert isinstance(collection_name, str)
-        return collection_name
-
     def _exists(self, name: str) -> bool:
-        path = f"/schema/{_capitalize_names(name)}"
+        path = f"/schema/{name}"
         try:
             response = self._connection.get(path=path)
         except RequestsConnectionError as conn_err:
@@ -279,7 +268,7 @@ class CollectionBase:
         UnexpectedStatusCodeException("collection exists", response)
 
     def _delete(self, name: str) -> None:
-        path = f"/schema/{_capitalize_names(name)}"
+        path = f"/schema/{name}"
         try:
             response = self._connection.delete(path=path)
         except RequestsConnectionError as conn_err:
@@ -288,10 +277,3 @@ class CollectionBase:
             return
 
         UnexpectedStatusCodeException("Delete collection", response)
-
-
-def _capitalize_names(name: str) -> str:
-    collection_name = name[0].upper()
-    if len(name) > 1:
-        collection_name += name[1:]
-    return collection_name

--- a/weaviate/collection/collection_base.py
+++ b/weaviate/collection/collection_base.py
@@ -245,14 +245,19 @@ class CollectionBase:
     def _create(
         self,
         config: CollectionConfigBase,
-    ) -> None:
+    ) -> str:
         weaviate_object = config.to_dict()
+
         try:
             response = self._connection.post(path="/schema", weaviate_object=weaviate_object)
         except RequestsConnectionError as conn_err:
             raise RequestsConnectionError("Class may not have been created properly.") from conn_err
         if response.status_code != 200:
             raise UnexpectedStatusCodeException("Create class", response)
+
+        collection_name = response.json()["class"]
+        assert isinstance(collection_name, str)
+        return collection_name
 
     def _exists(self, name: str) -> bool:
         path = f"/schema/{name}"

--- a/weaviate/collection/collection_base.py
+++ b/weaviate/collection/collection_base.py
@@ -8,7 +8,7 @@ from weaviate.collection.collection_classes import Errors, Error
 from weaviate.connect import Connection
 from weaviate.data.replication import ConsistencyLevel
 from weaviate.exceptions import UnexpectedStatusCodeException, ObjectAlreadyExistsException
-from weaviate.util import _to_beacons
+from weaviate.util import _to_beacons, _capitalize_first_letter
 from weaviate.weaviate_classes import CollectionConfigBase, UUID, Metadata
 from weaviate.weaviate_types import UUIDS
 
@@ -260,7 +260,7 @@ class CollectionBase:
         return collection_name
 
     def _exists(self, name: str) -> bool:
-        path = f"/schema/{name}"
+        path = f"/schema/{_capitalize_first_letter(name)}"
         try:
             response = self._connection.get(path=path)
         except RequestsConnectionError as conn_err:
@@ -273,7 +273,7 @@ class CollectionBase:
         UnexpectedStatusCodeException("collection exists", response)
 
     def _delete(self, name: str) -> None:
-        path = f"/schema/{name}"
+        path = f"/schema/{_capitalize_first_letter(name)}"
         try:
             response = self._connection.delete(path=path)
         except RequestsConnectionError as conn_err:

--- a/weaviate/collection/collection_model.py
+++ b/weaviate/collection/collection_model.py
@@ -1,248 +1,29 @@
-import datetime
-import hashlib
-import typing
-from dataclasses import dataclass
-from typing import Type, Optional, Any, List, Set, Dict, Generic, TypeVar, Tuple, Union
+from typing import Type, Optional, Any, List, Dict, Generic, Tuple, Union
 
 import uuid as uuid_package
-from pydantic import BaseModel, Field, create_model, field_validator
-from pydantic_core._pydantic_core import PydanticUndefined
+from pydantic import create_model
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.collection.collection_base import (
     CollectionBase,
     CollectionObjectBase,
-    _capitalize_names,
 )
 from weaviate.collection.collection_classes import Errors
 from weaviate.collection.grpc import GrpcBuilderBase, HybridFusion, ReturnValues
 from weaviate.connect import Connection
 from weaviate.data.replication import ConsistencyLevel
 from weaviate.exceptions import UnexpectedStatusCodeException
-from weaviate.util import _to_beacons
 from weaviate.weaviate_classes import (
-    CollectionConfigBase,
+    BaseProperty,
+    BatchReference,
+    CollectionModelConfig,
     Metadata,
     MetadataReturn,
-    Tokenization,
-    ModuleConfig,
+    Model,
+    UserModelType,
+    _Object,
 )
-from weaviate.weaviate_types import UUID, UUIDS, BEACON, GEO_COORDINATES
-
-DATATYPE_TO_PYTHON_TYPE = {
-    "text": str,
-    "int": int,
-    "text[]": List[str],
-    "int[]": List[int],
-    "boolean": bool,
-    "boolean[]": List[bool],
-    "number": float,
-    "number[]": List[float],
-    "date": datetime.datetime,
-    "date[]": List[datetime.datetime],
-    "geoCoordinates": GEO_COORDINATES,
-}
-PYTHON_TYPE_TO_DATATYPE = {val: key for key, val in DATATYPE_TO_PYTHON_TYPE.items()}
-
-
-@dataclass
-class PropertyConfig:
-    indexFilterable: Optional[bool] = None
-    indexSearchable: Optional[bool] = None
-    tokenization: Optional[Tokenization] = None
-    description: Optional[str] = None
-    moduleConfig: Optional[ModuleConfig] = None
-
-    # tmp solution. replace with a pydantic BaseModel, see bugreport: https://github.com/pydantic/pydantic/issues/6948
-    def model_dump(self, exclude_unset: bool = True, exclude_none: bool = True) -> Dict[str, Any]:
-        return {
-            "indexFilterable": self.indexFilterable,
-            "indexSearchable": self.indexSearchable,
-            "tokenization": self.tokenization,
-            "description": self.description,
-            "moduleConfig": self.moduleConfig,
-        }
-
-
-@dataclass
-class ReferenceTo:
-    ref_type: Union[Type, str]
-
-    @property
-    def name(self) -> str:
-        if isinstance(self.ref_type, type):
-            return _capitalize_names(self.ref_type.__name__)
-        else:
-            assert isinstance(self.ref_type, str)
-            return _capitalize_names(self.ref_type)
-
-
-@dataclass
-class BatchReference:
-    from_uuid: UUID
-    to_uuid: UUID
-
-
-class BaseProperty(BaseModel):
-    uuid: UUID = Field(default_factory=uuid_package.uuid4)
-    vector: Optional[List[float]] = None
-
-    # def __new__(cls, *args, **kwargs):
-    #     #
-    #     build = super().__new__(cls)
-    #     # fields, class_vars = collect_model_fields(cls)
-    #     for name, field in build.model_fields.items():
-    #         if name not in BaseProperty.model_fields:
-    #             field_type = build._remove_optional_type(field.annotation)
-    #             if inspect.isclass(field_type):
-    #                 if field.annotation not in PYTHON_TYPE_TO_DATATYPE:
-    #                     build.model_fields[name] = fields.FieldInfo(annotation=typing.Optional[UUID], default=None)
-    #
-    #     build.__class_vars__.update(build.__class_vars__)
-    #     return build
-    #
-    #
-    # make references optional by default - does not work
-    def __init__(self, **data) -> None:
-        super().__init__(**data)
-        self._reference_fields: Set[str] = self.get_ref_fields(type(self))
-
-        self._reference_to_class: Dict[str, str] = {}
-        for ref in self._reference_fields:
-            self._reference_to_class[ref] = self.model_fields[ref].metadata[0].name
-
-    @staticmethod
-    def get_ref_fields(model: Type["BaseProperty"]) -> Set[str]:
-        return {
-            name
-            for name, field in model.model_fields.items()
-            if (
-                field.metadata is not None
-                and len(field.metadata) > 0
-                and isinstance(field.metadata[0], ReferenceTo)
-            )
-            and name not in BaseProperty.model_fields
-        }
-
-    @staticmethod
-    def get_non_ref_fields(model: Type["BaseProperty"]) -> Set[str]:
-        return {
-            name
-            for name, field in model.model_fields.items()
-            if (
-                field.metadata is None
-                or len(field.metadata) == 0
-                or isinstance(field.metadata[0], PropertyConfig)
-            )
-            and name not in BaseProperty.model_fields
-        }
-
-    def props_to_dict(self, update: bool = False) -> Dict[str, Any]:
-        fields_to_exclude: Set[str] = self._reference_fields.union({"uuid", "vector"})
-        if update:
-            fields_to_exclude.union(
-                {field for field in self.model_fields.keys() if field not in self.model_fields_set}
-            )
-
-        c = self.model_dump(exclude=fields_to_exclude)
-        for ref in self._reference_fields:
-            val = getattr(self, ref, None)
-            if val is not None:
-                c[ref] = _to_beacons(val, self._reference_to_class[ref])
-        return c
-
-    @field_validator("uuid")
-    def create_valid_uuid(cls, input_uuid: UUID) -> uuid_package.UUID:
-        if isinstance(input_uuid, uuid_package.UUID):
-            return input_uuid
-
-        # see if str is already a valid uuid
-        try:
-            return uuid_package.UUID(input_uuid)
-        except ValueError:
-            hex_string = hashlib.md5(input_uuid.encode("UTF-8")).hexdigest()
-            return uuid_package.UUID(hex=hex_string)
-
-    @staticmethod
-    def type_to_dict(model: Type["BaseProperty"]) -> List[Dict[str, Any]]:
-        types = typing.get_type_hints(model)
-
-        non_optional_types = {
-            name: BaseProperty._remove_optional_type(tt)
-            for name, tt in types.items()
-            if name not in BaseProperty.model_fields
-        }
-
-        non_ref_fields = model.get_non_ref_fields(model)
-        properties = []
-        for name in non_ref_fields:
-            prop = {
-                "name": _capitalize_names(name),
-                "dataType": [PYTHON_TYPE_TO_DATATYPE[non_optional_types[name]]],
-            }
-            metadata_list = model.model_fields[name].metadata
-            if metadata_list is not None and len(metadata_list) > 0:
-                metadata = metadata_list[0]
-                if isinstance(metadata, PropertyConfig):
-                    prop.update(metadata.model_dump(exclude_unset=True, exclude_none=True))
-
-            properties.append(prop)
-
-        reference_fields = model.get_ref_fields(model)
-        properties.extend(
-            {
-                "name": _capitalize_names(name),
-                "dataType": [model.model_fields[name].metadata[0].name],
-            }
-            for name in reference_fields
-        )
-
-        return properties
-
-    @staticmethod
-    def get_non_optional_fields(model: Type["BaseProperty"]) -> Set[str]:
-        return {
-            field
-            for field, val in model.model_fields.items()
-            if val.default == PydanticUndefined and field not in BaseProperty.model_fields.keys()
-        }
-
-    @staticmethod
-    def _remove_optional_type(python_type: type) -> type:
-        is_list = typing.get_origin(python_type) == list
-        args = typing.get_args(python_type)
-        if len(args) == 0:
-            return python_type
-
-        return_type = [t for t in args if t is not None][0]
-
-        if is_list:
-            return typing.List[return_type]
-        else:
-            return return_type
-
-
-Model = TypeVar("Model", bound=BaseProperty)
-
-
-class RefToObjectModel(BaseModel, Generic[Model]):
-    uuids_to: Union[List[UUID], UUID] = Field()
-
-    def to_beacon(self) -> List[Dict[str, str]]:
-        return _to_beacons(self.uuids_to)
-
-
-UserModelType = Type[BaseProperty]
-
-
-class CollectionConfigModel(CollectionConfigBase):
-    pass
-
-
-@dataclass
-class _Object(Generic[Model]):
-    data: Model
-    metadata: MetadataReturn
+from weaviate.weaviate_types import UUID, UUIDS, BEACON, PYTHON_TYPE_TO_DATATYPE
 
 
 class GrpcBuilderModel(Generic[Model], GrpcBuilderBase):
@@ -419,15 +200,12 @@ class CollectionModel(CollectionBase):
     def __init__(self, connection: Connection):
         super().__init__(connection)
 
-    def create(
-        self, config: CollectionConfigModel, model: Type[Model]
-    ) -> CollectionObjectModel[Model]:
-        name = super()._create(config, model.type_to_dict(model), _capitalize_names(model.__name__))
-        return CollectionObjectModel[Model](self._connection, name, model)
+    def create(self, config: CollectionModelConfig[Model]) -> CollectionObjectModel[Model]:
+        super()._create(config)
+        return CollectionObjectModel[Model](self._connection, config.name, config.model)
 
-    def get(self, model: Type[Model]) -> CollectionObjectModel[Model]:
-        collection_name = _capitalize_names(model.__name__)
-        path = f"/schema/{collection_name}"
+    def get(self, model: Type[Model], name: str) -> CollectionObjectModel[Model]:
+        path = f"/schema/{name}"
 
         try:
             response = self._connection.get(path=path)
@@ -454,12 +232,10 @@ class CollectionModel(CollectionBase):
 
         if compare(model_props, schema_props):
             raise TypeError("Schemas not compatible")
-        return CollectionObjectModel[Model](self._connection, collection_name, model)
+        return CollectionObjectModel[Model](self._connection, name, model)
 
-    def get_dynamic(
-        self, collection_name: str
-    ) -> Tuple[CollectionObjectModel[Model], UserModelType]:
-        path = f"/schema/{_capitalize_names(collection_name)}"
+    def get_dynamic(self, name: str) -> Tuple[CollectionObjectModel[Model], UserModelType]:
+        path = f"/schema/{name}"
 
         try:
             response = self._connection.get(path=path)
@@ -475,14 +251,10 @@ class CollectionModel(CollectionBase):
         }
         model = create_model(response_json["class"], **fields, __base__=BaseProperty)
 
-        return CollectionObjectModel(self._connection, collection_name, model), model
+        return CollectionObjectModel(self._connection, name, model), model
 
-    def delete(self, model: Union[str, Type[Model]]) -> None:
-        if isinstance(model, str):
-            return self._delete(model)
-        return self._delete(model.__name__)
+    def delete(self, name: str) -> None:
+        return self._delete(name)
 
-    def exists(self, model: Union[str, Type[Model]]) -> bool:
-        if isinstance(model, str):
-            return self._exists(model)
-        return self._exists(model.__name__)
+    def exists(self, name: str) -> bool:
+        return self._exists(name)

--- a/weaviate/collection/collection_model.py
+++ b/weaviate/collection/collection_model.py
@@ -201,7 +201,11 @@ class CollectionModel(CollectionBase):
         super().__init__(connection)
 
     def create(self, config: CollectionModelConfig[Model]) -> CollectionObjectModel[Model]:
-        super()._create(config)
+        name = super()._create(config)
+        if config.name != name:
+            raise ValueError(
+                f"Name of created collection ({name}) does not match given name ({config.name})"
+            )
         return CollectionObjectModel[Model](self._connection, config.name, config.model)
 
     def get(self, model: Type[Model], name: str) -> CollectionObjectModel[Model]:

--- a/weaviate/collection/collection_model.py
+++ b/weaviate/collection/collection_model.py
@@ -13,6 +13,7 @@ from weaviate.collection.grpc import GrpcBuilderBase, HybridFusion, ReturnValues
 from weaviate.connect import Connection
 from weaviate.data.replication import ConsistencyLevel
 from weaviate.exceptions import UnexpectedStatusCodeException
+from weaviate.util import _capitalize_first_letter
 from weaviate.weaviate_classes import (
     BaseProperty,
     BatchReference,
@@ -209,7 +210,7 @@ class CollectionModel(CollectionBase):
         return CollectionObjectModel[Model](self._connection, config.name, config.model)
 
     def get(self, model: Type[Model], name: str) -> CollectionObjectModel[Model]:
-        path = f"/schema/{name}"
+        path = f"/schema/{_capitalize_first_letter(name)}"
 
         try:
             response = self._connection.get(path=path)
@@ -239,7 +240,7 @@ class CollectionModel(CollectionBase):
         return CollectionObjectModel[Model](self._connection, name, model)
 
     def get_dynamic(self, name: str) -> Tuple[CollectionObjectModel[Model], UserModelType]:
-        path = f"/schema/{name}"
+        path = f"/schema/{_capitalize_first_letter(name)}"
 
         try:
             response = self._connection.get(path=path)

--- a/weaviate/weaviate_classes.py
+++ b/weaviate/weaviate_classes.py
@@ -1,12 +1,27 @@
+import hashlib
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union, Dict, Any, Optional, List, Set
+from typing import (
+    Union,
+    Dict,
+    Any,
+    Optional,
+    List,
+    Set,
+    TypeVar,
+    Type,
+    Generic,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 import uuid as uuid_package
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+from pydantic_core._pydantic_core import PydanticUndefined
 
 from weaviate.util import _to_beacons
-from weaviate.weaviate_types import UUID
+from weaviate.weaviate_types import UUID, PYTHON_TYPE_TO_DATATYPE
 
 
 class DataType(str, Enum):
@@ -110,6 +125,7 @@ class InvertedIndexConfig(BaseModel):
 
 
 class CollectionConfigBase(BaseModel):
+    name: str
     vectorIndexType: Optional[VectorIndexType] = None
     vectorizer: Optional[Vectorizer] = None
     vectorIndexConfig: Optional[VectorIndexConfig] = None
@@ -123,8 +139,10 @@ class CollectionConfigBase(BaseModel):
 
         for cls_field in self.model_fields:
             val = getattr(self, cls_field)
-            if cls_field in ["name", "properties"] or val is None:
+            if cls_field in ["model", "properties"] or val is None:
                 continue
+            if cls_field == "name":
+                ret_dict["class"] = val
             if isinstance(val, Enum):
                 ret_dict[cls_field] = str(val.value)
             elif isinstance(val, (bool, float, str, int)):
@@ -167,7 +185,6 @@ class ReferenceProperty(BaseModel):
 
 
 class CollectionConfig(CollectionConfigBase):
-    name: str
     properties: Optional[List[Union[Property, ReferenceProperty]]] = None
 
     def model_post_init(self, __context: Any) -> None:
@@ -178,8 +195,6 @@ class CollectionConfig(CollectionConfigBase):
 
     def to_dict(self) -> Dict[str, Any]:
         ret_dict = super().to_dict()
-
-        ret_dict["class"] = self.name
 
         if self.properties is not None:
             ret_dict["properties"] = [prop.to_dict() for prop in self.properties]
@@ -233,3 +248,224 @@ class RefToObject:
 
     def to_beacon(self) -> List[Dict[str, str]]:
         return _to_beacons(self.uuids_to)
+
+
+@dataclass
+class PropertyConfig:
+    indexFilterable: Optional[bool] = None
+    indexSearchable: Optional[bool] = None
+    tokenization: Optional[Tokenization] = None
+    description: Optional[str] = None
+    moduleConfig: Optional[ModuleConfig] = None
+
+    # tmp solution. replace with a pydantic BaseModel, see bugreport: https://github.com/pydantic/pydantic/issues/6948
+    def model_dump(self, exclude_unset: bool = True, exclude_none: bool = True) -> Dict[str, Any]:
+        return {
+            "indexFilterable": self.indexFilterable,
+            "indexSearchable": self.indexSearchable,
+            "tokenization": self.tokenization,
+            "description": self.description,
+            "moduleConfig": self.moduleConfig,
+        }
+
+
+@dataclass
+class ReferenceTo:
+    ref_type: Union[Type, str]
+
+    @property
+    def name(self) -> str:
+        if isinstance(self.ref_type, type):
+            return _capitalize_names(self.ref_type.__name__)
+        else:
+            assert isinstance(self.ref_type, str)
+            return _capitalize_names(self.ref_type)
+
+
+@dataclass
+class BatchReference:
+    from_uuid: UUID
+    to_uuid: UUID
+
+
+class BaseProperty(BaseModel):
+    uuid: UUID = Field(default_factory=uuid_package.uuid4)
+    vector: Optional[List[float]] = None
+
+    # def __new__(cls, *args, **kwargs):
+    #     #
+    #     build = super().__new__(cls)
+    #     # fields, class_vars = collect_model_fields(cls)
+    #     for name, field in build.model_fields.items():
+    #         if name not in BaseProperty.model_fields:
+    #             field_type = build._remove_optional_type(field.annotation)
+    #             if inspect.isclass(field_type):
+    #                 if field.annotation not in PYTHON_TYPE_TO_DATATYPE:
+    #                     build.model_fields[name] = fields.FieldInfo(annotation=typing.Optional[UUID], default=None)
+    #
+    #     build.__class_vars__.update(build.__class_vars__)
+    #     return build
+    #
+    #
+    # make references optional by default - does not work
+    def __init__(self, **data) -> None:
+        super().__init__(**data)
+        self._reference_fields: Set[str] = self.get_ref_fields(type(self))
+
+        self._reference_to_class: Dict[str, str] = {}
+        for ref in self._reference_fields:
+            self._reference_to_class[ref] = self.model_fields[ref].metadata[0].name
+
+    @staticmethod
+    def get_ref_fields(model: Type["BaseProperty"]) -> Set[str]:
+        return {
+            name
+            for name, field in model.model_fields.items()
+            if (
+                field.metadata is not None
+                and len(field.metadata) > 0
+                and isinstance(field.metadata[0], ReferenceTo)
+            )
+            and name not in BaseProperty.model_fields
+        }
+
+    @staticmethod
+    def get_non_ref_fields(model: Type["BaseProperty"]) -> Set[str]:
+        return {
+            name
+            for name, field in model.model_fields.items()
+            if (
+                field.metadata is None
+                or len(field.metadata) == 0
+                or isinstance(field.metadata[0], PropertyConfig)
+            )
+            and name not in BaseProperty.model_fields
+        }
+
+    def props_to_dict(self, update: bool = False) -> Dict[str, Any]:
+        fields_to_exclude: Set[str] = self._reference_fields.union({"uuid", "vector"})
+        if update:
+            fields_to_exclude.union(
+                {field for field in self.model_fields.keys() if field not in self.model_fields_set}
+            )
+
+        c = self.model_dump(exclude=fields_to_exclude)
+        for ref in self._reference_fields:
+            val = getattr(self, ref, None)
+            if val is not None:
+                c[ref] = _to_beacons(val, self._reference_to_class[ref])
+        return c
+
+    @field_validator("uuid")
+    def create_valid_uuid(cls, input_uuid: UUID) -> uuid_package.UUID:
+        if isinstance(input_uuid, uuid_package.UUID):
+            return input_uuid
+
+        # see if str is already a valid uuid
+        try:
+            return uuid_package.UUID(input_uuid)
+        except ValueError:
+            hex_string = hashlib.md5(input_uuid.encode("UTF-8")).hexdigest()
+            return uuid_package.UUID(hex=hex_string)
+
+    @staticmethod
+    def type_to_dict(model: Type["BaseProperty"]) -> List[Dict[str, Any]]:
+        types = get_type_hints(model)
+
+        non_optional_types = {
+            name: BaseProperty._remove_optional_type(tt)
+            for name, tt in types.items()
+            if name not in BaseProperty.model_fields
+        }
+
+        non_ref_fields = model.get_non_ref_fields(model)
+        properties = []
+        for name in non_ref_fields:
+            prop = {
+                "name": _capitalize_names(name),
+                "dataType": [PYTHON_TYPE_TO_DATATYPE[non_optional_types[name]]],
+            }
+            metadata_list = model.model_fields[name].metadata
+            if metadata_list is not None and len(metadata_list) > 0:
+                metadata = metadata_list[0]
+                if isinstance(metadata, PropertyConfig):
+                    prop.update(metadata.model_dump(exclude_unset=True, exclude_none=True))
+
+            properties.append(prop)
+
+        reference_fields = model.get_ref_fields(model)
+        properties.extend(
+            {
+                "name": _capitalize_names(name),
+                "dataType": [model.model_fields[name].metadata[0].name],
+            }
+            for name in reference_fields
+        )
+
+        return properties
+
+    @staticmethod
+    def get_non_optional_fields(model: Type["BaseProperty"]) -> Set[str]:
+        return {
+            field
+            for field, val in model.model_fields.items()
+            if val.default == PydanticUndefined and field not in BaseProperty.model_fields.keys()
+        }
+
+    @staticmethod
+    def _remove_optional_type(python_type: type) -> type:
+        is_list = get_origin(python_type) == list
+        args = get_args(python_type)
+        if len(args) == 0:
+            return python_type
+
+        return_type = [t for t in args if t is not None][0]
+
+        if is_list:
+            return List[return_type]
+        else:
+            return return_type
+
+
+Model = TypeVar("Model", bound=BaseProperty)
+
+
+class RefToObjectModel(BaseModel, Generic[Model]):
+    uuids_to: Union[List[UUID], UUID] = Field()
+
+    def to_beacon(self) -> List[Dict[str, str]]:
+        return _to_beacons(self.uuids_to)
+
+
+UserModelType = Type[BaseProperty]
+
+
+@dataclass
+class _Object(Generic[Model]):
+    data: Model
+    metadata: MetadataReturn
+
+
+def _capitalize_names(name: str) -> str:
+    collection_name = name[0].upper()
+    if len(name) > 1:
+        collection_name += name[1:]
+    return collection_name
+
+
+class CollectionModelConfig(CollectionConfigBase, Generic[Model]):
+    model: Type[Model]
+
+    def model_post_init(self, __context: Any) -> None:
+        collection_name = self.name[0].upper()
+        if len(self.name) > 1:
+            collection_name += self.name[1:]
+        self.name = collection_name
+
+    def to_dict(self) -> Dict[str, Any]:
+        ret_dict = super().to_dict()
+
+        if self.model is not None:
+            ret_dict["properties"] = self.model.type_to_dict(self.model)
+
+        return ret_dict

--- a/weaviate/weaviate_classes.py
+++ b/weaviate/weaviate_classes.py
@@ -142,7 +142,7 @@ class CollectionConfigBase(BaseModel):
             if cls_field in ["model", "properties"] or val is None:
                 continue
             if cls_field == "name":
-                ret_dict["class"] = val
+                ret_dict["class"] = _capitalize_names(val)
             if isinstance(val, Enum):
                 ret_dict[cls_field] = str(val.value)
             elif isinstance(val, (bool, float, str, int)):

--- a/weaviate/weaviate_classes.py
+++ b/weaviate/weaviate_classes.py
@@ -20,7 +20,7 @@ import uuid as uuid_package
 from pydantic import BaseModel, Field, field_validator
 from pydantic_core._pydantic_core import PydanticUndefined
 
-from weaviate.util import _to_beacons
+from weaviate.util import _to_beacons, _capitalize_first_letter
 from weaviate.weaviate_types import UUID, PYTHON_TYPE_TO_DATATYPE
 
 
@@ -142,7 +142,7 @@ class CollectionConfigBase(BaseModel):
             if cls_field in ["model", "properties"] or val is None:
                 continue
             if cls_field == "name":
-                ret_dict["class"] = _capitalize_names(val)
+                ret_dict["class"] = _capitalize_first_letter(val)
             if isinstance(val, Enum):
                 ret_dict[cls_field] = str(val.value)
             elif isinstance(val, (bool, float, str, int)):
@@ -276,10 +276,10 @@ class ReferenceTo:
     @property
     def name(self) -> str:
         if isinstance(self.ref_type, type):
-            return _capitalize_names(self.ref_type.__name__)
+            return _capitalize_first_letter(self.ref_type.__name__)
         else:
             assert isinstance(self.ref_type, str)
-            return _capitalize_names(self.ref_type)
+            return _capitalize_first_letter(self.ref_type)
 
 
 @dataclass
@@ -382,7 +382,7 @@ class BaseProperty(BaseModel):
         properties = []
         for name in non_ref_fields:
             prop = {
-                "name": _capitalize_names(name),
+                "name": _capitalize_first_letter(name),
                 "dataType": [PYTHON_TYPE_TO_DATATYPE[non_optional_types[name]]],
             }
             metadata_list = model.model_fields[name].metadata
@@ -396,7 +396,7 @@ class BaseProperty(BaseModel):
         reference_fields = model.get_ref_fields(model)
         properties.extend(
             {
-                "name": _capitalize_names(name),
+                "name": _capitalize_first_letter(name),
                 "dataType": [model.model_fields[name].metadata[0].name],
             }
             for name in reference_fields
@@ -444,13 +444,6 @@ UserModelType = Type[BaseProperty]
 class _Object(Generic[Model]):
     data: Model
     metadata: MetadataReturn
-
-
-def _capitalize_names(name: str) -> str:
-    collection_name = name[0].upper()
-    if len(name) > 1:
-        collection_name += name[1:]
-    return collection_name
 
 
 class CollectionModelConfig(CollectionConfigBase, Generic[Model]):

--- a/weaviate/weaviate_types.py
+++ b/weaviate/weaviate_types.py
@@ -1,6 +1,6 @@
-from typing import Union, List, Tuple
-
+import datetime
 import uuid as uuid_package
+from typing import Union, List, Tuple
 
 UUID = Union[str, uuid_package.UUID]
 UUIDS = Union[List[UUID], UUID]
@@ -8,3 +8,18 @@ NUMBER = Union[int, float]
 GEO_COORDINATES = Tuple[float, float]
 
 BEACON = "weaviate://localhost/"
+
+DATATYPE_TO_PYTHON_TYPE = {
+    "text": str,
+    "int": int,
+    "text[]": List[str],
+    "int[]": List[int],
+    "boolean": bool,
+    "boolean[]": List[bool],
+    "number": float,
+    "number[]": List[float],
+    "date": datetime.datetime,
+    "date[]": List[datetime.datetime],
+    "geoCoordinates": GEO_COORDINATES,
+}
+PYTHON_TYPE_TO_DATATYPE = {val: key for key, val in DATATYPE_TO_PYTHON_TYPE.items()}


### PR DESCRIPTION
Refactors the currently disparate experimental `Collection` and `CollectionModel` APIs to have similar surfaces. The key difference resides in the method of specifying the properties of a class within Weaviate. Such specification now occurs at the same place when using either APIs, _i.e._, within the `config` option to the `create()` method.