### PR TITLE
embeddedoptions default: port:8080 version:latest

### DIFF
--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -29,8 +29,8 @@ GITHUB_RELEASE_DOWNLOAD_URL = "https://github.com/weaviate/weaviate/releases/dow
 class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", DEFAULT_PERSISTENCE_DATA_PATH)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", DEFAULT_BINARY_PATH)
-    version: str = "1.19.12"
-    port: int = 6666
+    version: str = "latest"
+    port: int = 8080
     hostname: str = "127.0.0.1"
     additional_env_vars: Optional[Dict[str, str]] = None
 


### PR DESCRIPTION
This will prevent users failing to use new features with embedded options.

Also, port 6666 is [not liked by browsers](https://medium.com/@msinha2801/why-are-some-ports-considered-unsafe-restricted-c3c22d0596c0) :man_shrugging: 

So one that tries to access it from browser, like opening the link from terminal, will find it weird that will not work on browser.

[related thread](https://forum.weaviate.io/t/cannot-add-tenancy-to-weaviate-class/496)