### PR TITLE
add debug mode options removed from other PR

### DIFF
--- a/test/collection/test_classes.py
+++ b/test/collection/test_classes.py
@@ -1,0 +1,34 @@
+import pytest
+import uuid
+from weaviate.collection.classes import ReferenceTo, ReferenceToMultiTarget, _ReferenceDataType
+
+
+def test_raises_error_when_reference_to_used_incorrectly():
+    ref_dtype = _ReferenceDataType(
+        collections=["Foo", "Bar"],
+    )
+    ref_to = ReferenceTo(
+        uuids=uuid.uuid4(),
+    )
+    with pytest.raises(ValueError) as error:
+        ref_to.to_beacons_strict(ref_dtype)
+        assert (
+            error
+            == "Can only use ReferenceTo on a reference property with a single target collection, use ReferenceToMultiTarget instead"
+        )
+
+
+def test_raises_error_when_target_collection_required_and_wrong():
+    ref_dtype = _ReferenceDataType(
+        collections=["Foo", "Bar"],
+    )
+    ref_to = ReferenceToMultiTarget(
+        uuids=uuid.uuid4(),
+        target_collection="Baz",
+    )
+    with pytest.raises(ValueError) as error:
+        ref_to.to_beacons_strict(ref_dtype)
+        assert (
+            error
+            == 'target_collection must be one of ["Foo", "Bar"] since these are the collections specified in the reference property of this collection but got "Baz" instead'
+        )

--- a/weaviate/collection/classes.py
+++ b/weaviate/collection/classes.py
@@ -699,12 +699,26 @@ def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
 class ReferenceTo(BaseModel):
     uuids: Union[List[UUID], UUID]
 
+    def to_beacons_strict(self, ref_dtype: _ReferenceDataType) -> List[Dict[str, str]]:
+        if len(ref_dtype.collections) > 1:
+            raise ValueError(
+                "Can only use ReferenceTo on a reference property with a single target collection, use ReferenceToMultiTarget instead"
+            )
+        return _to_beacons(self.uuids)
+
     def to_beacons(self) -> List[Dict[str, str]]:
         return _to_beacons(self.uuids)
 
 
 class ReferenceToMultiTarget(ReferenceTo):
     target_collection: str
+
+    def to_beacons_strict(self, ref_dtype: _ReferenceDataType) -> List[Dict[str, str]]:
+        if self.target_collection not in ref_dtype.collections:
+            raise ValueError(
+                f"target_collection must be one of {ref_dtype.collections} since these are the collections specified in the reference property of this collection but got {self.target_collection} instead"
+            )
+        return _to_beacons(self.uuids, self.target_collection)
 
     def to_beacons(self) -> List[Dict[str, str]]:
         return _to_beacons(self.uuids, self.target_collection)

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -44,16 +44,16 @@ class CollectionObject:
 
 
 class Collection(CollectionBase):
-    def create(self, config: CollectionConfig) -> CollectionObject:
+    def create(self, config: CollectionConfig, debug_mode: bool = False) -> CollectionObject:
         name = super()._create(config)
         if config.name != name:
             raise ValueError(
                 f"Name of created collection ({name}) does not match given name ({config.name})"
             )
-        return self.get(name)
+        return self.get(name, debug_mode)
 
-    def get(self, name: str) -> CollectionObject:
-        config = _ConfigCollection(self._connection, name)
+    def get(self, name: str, debug_mode: bool = False) -> CollectionObject:
+        config = _ConfigCollection.make(self._connection, name, debug_mode)
         return CollectionObject(self._connection, name, config)
 
     def delete(self, name: str) -> None:

--- a/weaviate/collection/collection_model.py
+++ b/weaviate/collection/collection_model.py
@@ -66,18 +66,20 @@ class CollectionModel(CollectionBase):
     def __init__(self, connection: Connection):
         super().__init__(connection)
 
-    def create(self, config: CollectionModelConfig[Model]) -> CollectionObjectModel[Model]:
+    def create(
+        self, config: CollectionModelConfig[Model], debug_mode: bool = False
+    ) -> CollectionObjectModel[Model]:
         name = super()._create(config)
         config_name = _capitalize_first_letter(config.model.__name__)
         if config_name != name:
             raise ValueError(
                 f"Name of created collection ({name}) does not match given name ({config_name})"
             )
-        return self.get(config.model)
+        return self.get(config.model, debug_mode)
 
-    def get(self, model: Type[Model]) -> CollectionObjectModel[Model]:
+    def get(self, model: Type[Model], debug_mode: bool = False) -> CollectionObjectModel[Model]:
         name = _capitalize_first_letter(model.__name__)
-        config = _ConfigCollectionModel(self._connection, name)
+        config = _ConfigCollectionModel.make(self._connection, name, debug_mode)
         if config.is_invalid(model):
             raise TypeError(
                 f"Model {model.__name__} definition does not match collection {name} config"
@@ -121,6 +123,6 @@ class CollectionModel(CollectionBase):
 
     def update(self, model: Type[Model]) -> CollectionObjectModel[Model]:
         name = _capitalize_first_letter(model.__name__)
-        config = _ConfigCollectionModel(self._connection, name)
+        config = _ConfigCollectionModel.make(self._connection, name, True)
         config.update_model(model)
         return CollectionObjectModel[model](self._connection, name, model, config)

--- a/weaviate/collection/config.py
+++ b/weaviate/collection/config.py
@@ -28,10 +28,21 @@ class _ConfigBase:
     the `collection.config` class attribute.
     """
 
-    def __init__(self, connection: Connection, name: str) -> None:
+    def __init__(self, connection: Connection, name: str, strict: bool) -> None:
         self.__cached: Optional[Dict[str, Any]] = None
         self.__connection = connection
         self.__name = name
+        self.__strict = strict
+
+    @classmethod
+    def make(cls, connection: Connection, name: str, strict: bool = False):
+        _cls = cls(connection, name, strict)
+        if strict:
+            _cls._fetch()
+        return _cls
+
+    def is_strict(self) -> bool:
+        return self.__strict
 
     def _fetch(self) -> None:
         try:


### PR DESCRIPTION
This PR adds new functionality to allow users to enable a "debug mode" whereby each invocation of either `collection.create` or `collection.get` will prefetch the collection's schema and hold it within an in-memory cache for usage across the client when validating a user's custom input for their collection. The implementation as an in-memory cache has an eye to the future when expanding the client-side checks to the growing client as future features are implemented.

Since such an implementation adds significant overhead in the form of schema prefetching requests, it is provided as an option that defaults to `False` so that developers can enable it when developing to help their debugging process and then disable it in production to ensure performance is not negatively affected. Yet, there are likely use-cases where a developer will want these debug features running in production so they will always have the option of enabling if desired. The default setting of `False` ensures that they do not accidentally have it switched on in their production environment.

This PR acts as place to continue the conversation started [here](https://github.com/weaviate/weaviate-python-client/pull/414#discussion_r1293051220)