### PR TITLE
revert ORM API to remove name and derive from ClassName instead

### DIFF
--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -45,6 +45,11 @@ def client():
     client.schema.delete_all()
 
 
+def test_with_existing_collection(client: weaviate.Client):
+    obj = client.collection_model.get(Group).data.get_by_id(REF_TO_UUID)
+    assert obj.data.name == "Name"
+
+
 @pytest.mark.parametrize(
     "member_type,value",
     [
@@ -64,9 +69,7 @@ def test_types(client: weaviate.Client, member_type, value, optional: bool):
     class ModelTypes(BaseProperty):
         name: member_type
 
-    name = "ModelTypes"
-
-    client.collection_model.delete(name)
+    client.collection_model.delete(ModelTypes)
     collection = client.collection_model.create(
         CollectionModelConfig(model=ModelTypes, vectorizer=Vectorizer.NONE)
     )
@@ -96,8 +99,7 @@ def test_types_annotates(client: weaviate.Client, member_type, annotation, value
     class ModelTypes(BaseProperty):
         name: Annotated[member_type, annotation]
 
-    name = "ModelTypes"
-    client.collection_model.delete(name)
+    client.collection_model.delete(ModelTypes)
     collection = client.collection_model.create(
         CollectionModelConfig(model=ModelTypes, vectorizer=Vectorizer.NONE)
     )
@@ -115,22 +117,21 @@ def test_create_and_delete(client: weaviate.Client):
     class DeleteModel(BaseProperty):
         name: int
 
-    name = "DeleteModel"
-    client.collection_model.delete(name)
+    client.collection_model.delete(DeleteModel)
     client.collection_model.create(
         CollectionModelConfig(model=DeleteModel, vectorizer=Vectorizer.NONE)
     )
 
-    assert client.collection_model.exists(name)
-    client.collection_model.delete(name)
-    assert not client.collection_model.exists(name)
+    assert client.collection_model.exists(DeleteModel)
+    client.collection_model.delete(DeleteModel)
+    assert not client.collection_model.exists(DeleteModel)
 
 
 def test_search(client: weaviate.Client):
     class SearchTest(BaseProperty):
         name: str
 
-    client.collection_model.delete("SearchTest")
+    client.collection_model.delete(SearchTest)
     collection = client.collection_model.create(
         CollectionModelConfig(model=SearchTest, vectorizer=Vectorizer.NONE)
     )
@@ -147,7 +148,7 @@ def test_tenants(client: weaviate.Client):
     class TenantsTest(BaseProperty):
         name: str
 
-    client.collection.delete("Tenants")
+    client.collection_model.delete(TenantsTest)
     collection = client.collection_model.create(
         CollectionModelConfig(
             vectorizer=Vectorizer.NONE,
@@ -170,13 +171,10 @@ def test_tenants(client: weaviate.Client):
 
 
 def test_multi_searches(client: weaviate.Client):
-    client.collection.delete("TestMultiSearches")
-
     class TestMultiSearches(BaseProperty):
         name: Optional[str] = None
 
-    name = "TestMultiSearches"
-    client.collection_model.delete(name)
+    client.collection_model.delete(TestMultiSearches)
     collection = client.collection_model.create(
         CollectionModelConfig(model=TestMultiSearches, vectorizer=Vectorizer.NONE)
     )
@@ -204,8 +202,7 @@ def test_multi_searches_with_references(client: weaviate.Client):
         name: Optional[str] = None
         group: Annotated[Optional[UUIDS], ReferenceTo(Group)] = None
 
-    name = "TestMultiSearchesWithReferences"
-    client.collection_model.delete(name)
+    client.collection_model.delete(TestMultiSearchesWithReferences)
     collection = client.collection_model.create(
         CollectionModelConfig(model=TestMultiSearchesWithReferences, vectorizer=Vectorizer.NONE)
     )
@@ -233,15 +230,12 @@ def test_multi_searches_with_references(client: weaviate.Client):
 
 
 def test_search_with_tenant(client: weaviate.Client):
-    name = "TestTenantSearch"
-    client.collection.delete(name)
-
     class TestTenantSearch(BaseProperty):
         name: str
 
+    client.collection_model.delete(TestTenantSearch)
     collection = client.collection_model.create(
         CollectionModelConfig(
-            name=name,
             model=TestTenantSearch,
             vectorizer=Vectorizer.NONE,
             multiTenancyConfig=MultiTenancyConfig(enabled=True),

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -37,7 +37,7 @@ def client():
     )
     client.schema.delete_all()
     collection = client.collection_model.create(
-        CollectionModelConfig(name="Group", model=Group, vectorizer=Vectorizer.NONE)
+        CollectionModelConfig(model=Group, vectorizer=Vectorizer.NONE)
     )
     collection.data.insert(obj=Group(name="Name", uuid=REF_TO_UUID))
 
@@ -68,7 +68,7 @@ def test_types(client: weaviate.Client, member_type, value, optional: bool):
 
     client.collection_model.delete(name)
     collection = client.collection_model.create(
-        CollectionModelConfig(name=name, model=ModelTypes, vectorizer=Vectorizer.NONE)
+        CollectionModelConfig(model=ModelTypes, vectorizer=Vectorizer.NONE)
     )
     assert collection._model == ModelTypes
 
@@ -99,7 +99,7 @@ def test_types_annotates(client: weaviate.Client, member_type, annotation, value
     name = "ModelTypes"
     client.collection_model.delete(name)
     collection = client.collection_model.create(
-        CollectionModelConfig(name=name, model=ModelTypes, vectorizer=Vectorizer.NONE)
+        CollectionModelConfig(model=ModelTypes, vectorizer=Vectorizer.NONE)
     )
     assert collection._model == ModelTypes
 
@@ -116,8 +116,9 @@ def test_create_and_delete(client: weaviate.Client):
         name: int
 
     name = "DeleteModel"
+    client.collection_model.delete(name)
     client.collection_model.create(
-        CollectionModelConfig(name=name, model=DeleteModel, vectorizer=Vectorizer.NONE)
+        CollectionModelConfig(model=DeleteModel, vectorizer=Vectorizer.NONE)
     )
 
     assert client.collection_model.exists(name)
@@ -129,10 +130,9 @@ def test_search(client: weaviate.Client):
     class SearchTest(BaseProperty):
         name: str
 
-    name = "SearchTest"
-    client.collection_model.delete(name)
+    client.collection_model.delete("SearchTest")
     collection = client.collection_model.create(
-        CollectionModelConfig(name=name, model=SearchTest, vectorizer=Vectorizer.NONE)
+        CollectionModelConfig(model=SearchTest, vectorizer=Vectorizer.NONE)
     )
 
     collection.data.insert(SearchTest(name="test name"))
@@ -144,13 +144,15 @@ def test_search(client: weaviate.Client):
 
 
 def test_tenants(client: weaviate.Client):
+    class TenantsTest(BaseProperty):
+        name: str
+
     client.collection.delete("Tenants")
-    collection = client.collection.create(
+    collection = client.collection_model.create(
         CollectionModelConfig(
-            name="Tenants",
             vectorizer=Vectorizer.NONE,
             multiTenancyConfig=MultiTenancyConfig(enabled=True),
-            model=BaseProperty,
+            model=TenantsTest,
         )
     )
 
@@ -170,17 +172,17 @@ def test_tenants(client: weaviate.Client):
 def test_multi_searches(client: weaviate.Client):
     client.collection.delete("TestMultiSearches")
 
-    class SearchTest(BaseProperty):
+    class TestMultiSearches(BaseProperty):
         name: Optional[str] = None
 
     name = "TestMultiSearches"
     client.collection_model.delete(name)
     collection = client.collection_model.create(
-        CollectionModelConfig(name=name, model=SearchTest, vectorizer=Vectorizer.NONE)
+        CollectionModelConfig(model=TestMultiSearches, vectorizer=Vectorizer.NONE)
     )
 
-    collection.data.insert(SearchTest(name="some word"))
-    collection.data.insert(SearchTest(name="other"))
+    collection.data.insert(TestMultiSearches(name="some word"))
+    collection.data.insert(TestMultiSearches(name="other"))
 
     objects = collection.query.bm25_flat(
         query="word",
@@ -198,20 +200,18 @@ def test_multi_searches(client: weaviate.Client):
 
 @pytest.mark.skip()
 def test_multi_searches_with_references(client: weaviate.Client):
-    client.collection.delete("TestMultiSearchesWithReferences")
-
-    class SearchTest(BaseProperty):
+    class TestMultiSearchesWithReferences(BaseProperty):
         name: Optional[str] = None
         group: Annotated[Optional[UUIDS], ReferenceTo(Group)] = None
 
     name = "TestMultiSearchesWithReferences"
     client.collection_model.delete(name)
     collection = client.collection_model.create(
-        CollectionModelConfig(name=name, model=SearchTest, vectorizer=Vectorizer.NONE)
+        CollectionModelConfig(model=TestMultiSearchesWithReferences, vectorizer=Vectorizer.NONE)
     )
 
-    collection.data.insert(SearchTest(name="some word", group=REF_TO_UUID))
-    collection.data.insert(SearchTest(name="other", group=REF_TO_UUID))
+    collection.data.insert(TestMultiSearchesWithReferences(name="some word", group=REF_TO_UUID))
+    collection.data.insert(TestMultiSearchesWithReferences(name="other", group=REF_TO_UUID))
 
     objects = collection.query.bm25_flat(
         query="word",

--- a/weaviate/collection/collection_model.py
+++ b/weaviate/collection/collection_model.py
@@ -350,12 +350,12 @@ class _GRPCWrapper(Generic[Model]):
 
 
 class CollectionObjectModel(CollectionObjectBase, Generic[Model]):
-    def __init__(self, connection: Connection, name: str, model: Type[Model]) -> None:
-        super().__init__(connection, name)
+    def __init__(self, connection: Connection, model: Type[Model]) -> None:
+        super().__init__(connection, model.__name__)
         self._model: Type[Model] = model
         self._default_props = model.get_non_optional_fields(model)
         self.data = _Data[Model](self)
-        self.query = _GRPCWrapper[Model](connection, name, model)
+        self.query = _GRPCWrapper[Model](connection, model.__name__, model)
 
     def with_tenant(self, tenant: Optional[str] = None) -> "CollectionObjectModel":
         return self._with_tenant(tenant)
@@ -398,11 +398,11 @@ class CollectionModel(CollectionBase):
 
     def create(self, config: CollectionModelConfig[Model]) -> CollectionObjectModel[Model]:
         name = super()._create(config)
-        if config.name != name:
+        if config.model.__name__ != name:
             raise ValueError(
-                f"Name of created collection ({name}) does not match given name ({config.name})"
+                f"Name of created collection ({name}) does not match given name ({config.model.__name__})"
             )
-        return CollectionObjectModel[Model](self._connection, config.name, config.model)
+        return CollectionObjectModel[config.model](self._connection, config.model)
 
     def get(self, model: Type[Model], name: str) -> CollectionObjectModel[Model]:
         path = f"/schema/{_capitalize_first_letter(name)}"

--- a/weaviate/weaviate_classes.py
+++ b/weaviate/weaviate_classes.py
@@ -458,7 +458,7 @@ class CollectionModelConfig(CollectionConfigBase, Generic[Model]):
     def to_dict(self) -> Dict[str, Any]:
         ret_dict = super().to_dict()
 
-        ret_dict["class"] = self.model.__name__
+        ret_dict["class"] = _capitalize_first_letter(self.model.__name__)
 
         if self.model is not None:
             ret_dict["properties"] = self.model.type_to_dict(self.model)


### PR DESCRIPTION
Reverts the changes made earlier to require users to specify both the name of their collection and the collection's class type definition. Now, the Python data structure is coupled to the Weaviate data structure as an ORM would.