### PR TITLE
Bug fixes of where filtering for valueText & valueString and valueGeoRange

### DIFF
--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -644,7 +644,7 @@ class TestWhere(unittest.TestCase):
         test_filter = helper_get_test_filter("valueGeoRange", geo_range)
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: Equal valueGeoRange: {"geoCoordinates": {"latitude": 51.51, "longitude": -0.09}, "distance": {"max": 2000}}} ',
+            'where: {path: ["name"] operator: Equal valueGeoRange: { geoCoordinates: { latitude: 51.51 longitude: -0.09 } distance: { max: 2000 } } ',
             str(result),
         )
 

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -644,7 +644,7 @@ class TestWhere(unittest.TestCase):
         test_filter = helper_get_test_filter("valueGeoRange", geo_range)
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: Equal valueGeoRange: { geoCoordinates: { latitude: 51.51 longitude: -0.09 } distance: { max: 2000 } } }',
+            'where: {path: ["name"] operator: Equal valueGeoRange: { geoCoordinates: { latitude: 51.51 longitude: -0.09 } distance: { max: 2000 }}} ',
             str(result),
         )
 

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -644,7 +644,7 @@ class TestWhere(unittest.TestCase):
         test_filter = helper_get_test_filter("valueGeoRange", geo_range)
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: Equal valueGeoRange: { geoCoordinates: { latitude: 51.51 longitude: -0.09 } distance: { max: 2000 } } ',
+            'where: {path: ["name"] operator: Equal valueGeoRange: { geoCoordinates: { latitude: 51.51 longitude: -0.09 } distance: { max: 2000 } } }',
             str(result),
         )
 

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -619,6 +619,23 @@ class TestWhere(unittest.TestCase):
         result = str(Where(test_filter))
         self.assertEqual('where: {path: ["name"] operator: Equal valueString: "Test"} ', result)
 
+        test_filter = helper_get_test_filter("valueText", "n\n")
+        result = str(Where(test_filter))
+        self.assertEqual('where: {path: ["name"] operator: Equal valueText: "n "} ', result)
+
+        test_filter = helper_get_test_filter("valueString", 'what is an "airport"?')
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: Equal valueString: "what is an \\"airport\\"?"} ',
+            result,
+        )
+
+        test_filter = helper_get_test_filter("valueText", "what is an 'airport'?")
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: Equal valueText: "what is an \'airport\'?"} ', result
+        )
+
         test_filter = helper_get_test_filter("valueInt", 1)
         result = str(Where(test_filter))
         self.assertEqual('where: {path: ["name"] operator: Equal valueInt: 1} ', result)

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -630,6 +630,20 @@ class TestWhere(unittest.TestCase):
             result,
         )
 
+        test_filter = helper_get_test_filter("valueString", "this is an escape sequence \a")
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: Equal valueString: "this is an escape sequence \\u0007"} ',
+            result,
+        )
+
+        test_filter = helper_get_test_filter("valueString", "this is a hex value \u03A9")
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: Equal valueString: "this is a hex value \\u03a9"} ',
+            result,
+        )
+
         test_filter = helper_get_test_filter("valueText", "what is an 'airport'?")
         result = str(Where(test_filter))
         self.assertEqual(

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -592,6 +592,13 @@ class Where(Filter):
         for operand in _content["operands"]:
             self.operands.append(Where(operand))
 
+    def _render_value_geo_range(self, content: dict) -> str:
+        print(content)
+        latitude = content["geoCoordinates"]["latitude"]
+        longitude = content["geoCoordinates"]["longitude"]
+        distance = content["distance"]["max"]
+        return f"{{ geoCoordinates: {{ latitude: {latitude} longitude: {longitude} }} distance: {{ max: {distance} }} }}"
+
     def __str__(self):
         if self.is_filter:
             gql = f"where: {{path: {self.path} operator: {self.operator} {self.value_type}: "
@@ -600,7 +607,7 @@ class Where(Filter):
             elif self.value_type == "valueBoolean":
                 gql += f"{_bool_to_str(self.value)}}}"
             elif self.value_type == "valueGeoRange":
-                gql += f"{dumps(self.value)}}}"
+                gql += self._render_value_geo_range(self.value)
             else:
                 gql += f'"{self.value}"}}'
             return gql + " "

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -592,12 +592,6 @@ class Where(Filter):
         for operand in _content["operands"]:
             self.operands.append(Where(operand))
 
-    def _render_value_geo_range(self, content: dict) -> str:
-        latitude = content["geoCoordinates"]["latitude"]
-        longitude = content["geoCoordinates"]["longitude"]
-        distance = content["distance"]["max"]
-        return f"{{ geoCoordinates: {{ latitude: {latitude} longitude: {longitude} }} distance: {{ max: {distance} }} }}"
-
     def __str__(self):
         if self.is_filter:
             gql = f"where: {{path: {self.path} operator: {self.operator} {self.value_type}: "
@@ -606,7 +600,7 @@ class Where(Filter):
             elif self.value_type == "valueBoolean":
                 gql += f"{_bool_to_str(self.value)}}}"
             elif self.value_type == "valueGeoRange":
-                gql += f"{self._render_value_geo_range(self.value)} }}"
+                gql += f"{_geo_range_to_str(self.value)}}}"
             else:
                 gql += f'"{self.value}"}}'
             return gql + " "
@@ -617,6 +611,26 @@ class Where(Filter):
             operands_str.append(str(operand)[7:-1])
         operands = ", ".join(operands_str)
         return f"where: {{operator: {self.operator} operands: [{operands}]}} "
+
+
+def _geo_range_to_str(value: dict) -> str:
+    """
+    Convert the valueGeoRange object to match `json` formatting.
+
+    Parameters
+    ----------
+    value : dict
+        The value to be converted.
+
+    Returns
+    -------
+    str
+        The string interpretation of the value in `json` format.
+    """
+    latitude = value["geoCoordinates"]["latitude"]
+    longitude = value["geoCoordinates"]["longitude"]
+    distance = value["distance"]["max"]
+    return f"{{ geoCoordinates: {{ latitude: {latitude} longitude: {longitude} }} distance: {{ max: {distance} }}}}"
 
 
 def _bool_to_str(value: bool) -> str:

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -606,7 +606,7 @@ class Where(Filter):
             elif self.value_type == "valueBoolean":
                 gql += f"{_bool_to_str(self.value)}}}"
             elif self.value_type == "valueGeoRange":
-                gql += self._render_value_geo_range(self.value)
+                gql += f"{self._render_value_geo_range(self.value)}}}"
             else:
                 gql += f'"{self.value}"}}'
             return gql + " "

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -598,7 +598,6 @@ class Where(Filter):
             if self.value_type in ["valueInt", "valueNumber"]:
                 gql += f"{self.value}}}"
             elif self.value_type in ["valueText", "valueString"]:
-                print(self.value)
                 gql += f"{_sanitize_str(self.value)}}}"
             elif self.value_type == "valueBoolean":
                 gql += f"{_bool_to_str(self.value)}}}"

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -597,6 +597,9 @@ class Where(Filter):
             gql = f"where: {{path: {self.path} operator: {self.operator} {self.value_type}: "
             if self.value_type in ["valueInt", "valueNumber"]:
                 gql += f"{self.value}}}"
+            elif self.value_type in ["valueText", "valueString"]:
+                print(self.value)
+                gql += f"{_sanitize_str(self.value)}}}"
             elif self.value_type == "valueBoolean":
                 gql += f"{_bool_to_str(self.value)}}}"
             elif self.value_type == "valueGeoRange":
@@ -631,6 +634,24 @@ def _geo_range_to_str(value: dict) -> str:
     longitude = value["geoCoordinates"]["longitude"]
     distance = value["distance"]["max"]
     return f"{{ geoCoordinates: {{ latitude: {latitude} longitude: {longitude} }} distance: {{ max: {distance} }}}}"
+
+
+def _sanitize_str(value: str) -> str:
+    """
+    Ensures string is sanitized for GraphQL.
+
+    Parameters
+    ----------
+    value : str
+        The value to be converted.
+
+    Returns
+    -------
+    str
+        The sanitized string.
+    """
+    value = value.replace("\n", " ")
+    return dumps(value)
 
 
 def _bool_to_str(value: bool) -> str:

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -606,7 +606,7 @@ class Where(Filter):
             elif self.value_type == "valueBoolean":
                 gql += f"{_bool_to_str(self.value)}}}"
             elif self.value_type == "valueGeoRange":
-                gql += f"{self._render_value_geo_range(self.value)}}}"
+                gql += f"{self._render_value_geo_range(self.value)} }}"
             else:
                 gql += f'"{self.value}"}}'
             return gql + " "

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -593,7 +593,6 @@ class Where(Filter):
             self.operands.append(Where(operand))
 
     def _render_value_geo_range(self, content: dict) -> str:
-        print(content)
         latitude = content["geoCoordinates"]["latitude"]
         longitude = content["geoCoordinates"]["longitude"]
         distance = content["distance"]["max"]


### PR DESCRIPTION
This PR fixes:
1. the GraphQL string rendering of the valueGeoRange where filter
2. the GraphQL string rendering of the valueText and valueString where filters when `\n` chars are present

Resolves #419
Resolves #294 