### PR TITLE
BUGFIX for with_bm25: use json dumps to add escape quotes 

### DIFF
--- a/test/gql/test_get.py
+++ b/test/gql/test_get.py
@@ -67,6 +67,7 @@ def test_getbuilder_with_additional_props(additional_props: AdditionalProperties
         ),
         ("other query", [], 'bm25:{query: "other query"}'),
         ("other query", None, 'bm25:{query: "other query"}'),
+        ('what is an "airport"', None, 'bm25:{query: "what is an \\"airport\\""}'),
     ],
 )
 def test_bm25(query: str, properties: List[str], expected: str):

--- a/weaviate/gql/get.py
+++ b/weaviate/gql/get.py
@@ -38,7 +38,7 @@ class BM25:
     properties: Optional[List[str]]
 
     def __str__(self) -> str:
-        ret = f'query: "{util.strip_newlines(self.query)}"'
+        ret = f"query: {dumps(util.strip_newlines(self.query))}"
         if self.properties is not None and len(self.properties) > 0:
             props = '","'.join(self.properties)
             ret += f', properties: ["{props}"]'


### PR DESCRIPTION
This PR fixes a bug in BM25 retrieval by using json.dumps method on the query for escaping quotes. 

I kept `strip_newlines` to maintain previous behavior on the "\n" character (instead of escaping it, `strip_newlines` replace it with a space).

### Problem 
Similar to the [issue#121](https://github.com/weaviate/weaviate-python-client/issues/121),
I am getting an error in with_bm25() method if query text contains double quotes, e.g.
```python
query = 'what is an "airport"'
weaviate_client.query.get(...).with_bm25(query=query)
```
 throws this message
```...'message': 'Syntax Error GraphQL request (1:61) Expected :, found String\n...... bm25:{query: "what is an "airport""``` 