### PR TITLE
Support new contains filters

### DIFF
--- a/ci/docker-compose-azure.yml
+++ b/ci/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -25,7 +25,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     ports:
       - 8088:8080
       - 6061:6060

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-openai.yml
+++ b/ci/docker-compose-openai.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-release-v1-21-0-rc-1-d7c8d9e
+    image: semitechnologies/weaviate:preview-containsany-containsall-filter-operators-5713a16
     ports:
       - "8080:8080"
       - "50051:50051"

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -4,7 +4,7 @@ import pytest
 
 import weaviate
 
-GIT_HASH = "d7c8d9e"
+GIT_HASH = "5713a16"
 SERVER_VERSION = "1.21.0-rc.1"
 NODE_NAME = "node1"
 NUM_OBJECT = 10

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -116,36 +116,30 @@ def test_get_data_with_where_contains_any(client: weaviate.Client):
     where_filter = {"path": ["size"], "operator": "ContainsAny", "valueIntList": [5]}
     result = client.query.get("Ship", ["name", "size"]).with_where(where_filter).do()
     objects = get_objects_from_result(result)
-    a_found = False
-    for obj in objects:
-        if obj["name"] == "HMS British Name":
-            a_found = True
-    assert a_found and len(objects) == 1
+    assert len(objects) == 1 and objects[0]["name"] == "HMS British Name"
 
 
-def test_get_data_with_where_contains_all(client: weaviate.Client):
+@pytest.mark.parametrize(
+    "value_string_list,expected_objects_len",
+    [
+        (["sponges, sponges, sponges"], 1),
+        (["sponges, sponges, sponges", "doesn't exist"], 0),
+    ],
+)
+def test_get_data_with_where_contains_all(
+    client: weaviate.Client, value_string_list: List[str], expected_objects_len: int
+):
     """Test GraphQL's Get clause with where filter."""
     where_filter = {
         "path": ["description"],
         "operator": "ContainsAll",
-        "valueStringList": ["sponges, sponges, sponges"],
+        "valueStringList": value_string_list,
     }
-    result = client.query.get("Ship", ["name", "size"]).with_where(where_filter).do()
+    result = client.query.get("Ship", ["name"]).with_where(where_filter).do()
     objects = get_objects_from_result(result)
-    a_found = False
-    for obj in objects:
-        if obj["name"] == "The Crusty Crab":
-            a_found = True
-    assert a_found and len(objects) == 1
-
-    where_filter = {
-        "path": ["description"],
-        "operator": "ContainsAll",
-        "valueStringList": ["sponges, sponges, sponges", "doesn't exist"],
-    }
-    result = client.query.get("Ship", ["name", "size"]).with_where(where_filter).do()
-    objects = get_objects_from_result(result)
-    assert len(objects) == 0
+    assert len(objects) == expected_objects_len
+    if expected_objects_len == 1:
+        assert objects[0]["name"] == "The Crusty Crab"
 
 
 def test_get_data_after(client: weaviate.Client):

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -1,7 +1,15 @@
 import unittest
 
 from test.util import check_error_message, check_startswith_error_message
-from weaviate.gql.filter import NearText, NearVector, NearObject, NearImage, Where, Ask
+from weaviate.gql.filter import (
+    NearText,
+    NearVector,
+    NearObject,
+    NearImage,
+    Where,
+    Ask,
+    WHERE_OPERATORS,
+)
 
 
 def helper_get_test_filter(filter_type, value):
@@ -539,6 +547,9 @@ class TestWhere(unittest.TestCase):
         path_key_error = "Filter is missing required field `operator`. Given: "
         dtype_no_value_error_msg = "Filter is missing required field 'value<TYPE>': "
         dtype_multiple_value_error_msg = "Multiple fields 'value<TYPE>' are not supported: "
+        operator_error_msg = (
+            lambda op: f"Operator {op} is not allowed. Allowed operators are: {', '.join(WHERE_OPERATORS)}"
+        )
 
         with self.assertRaises(TypeError) as error:
             Where(None)
@@ -575,6 +586,10 @@ class TestWhere(unittest.TestCase):
         with self.assertRaises(TypeError) as error:
             Where({"operands": ["some_path"], "operator": "Like"})
         check_error_message(self, error, content_error_msg(str))
+
+        with self.assertRaises(ValueError) as error:
+            Where({"path": "some_path", "operator": "NotValid"})
+        check_error_message(self, error, operator_error_msg("NotValid"))
 
         # test valid calls
         Where({"path": "hasTheOneRing", "operator": "Equal", "valueBoolean": False})

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -679,6 +679,37 @@ class TestWhere(unittest.TestCase):
             str(result),
         )
 
+        test_filter = {
+            "path": ["name"],
+            "operator": "ContainsAny",
+            "valueText": ["A", "B\n"],
+        }
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: ContainsAny valueText: ["A","B "]} ', str(result)
+        )
+
+        test_filter = {
+            "path": ["name"],
+            "operator": "ContainsAll",
+            "valueString": ["A", '"B"'],
+        }
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: ContainsAll valueString: ["A","\\"B\\""]} ',
+            str(result),
+        )
+
+        test_filter = {
+            "path": ["name"],
+            "operator": "Equal",
+            "valueText": "😃",
+        }
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: Equal valueText: "\\ud83d\\ude03"} ', str(result)
+        )
+
 
 class TestAskFilter(unittest.TestCase):
     def test___init__(self):

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -745,6 +745,12 @@ class TestWhere(unittest.TestCase):
             str(result),
         )
 
+        test_filter = {"path": ["name"], "operator": "ContainsAny", "valueIntList": [1, 2]}
+        result = str(Where(test_filter))
+        self.assertEqual(
+            'where: {path: ["name"] operator: ContainsAny valueInt: [1, 2]} ', str(result)
+        )
+
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAny",

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -47,7 +47,6 @@ WHERE_OPERATORS = [
     "LessThan",
     "LessThanEqual",
     "Like",
-    "Not",
     "NotEqual",
     "Or",
     "WithinGeoRange",

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -25,7 +25,7 @@ VALUE_TYPES = {
     "valueGeoRange",
 }
 
-WHERE_OPERATORS = {
+WHERE_OPERATORS = [
     "And",
     "ContainsAll",
     "ContainsAny",
@@ -40,7 +40,7 @@ WHERE_OPERATORS = {
     "NotEqual",
     "Or",
     "WithinGeoRange",
-}
+]
 
 
 class GraphQL(ABC):
@@ -583,7 +583,7 @@ class Where(Filter):
         if content["operator"] not in WHERE_OPERATORS:
             raise ValueError(
                 f"Operator {content['operator']} is not allowed. "
-                f"Allowed operators are: {WHERE_OPERATORS}"
+                f"Allowed operators are: {', '.join(WHERE_OPERATORS)}"
             )
         self.path = dumps(content["path"])
         self.operator = content["operator"]

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -652,7 +652,7 @@ class Where(Filter):
                 gql += f"{self.value}}}"
             elif self.value_type in ["valueIntList", "valueNumberList"]:
                 _check_is_list(self.value, self.value_type)
-                gql += f"{_render_list(self.value)}}}"
+                gql += f"{self.value}}}"
             elif self.value_type in ["valueText", "valueString"]:
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_sanitize_str(self.value)}}}"


### PR DESCRIPTION
Adds support for the new `ContainsAny` and `ContainsAll` filters.

These must be used in conjunction with `valueText` and `valueString` as lists of strings. This is not checked within the client itself so will result in a Weaviate REST exception upon user error. This nuance should therefore be communicated to users by DevRel.

When implementing this in the experimental collections API, these checks will be included to aid UX.