### PR TITLE
begin work implementing ORM relationships

### DIFF
--- a/weaviate/collection/classes.py
+++ b/weaviate/collection/classes.py
@@ -342,10 +342,22 @@ class DataObject:
     vector: Optional[List[float]] = None
 
 
+class _Metadata(BaseModel):
+    # uuid: Optional[uuid_package.UUID] = Field(None, alias="id")
+    # vector: Optional[List[float]] = None
+    creation_time_unix: Optional[int] = Field(None, alias="creationTimeUnix")
+    last_update_time_unix: Optional[int] = Field(None, alias="lastUpdateTimeUnix")
+    distance: Optional[float] = None
+    certainty: Optional[float] = None
+    score: Optional[float] = None
+    explain_score: Optional[str] = Field(None, alias="explainScore")
+    is_consistent: Optional[bool] = Field(None, alias="isConsistent")
+
+
 class BaseProperty(BaseModel):
     uuid: UUID = Field(default_factory=uuid_package.uuid4)
     vector: Optional[List[float]] = None
-
+    metadata: Optional[_Metadata] = None
     # def __new__(cls, *args, **kwargs):
     #     #
     #     build = super().__new__(cls)
@@ -362,6 +374,7 @@ class BaseProperty(BaseModel):
     #
     #
     # make references optional by default - does not work
+
     def __init__(self, **data) -> None:
         super().__init__(**data)
         self._reference_fields: Set[str] = self.get_ref_fields(type(self))

--- a/weaviate/collection/collection_model.py
+++ b/weaviate/collection/collection_model.py
@@ -274,6 +274,18 @@ class _GRPCWrapper(Generic[Model]):
             )
         ]
 
+    def bm25_orm(
+        self,
+        query: str,
+        properties: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        autocut: Optional[int] = None,
+        return_properties: Optional[List] = None,
+    ) -> List[Model]:
+        print(return_properties)
+        for prop in return_properties:
+            print("#####PROP: ", prop)
+
     def near_vector_flat(
         self,
         vector: List[float],

--- a/weaviate/collection/orm.py
+++ b/weaviate/collection/orm.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+
+def Property(
+    default: Any,
+):
+    pass


### PR DESCRIPTION
Allow users the ability to define cross references as ORM-style relationships within their object definitions. Such an implementation is heavily inspired by the ORM capabilities of SQLalchemy, Django, and ODMantic.