### PR TITLE
Add tenant activation methods

### DIFF
--- a/ci/docker-compose-azure.yml
+++ b/ci/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-add-batch-queue-congestion-info-to-node-status-c14301b
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:preview-add-batch-queue-congestion-info-to-node-status-c14301b
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -25,7 +25,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.20.0-prealpha-628c8ff
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     ports:
       - 8088:8080
       - 6061:6060

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-add-batch-queue-congestion-info-to-node-status-c14301b
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-add-batch-queue-congestion-info-to-node-status-c14301b
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-openai.yml
+++ b/ci/docker-compose-openai.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-add-batch-queue-congestion-info-to-node-status-c14301b
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-add-batch-queue-congestion-info-to-node-status-c14301b
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-add-batch-queue-congestion-info-to-node-status-c14301b
+    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
     ports:
       - "8080:8080"
       - "50051:50051"

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -4,7 +4,7 @@ import pytest
 
 import weaviate
 
-GIT_HASH = "c14301b"
+GIT_HASH = "d7c8d9e"
 SERVER_VERSION = "1.20.5"
 NODE_NAME = "node1"
 NUM_OBJECT = 10

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -5,7 +5,7 @@ import pytest
 import weaviate
 
 GIT_HASH = "d7c8d9e"
-SERVER_VERSION = "1.20.5"
+SERVER_VERSION = "1.21.0-rc.1"
 NODE_NAME = "node1"
 NUM_OBJECT = 10
 

--- a/integration/test_schema.py
+++ b/integration/test_schema.py
@@ -132,8 +132,16 @@ def test_class_tenants_activate_deactivate(client: weaviate.Client):
     client.schema.add_class_tenants(class_name, tenants)
     tenants_get = client.schema.get_class_tenants(class_name)
     assert len(tenants_get) == len(tenants)
-    assert tenants_get[0].name == "Tenant1"
-    assert tenants_get[0].activity_status == TenantActivityStatus.HOT
+    # below required because tenants are returned in random order by the server
+    for tenant in tenants_get:
+        if tenant.name == "Tenant1":
+            assert tenant.activity_status == TenantActivityStatus.HOT
+        elif tenant.name == "Tenant2":
+            assert tenant.activity_status == TenantActivityStatus.COLD
+        elif tenant.name == "Tenant3":
+            assert tenant.activity_status == TenantActivityStatus.HOT
+        else:
+            raise AssertionError(f"Unexpected tenant: {tenant.name}")
 
     updated_tenants = [
         Tenant(activity_status=TenantActivityStatus.COLD, name="Tenant1"),

--- a/integration/test_schema.py
+++ b/integration/test_schema.py
@@ -3,7 +3,7 @@ from typing import Optional
 import pytest
 
 import weaviate
-from weaviate import Tenant
+from weaviate import Tenant, TenantActivityStatus
 
 
 @pytest.fixture(scope="module")
@@ -115,3 +115,40 @@ def test_class_tenants(client: weaviate.Client):
     client.schema.remove_class_tenants(class_name, ["Tenant2", "Tenant4"])
     tenants_get = client.schema.get_class_tenants(class_name)
     assert len(tenants_get) == 2
+
+
+def test_class_tenants_activate_deactivate(client: weaviate.Client):
+    class_name = "MultiTenancyActivateDeactivateSchemaTest"
+    single_class = {"class": class_name, "multiTenancyConfig": {"enabled": True}}
+    client.schema.delete_all()
+    client.schema.create_class(single_class)
+    assert client.schema.exists(class_name)
+
+    tenants = [
+        Tenant(name="Tenant1"),
+        Tenant(activity_status=TenantActivityStatus.COLD, name="Tenant2"),
+        Tenant(name="Tenant3"),
+    ]
+    client.schema.add_class_tenants(class_name, tenants)
+    tenants_get = client.schema.get_class_tenants(class_name)
+    assert len(tenants_get) == len(tenants)
+    assert tenants_get[0].name == "Tenant1"
+    assert tenants_get[0].activity_status == TenantActivityStatus.HOT
+
+    updated_tenants = [
+        Tenant(activity_status=TenantActivityStatus.COLD, name="Tenant1"),
+        Tenant(activity_status=TenantActivityStatus.HOT, name="Tenant2"),
+    ]
+    client.schema.update_class_tenant_activities(class_name, updated_tenants)
+    tenants_get = client.schema.get_class_tenants(class_name)
+    assert len(tenants_get) == len(tenants)
+    # below required because tenants are returned in random order by the server
+    for tenant in tenants_get:
+        if tenant.name == "Tenant1":
+            assert tenant.activity_status == TenantActivityStatus.COLD
+        elif tenant.name == "Tenant2":
+            assert tenant.activity_status == TenantActivityStatus.HOT
+        elif tenant.name == "Tenant3":
+            assert tenant.activity_status == TenantActivityStatus.HOT
+        else:
+            raise AssertionError(f"Unexpected tenant: {tenant.name}")

--- a/weaviate/__init__.py
+++ b/weaviate/__init__.py
@@ -51,6 +51,7 @@ __all__ = [
     "AdditionalProperties",
     "LinkTo",
     "Tenant",
+    "TenantActivityStatus",
 ]
 
 import sys
@@ -66,7 +67,7 @@ from .auth import AuthClientCredentials, AuthClientPassword, AuthBearerToken, Au
 from .batch.crud_batch import WeaviateErrorRetryConf
 from .client import Client
 from .data.replication import ConsistencyLevel
-from .schema.crud_schema import Tenant
+from .schema.crud_schema import Tenant, TenantActivityStatus
 from .embedded import EmbeddedOptions
 from .exceptions import (
     UnexpectedStatusCodeException,

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -49,10 +49,8 @@ class TenantActivityStatus(str, Enum):
 
     Attributes
     ----------
-    HOT : str
-        The tenant is fully active and can be used.
-    COLD : str
-        The tenant is not active, files stored locally.
+    HOT: The tenant is fully active and can be used.
+    COLD: The tenant is not active, files stored locally.
     """
 
     HOT = "HOT"
@@ -72,7 +70,7 @@ class Tenant:
     """
 
     name: str
-    activity_status: TenantActivityStatus = "HOT"
+    activity_status: TenantActivityStatus = TenantActivityStatus.HOT
 
     def _to_weaviate_object(self) -> Dict[str, str]:
         return {

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -2,7 +2,8 @@
 Schema class definition.
 """
 from dataclasses import dataclass
-from typing import Union, Optional, List
+from enum import Enum
+from typing import Union, Optional, List, Dict
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
@@ -42,17 +43,49 @@ _PRIMITIVE_WEAVIATE_TYPES_SET = {
 }
 
 
+class TenantActivityStatus(str, Enum):
+    """
+    TenantActivityStatus class used to describe the activity status of a tenant in Weaviate.
+
+    Attributes
+    ----------
+    HOT : str
+        The tenant is fully active and can be used.
+    COLD : str
+        The tenant is not active, files stored locally.
+    """
+
+    HOT = "HOT"
+    COLD = "COLD"
+
+
 @dataclass
 class Tenant:
     """
     Tenant class used to describe a tenant in Weaviate.
 
-    Parameters
+    Attributes
     ----------
+    activity_status : TenantActivityStatus, optional
+        default: "HOT"
     name: the name of the tenant.
     """
 
     name: str
+    activity_status: TenantActivityStatus = "HOT"
+
+    def _to_weaviate_object(self) -> Dict[str, str]:
+        return {
+            "activityStatus": self.activity_status,
+            "name": self.name,
+        }
+
+    @classmethod
+    def _from_weaviate_object(cls, weaviate_object: Dict[str, str]) -> "Tenant":
+        return cls(
+            name=weaviate_object["name"],
+            activity_status=weaviate_object.get("activityStatus", "HOT"),
+        )
 
 
 class Schema:
@@ -807,7 +840,7 @@ class Schema:
             If Weaviate reports a non-OK status.
         """
 
-        loaded_tenants = [{"name": tenant.name} for tenant in tenants]
+        loaded_tenants = [tenant._to_weaviate_object() for tenant in tenants]
 
         path = "/schema/" + class_name + "/tenants"
         try:
@@ -881,7 +914,60 @@ class Schema:
             raise UnexpectedStatusCodeException("Get classes tenants", response)
 
         tenant_resp = response.json()
-        return [Tenant(tenant["name"]) for tenant in tenant_resp]
+        return [Tenant._from_weaviate_object(tenant) for tenant in tenant_resp]
+
+    def update_class_tenant_activities(self, class_name: str, tenants: List[Tenant]) -> None:
+        """Update the activity status of tenants for a class.
+
+        Use this when you want to move tenants from one activity state to another.
+
+        Parameters
+        ----------
+        class_name : str
+            The class for which we update tenants.
+        tenants : List[Tenant]
+            List of Tenants.
+
+        Examples
+        --------
+        >>> client.schema.add_class_tenants(
+                "class_name",
+                [
+                    Tenant(activity_status=TenantActivityStatus.HOT, name="Tenant1")),
+                    Tenant(activity_status=TenantActivityStatus.COLD, name="Tenant2"))
+                    Tenant(name="Tenant3")
+                ]
+            )
+        >>> client.schema.update_class_tenant_activities(
+                "class_name",
+                [
+                    Tenant(activity_status=TenantActivityStatus.COLD, name="Tenant1")),
+                    Tenant(activity_status=TenantActivityStatus.HOT, name="Tenant2"))
+                ]
+            )
+        >>> client.schema.get_class_tenants("class_name")
+        [
+            Tenant(activity_status=TenantActivityStatus.COLD, name="Tenant1")),
+            Tenant(activity_status=TenantActivityStatus.HOT, name="Tenant2")),
+            Tenant(activity_status=TenantActivityStatus.HOT, name="Tenant3"))
+        ]
+
+
+        Raises
+        ------
+        requests.ConnectionError
+            If the network connection to Weaviate fails.
+        weaviate.UnexpectedStatusCodeException
+            If Weaviate reports a non-OK status.
+        """
+        path = "/schema/" + class_name + "/tenants"
+        loaded_tenants = [tenant._to_weaviate_object() for tenant in tenants]
+        try:
+            response = self._connection.put(path=path, weaviate_object=loaded_tenants)
+        except RequestsConnectionError as conn_err:
+            raise RequestsConnectionError("Could not update class tenants.") from conn_err
+        if response.status_code != 200:
+            raise UnexpectedStatusCodeException("Update classes tenants", response)
 
 
 def _property_is_primitive(data_type_list: list) -> bool:


### PR DESCRIPTION
This PR introduces a method on `client.schema` to allow for the updating of tenants activity statuses. It also updates all the CI scripts to use the latest Weaviate RC image.

The currently implemented status on the Weaviate side are `HOT` and `COLD` but `WARM` and `FROZEN` are defined to be implemented later. As such, only `HOT` and `COLD` are implemented within the client for now so as to avoid user error. The `TenantActivityStatus` can be extended in future to include these extra enums as and when they become supported.