### PR TITLE
Add schema to collection

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -439,7 +439,7 @@ def test_collection_schema(client: weaviate.Client):
         )
     )
     schema = collection.schema.get()
-    assert schema.className == "TestCollectionSchema"
+    assert schema.class_name == "TestCollectionSchema"
     assert len(schema.properties) == 2
     assert schema.properties[0].name == "name"
     assert schema.properties[0].data_type == DataType.TEXT

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -424,3 +424,25 @@ def test_add_property(client: weaviate.Client):
     assert "name" in obj1.data
     assert "name" in obj2.data
     assert "number" in obj2.data
+
+
+def test_collection_schema(client: weaviate.Client):
+    client.collection.delete("TestCollectionSchema")
+    collection = client.collection.create(
+        CollectionConfig(
+            name="TestCollectionSchema",
+            vectorizer=Vectorizer.NONE,
+            properties=[
+                Property(name="name", dataType=DataType.TEXT),
+                Property(name="age", dataType=DataType.INT),
+            ],
+        )
+    )
+    schema = collection.schema.get()
+    assert schema.className == "TestCollectionSchema"
+    assert len(schema.properties) == 2
+    assert schema.properties[0].name == "name"
+    assert schema.properties[0].data_type == DataType.TEXT
+    assert schema.properties[1].name == "age"
+    assert schema.properties[1].data_type == DataType.INT
+    assert schema.vectorizer == Vectorizer.NONE

--- a/weaviate/collection/classes.py
+++ b/weaviate/collection/classes.py
@@ -269,7 +269,7 @@ class _VectorIndexConfig:
 
 @dataclass
 class _SchemaConfig:
-    className: str
+    class_name: str
     description: Optional[str]
     inverted_index_config: _InvertedIndexConfig
     multi_tenancy_config: _MultiTenancyConfig
@@ -283,7 +283,7 @@ class _SchemaConfig:
 
 def schema_config_from_json(schema: Dict[str, Any]) -> _SchemaConfig:
     return _SchemaConfig(
-        className=schema["class"],
+        class_name=schema["class"],
         description=schema.get("description"),
         inverted_index_config=_InvertedIndexConfig(
             bm25=_BM25Config(


### PR DESCRIPTION
Port functionality from `schema.crud_schema.py` into collections APIs. In the process, define new models that users must use when defining the options they wish to update on a collection's schema. These options are comprehensive of the mutable options available to users. No immutable option is presented for use by users.