### PR TITLE
Fix batch objects where filter

### DIFF
--- a/ci/docker-compose-azure.yml
+++ b/ci/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -25,7 +25,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     ports:
       - 8088:8080
       - 6061:6060

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-openai.yml
+++ b/ci/docker-compose-openai.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.21.0
+    image: semitechnologies/weaviate:1.21.1
     ports:
       - "8080:8080"
       - "50051:50051"

--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -109,7 +109,7 @@ def test_delete_objects(client: weaviate.Client):
             where={
                 "path": ["name"],
                 "operator": "ContainsAny",
-                "valueTextList": ["two", "three"],
+                "valueTextArray": ["two", "three"],
             },
         )
     res = client.data_object.get()
@@ -123,7 +123,7 @@ def test_delete_objects(client: weaviate.Client):
             where={
                 "path": ["name"],
                 "operator": "ContainsAll",
-                "valueTextList": ["four", "five"],
+                "valueTextArray": ["four", "five"],
             },
         )
     res = client.data_object.get()

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -4,8 +4,8 @@ import pytest
 
 import weaviate
 
-GIT_HASH = "8172acb"
-SERVER_VERSION = "1.21.0"
+GIT_HASH = "5f2df4d"
+SERVER_VERSION = "1.21.1"
 NODE_NAME = "node1"
 NUM_OBJECT = 10
 

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -113,7 +113,7 @@ def test_get_data(client: weaviate.Client):
 
 def test_get_data_with_where_contains_any(client: weaviate.Client):
     """Test GraphQL's Get clause with where filter."""
-    where_filter = {"path": ["size"], "operator": "ContainsAny", "valueIntArray": [5]}
+    where_filter = {"path": ["size"], "operator": "ContainsAny", "valueIntList": [5]}
     result = client.query.get("Ship", ["name", "size"]).with_where(where_filter).do()
     objects = get_objects_from_result(result)
     assert len(objects) == 1 and objects[0]["name"] == "HMS British Name"
@@ -133,7 +133,7 @@ def test_get_data_with_where_contains_all(
     where_filter = {
         "path": ["description"],
         "operator": "ContainsAll",
-        "valueStringArray": value_string_list,
+        "valueStringList": value_string_list,
     }
     result = client.query.get("Ship", ["name"]).with_where(where_filter).do()
     objects = get_objects_from_result(result)

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -113,7 +113,7 @@ def test_get_data(client: weaviate.Client):
 
 def test_get_data_with_where_contains_any(client: weaviate.Client):
     """Test GraphQL's Get clause with where filter."""
-    where_filter = {"path": ["size"], "operator": "ContainsAny", "valueIntList": [5]}
+    where_filter = {"path": ["size"], "operator": "ContainsAny", "valueIntArray": [5]}
     result = client.query.get("Ship", ["name", "size"]).with_where(where_filter).do()
     objects = get_objects_from_result(result)
     assert len(objects) == 1 and objects[0]["name"] == "HMS British Name"
@@ -133,7 +133,7 @@ def test_get_data_with_where_contains_all(
     where_filter = {
         "path": ["description"],
         "operator": "ContainsAll",
-        "valueStringList": value_string_list,
+        "valueStringArray": value_string_list,
     }
     result = client.query.get("Ship", ["name"]).with_where(where_filter).do()
     objects = get_objects_from_result(result)

--- a/test/data/test_crud_data.py
+++ b/test/data/test_crud_data.py
@@ -455,11 +455,13 @@ class TestDataObject(unittest.TestCase):
 
         mock_get = Mock(return_value="Test")
         data_object.get = mock_get
-        data_object.get_by_id(uuid="UUID", additional_properties=["Test", "list"], with_vector=True)
+        data_object.get_by_id(
+            uuid="UUID", additional_properties=["Test", "Array"], with_vector=True
+        )
         mock_get.assert_called_with(
             uuid="UUID",
             class_name=None,
-            additional_properties=["Test", "list"],
+            additional_properties=["Test", "Array"],
             with_vector=True,
             node_name=None,
             consistency_level=None,

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -733,47 +733,47 @@ class TestWhere(unittest.TestCase):
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAny",
-            "valueTextList": ["A", "B\n"],
+            "valueTextArray": ["A", "B\n"],
         }
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: ContainsAny valueText: ["A","B "]} ', str(result)
+            'where: {path: ["name"] operator: ContainsAny valueTextArray: ["A","B "]} ', str(result)
         )
 
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAll",
-            "valueStringList": ["A", '"B"'],
+            "valueStringArray": ["A", '"B"'],
         }
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: ContainsAll valueString: ["A","\\"B\\""]} ',
+            'where: {path: ["name"] operator: ContainsAll valueStringArray: ["A","\\"B\\""]} ',
             str(result),
         )
 
-        test_filter = {"path": ["name"], "operator": "ContainsAny", "valueIntList": [1, 2]}
+        test_filter = {"path": ["name"], "operator": "ContainsAny", "valueIntArray": [1, 2]}
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: ContainsAny valueInt: [1, 2]} ', str(result)
+            'where: {path: ["name"] operator: ContainsAny valueIntArray: [1, 2]} ', str(result)
         )
 
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAny",
-            "valueStringList": "A",
+            "valueStringArray": "A",
         }
         with self.assertRaises(TypeError) as error:
             str(Where(test_filter))
-        check_error_message(self, error, value_is_not_list_err("A", "valueStringList"))
+        check_error_message(self, error, value_is_not_list_err("A", "valueStringArray"))
 
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAll",
-            "valueTextList": "A",
+            "valueTextArray": "A",
         }
         with self.assertRaises(TypeError) as error:
             str(Where(test_filter))
-        check_error_message(self, error, value_is_not_list_err("A", "valueTextList"))
+        check_error_message(self, error, value_is_not_list_err("A", "valueTextArray"))
 
         test_filter = {
             "path": ["name"],

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -733,7 +733,7 @@ class TestWhere(unittest.TestCase):
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAny",
-            "valueTextList": ["A", "B\n"],
+            "valueTextArray": ["A", "B\n"],
         }
         result = str(Where(test_filter))
         self.assertEqual(
@@ -743,7 +743,7 @@ class TestWhere(unittest.TestCase):
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAll",
-            "valueStringList": ["A", '"B"'],
+            "valueStringArray": ["A", '"B"'],
         }
         result = str(Where(test_filter))
         self.assertEqual(
@@ -751,7 +751,7 @@ class TestWhere(unittest.TestCase):
             str(result),
         )
 
-        test_filter = {"path": ["name"], "operator": "ContainsAny", "valueIntList": [1, 2]}
+        test_filter = {"path": ["name"], "operator": "ContainsAny", "valueIntArray": [1, 2]}
         result = str(Where(test_filter))
         self.assertEqual(
             'where: {path: ["name"] operator: ContainsAny valueInt: [1, 2]} ', str(result)
@@ -760,20 +760,20 @@ class TestWhere(unittest.TestCase):
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAny",
-            "valueStringList": "A",
+            "valueStringArray": "A",
         }
         with self.assertRaises(TypeError) as error:
             str(Where(test_filter))
-        check_error_message(self, error, value_is_not_list_err("A", "valueStringList"))
+        check_error_message(self, error, value_is_not_list_err("A", "valueStringArray"))
 
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAll",
-            "valueTextList": "A",
+            "valueTextArray": "A",
         }
         with self.assertRaises(TypeError) as error:
             str(Where(test_filter))
-        check_error_message(self, error, value_is_not_list_err("A", "valueTextList"))
+        check_error_message(self, error, value_is_not_list_err("A", "valueTextArray"))
 
         test_filter = {
             "path": ["name"],

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -733,47 +733,47 @@ class TestWhere(unittest.TestCase):
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAny",
-            "valueTextArray": ["A", "B\n"],
+            "valueTextList": ["A", "B\n"],
         }
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: ContainsAny valueTextArray: ["A","B "]} ', str(result)
+            'where: {path: ["name"] operator: ContainsAny valueText: ["A","B "]} ', str(result)
         )
 
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAll",
-            "valueStringArray": ["A", '"B"'],
+            "valueStringList": ["A", '"B"'],
         }
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: ContainsAll valueStringArray: ["A","\\"B\\""]} ',
+            'where: {path: ["name"] operator: ContainsAll valueString: ["A","\\"B\\""]} ',
             str(result),
         )
 
-        test_filter = {"path": ["name"], "operator": "ContainsAny", "valueIntArray": [1, 2]}
+        test_filter = {"path": ["name"], "operator": "ContainsAny", "valueIntList": [1, 2]}
         result = str(Where(test_filter))
         self.assertEqual(
-            'where: {path: ["name"] operator: ContainsAny valueIntArray: [1, 2]} ', str(result)
+            'where: {path: ["name"] operator: ContainsAny valueInt: [1, 2]} ', str(result)
         )
 
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAny",
-            "valueStringArray": "A",
+            "valueStringList": "A",
         }
         with self.assertRaises(TypeError) as error:
             str(Where(test_filter))
-        check_error_message(self, error, value_is_not_list_err("A", "valueStringArray"))
+        check_error_message(self, error, value_is_not_list_err("A", "valueStringList"))
 
         test_filter = {
             "path": ["name"],
             "operator": "ContainsAll",
-            "valueTextArray": "A",
+            "valueTextList": "A",
         }
         with self.assertRaises(TypeError) as error:
             str(Where(test_filter))
-        check_error_message(self, error, value_is_not_list_err("A", "valueTextArray"))
+        check_error_message(self, error, value_is_not_list_err("A", "valueTextList"))
 
         test_filter = {
             "path": ["name"],

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -1832,17 +1832,17 @@ def _convert_value_type(_type: str) -> str:
     str
         The Weaviate-defined where filter type.
     """
-    if _type == "valueTextList":
+    if _type == "valueTextArray":
         return "valueTextArray"
-    elif _type == "valueStringList":
+    elif _type == "valueStringArray":
         return "valueStringArray"
-    elif _type == "valueIntList":
+    elif _type == "valueIntArray":
         return "valueIntArray"
-    elif _type == "valueNumberList":
+    elif _type == "valueNumberArray":
         return "valueNumberArray"
-    elif _type == "valueBooleanList":
+    elif _type == "valueBooleanArray":
         return "valueBooleanArray"
-    elif _type == "valueDateList":
+    elif _type == "valueDateArray":
         return "valueDateArray"
     else:
         return _type

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -1832,17 +1832,17 @@ def _convert_value_type(_type: str) -> str:
     str
         The Weaviate-defined where filter type.
     """
-    if _type == "valueTextArray":
+    if _type == "valueTextList":
         return "valueTextArray"
-    elif _type == "valueStringArray":
+    elif _type == "valueStringList":
         return "valueStringArray"
-    elif _type == "valueIntArray":
+    elif _type == "valueIntList":
         return "valueIntArray"
-    elif _type == "valueNumberArray":
+    elif _type == "valueNumberList":
         return "valueNumberArray"
-    elif _type == "valueBooleanArray":
-        return "valueBooleanArray"
-    elif _type == "valueDateArray":
+    elif _type == "valueBooleanList":
+        return "valueBooleanList"
+    elif _type == "valueDateList":
         return "valueDateArray"
     else:
         return _type

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -18,6 +18,7 @@ from requests.exceptions import HTTPError as RequestsHTTPError
 
 from weaviate.connect import Connection
 from weaviate.data.replication import ConsistencyLevel
+from weaviate.gql.filter import _find_value_type
 from weaviate.types import UUID
 from .requests import BatchRequest, ObjectsBatchRequest, ReferenceBatchRequest, BatchResponse
 from ..cluster import Cluster
@@ -1308,7 +1309,7 @@ class Batch:
         payload = {
             "match": {
                 "class": class_name,
-                "where": where,
+                "where": _clean_delete_objects_where(where),
             },
             "output": output,
             "dryRun": dry_run,
@@ -1795,3 +1796,53 @@ def _batch_create_error_handler(retry: int, max_retries: int, error: Exception) 
         flush=True,
     )
     time.sleep((retry + 1) * 2)
+
+
+def _clean_delete_objects_where(where: dict) -> dict:
+    """Converts the Python-defined where filter type into the Weaviate-defined
+    where filter type used in the Batch REST request endpoint.
+
+    Parameters
+    ----------
+    where : dict
+        The Python-defined where filter.
+
+    Returns
+    -------
+    dict
+        The Weaviate-defined where filter.
+    """
+    py_value_type = _find_value_type(where)
+    weaviate_value_type = _convert_value_type(py_value_type)
+    where[weaviate_value_type] = where.pop(py_value_type)
+    return where
+
+
+def _convert_value_type(_type: str) -> str:
+    """Converts the Python-defined where filter type into the Weaviate-defined
+    where filter type used in the Batch REST request endpoint.
+
+    Parameters
+    ----------
+    _type : str
+        The Python-defined where filter type.
+
+    Returns
+    -------
+    str
+        The Weaviate-defined where filter type.
+    """
+    if _type == "valueTextList":
+        return "valueTextArray"
+    elif _type == "valueStringList":
+        return "valueStringArray"
+    elif _type == "valueIntList":
+        return "valueIntArray"
+    elif _type == "valueNumberList":
+        return "valueNumberArray"
+    elif _type == "valueBooleanList":
+        return "valueBooleanArray"
+    elif _type == "valueDateList":
+        return "valueDateArray"
+    else:
+        return _type

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -23,6 +23,12 @@ VALUE_LIST_TYPES = {
     "valueNumberArray",
     "valueBooleanArray",
     "valueDateArray",
+    "valueStringList",
+    "valueTextList",
+    "valueIntList",
+    "valueNumberList",
+    "valueBooleanList",
+    "valueDateList",
 }
 
 VALUE_PRIMITIVE_TYPES = {
@@ -889,17 +895,17 @@ def _convert_value_type(_type: str) -> str:
     str
         The string interpretation of the type in Weaviate-defined `json` format.
     """
-    if _type == "valueTextArray":
+    if _type == "valueTextArray" or _type == "valueTextList":
         return "valueText"
-    elif _type == "valueStringArray":
+    elif _type == "valueStringArray" or _type == "valueStringList":
         return "valueString"
-    elif _type == "valueIntArray":
+    elif _type == "valueIntArray" or _type == "valueIntList":
         return "valueInt"
-    elif _type == "valueNumberArray":
+    elif _type == "valueNumberArray" or _type == "valueNumberList":
         return "valueNumber"
-    elif _type == "valueBooleanArray":
+    elif _type == "valueBooleanArray" or _type == "valueBooleanList":
         return "valueBoolean"
-    elif _type == "valueDateArray":
+    elif _type == "valueDateArray" or _type == "valueDateList":
         return "valueDate"
     else:
         return _type

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -17,12 +17,12 @@ from weaviate.exceptions import UnexpectedStatusCodeException
 from weaviate.util import get_vector, _sanitize_str
 
 VALUE_LIST_TYPES = {
-    "valueStringList",
-    "valueTextList",
-    "valueIntList",
-    "valueNumberList",
-    "valueBooleanList",
-    "valueDateList",
+    "valueStringArray",
+    "valueTextArray",
+    "valueIntArray",
+    "valueNumberArray",
+    "valueBooleanArray",
+    "valueDateArray",
 }
 
 VALUE_PRIMITIVE_TYPES = {
@@ -839,23 +839,23 @@ class Where(Filter):
             if self.value_type in ["valueInt", "valueNumber"]:
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{self.value}}}"
-            elif self.value_type in ["valueIntList", "valueNumberList"]:
+            elif self.value_type in ["valueIntArray", "valueNumberArray"]:
                 _check_is_list(self.value, self.value_type)
                 gql += f"{self.value}}}"
             elif self.value_type in ["valueText", "valueString"]:
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_sanitize_str(self.value)}}}"
-            elif self.value_type in ["valueTextList", "valueStringList"]:
+            elif self.value_type in ["valueTextArray", "valueStringArray"]:
                 _check_is_list(self.value, self.value_type)
                 val = [_sanitize_str(v) for v in self.value]
                 gql += f"{_render_list(val)}}}"
             elif self.value_type == "valueBoolean":
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_bool_to_str(self.value)}}}"
-            elif self.value_type == "valueBooleanList":
+            elif self.value_type == "valueBooleanArray":
                 _check_is_list(self.value, self.value_type)
                 gql += f"{_render_list(self.value)}}}"
-            elif self.value_type == "valueDateList":
+            elif self.value_type == "valueDateArray":
                 _check_is_list(self.value, self.value_type)
                 gql += f"{_render_list(self.value)}}}"
             elif self.value_type == "valueGeoRange":
@@ -889,17 +889,17 @@ def _convert_value_type(_type: str) -> str:
     str
         The string interpretation of the type in Weaviate-defined `json` format.
     """
-    if _type == "valueTextList":
+    if _type == "valueTextArray":
         return "valueText"
-    elif _type == "valueStringList":
+    elif _type == "valueStringArray":
         return "valueString"
-    elif _type == "valueIntList":
+    elif _type == "valueIntArray":
         return "valueInt"
-    elif _type == "valueNumberList":
+    elif _type == "valueNumberArray":
         return "valueNumber"
-    elif _type == "valueBooleanList":
+    elif _type == "valueBooleanArray":
         return "valueBoolean"
-    elif _type == "valueDateList":
+    elif _type == "valueDateArray":
         return "valueDate"
     else:
         return _type

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -875,17 +875,19 @@ class Where(Filter):
 
 
 def _convert_value_type(_type: str) -> str:
-    """Convert the value type to match `json` formatting required by Weaviate.
+    """Convert the value type to match `json` formatting required by the Weaviate-defined
+    GraphQL endpoints. NOTE: This is crucially different to the Batch REST endpoints wherein
+    the where filter is also used.
 
     Parameters
     ----------
     _type : str
-        The type to be converted.
+        The Python-defined type to be converted.
 
     Returns
     -------
     str
-        The string interpretation of the type in `json` format.
+        The string interpretation of the type in Weaviate-defined `json` format.
     """
     if _type == "valueTextList":
         return "valueText"

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -16,13 +16,13 @@ from weaviate.error_msgs import FILTER_BEACON_V14_CLS_NS_W
 from weaviate.exceptions import UnexpectedStatusCodeException
 from weaviate.util import get_vector, _sanitize_str
 
-VALUE_LIST_TYPES = {
-    "valueStringList",
-    "valueTextList",
-    "valueIntList",
-    "valueNumberList",
-    "valueBooleanList",
-    "valueDateList",
+VALUE_ARRAY_TYPES = {
+    "valueStringArray",
+    "valueTextArray",
+    "valueIntArray",
+    "valueNumberArray",
+    "valueBooleanArray",
+    "valueDateArray",
 }
 
 VALUE_PRIMITIVE_TYPES = {
@@ -35,7 +35,7 @@ VALUE_PRIMITIVE_TYPES = {
     "valueGeoRange",
 }
 
-VALUE_TYPES = VALUE_LIST_TYPES.union(VALUE_PRIMITIVE_TYPES)
+VALUE_TYPES = VALUE_ARRAY_TYPES.union(VALUE_PRIMITIVE_TYPES)
 
 WHERE_OPERATORS = [
     "And",
@@ -792,7 +792,7 @@ class Where(Filter):
 
         if (
             self.operator in ["ContainsAny", "ContainsAll"]
-            and self.value_type not in VALUE_LIST_TYPES
+            and self.value_type not in VALUE_ARRAY_TYPES
         ):
             raise ValueError(
                 f"Operator {self.operator} requires a value of type {self.value_type}List. "
@@ -835,27 +835,27 @@ class Where(Filter):
 
     def __str__(self):
         if self.is_filter:
-            gql = f"where: {{path: {self.path} operator: {self.operator} {_convert_value_type(self.value_type)}: "
+            gql = f"where: {{path: {self.path} operator: {self.operator} {self.value_type}: "
             if self.value_type in ["valueInt", "valueNumber"]:
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{self.value}}}"
-            elif self.value_type in ["valueIntList", "valueNumberList"]:
+            elif self.value_type in ["valueIntArray", "valueNumberArray"]:
                 _check_is_list(self.value, self.value_type)
                 gql += f"{self.value}}}"
             elif self.value_type in ["valueText", "valueString"]:
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_sanitize_str(self.value)}}}"
-            elif self.value_type in ["valueTextList", "valueStringList"]:
+            elif self.value_type in ["valueTextArray", "valueStringArray"]:
                 _check_is_list(self.value, self.value_type)
                 val = [_sanitize_str(v) for v in self.value]
                 gql += f"{_render_list(val)}}}"
             elif self.value_type == "valueBoolean":
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_bool_to_str(self.value)}}}"
-            elif self.value_type == "valueBooleanList":
+            elif self.value_type == "valueBooleanArray":
                 _check_is_list(self.value, self.value_type)
                 gql += f"{_render_list(self.value)}}}"
-            elif self.value_type == "valueDateList":
+            elif self.value_type == "valueDateArray":
                 _check_is_list(self.value, self.value_type)
                 gql += f"{_render_list(self.value)}}}"
             elif self.value_type == "valueGeoRange":
@@ -872,35 +872,6 @@ class Where(Filter):
             operands_str.append(str(operand)[7:-1])
         operands = ", ".join(operands_str)
         return f"where: {{operator: {self.operator} operands: [{operands}]}} "
-
-
-def _convert_value_type(_type: str) -> str:
-    """Convert the value type to match `json` formatting required by Weaviate.
-
-    Parameters
-    ----------
-    _type : str
-        The type to be converted.
-
-    Returns
-    -------
-    str
-        The string interpretation of the type in `json` format.
-    """
-    if _type == "valueTextList":
-        return "valueText"
-    elif _type == "valueStringList":
-        return "valueString"
-    elif _type == "valueIntList":
-        return "valueInt"
-    elif _type == "valueNumberList":
-        return "valueNumber"
-    elif _type == "valueBooleanList":
-        return "valueBoolean"
-    elif _type == "valueDateList":
-        return "valueDate"
-    else:
-        return _type
 
 
 def _render_list(value: list) -> str:


### PR DESCRIPTION
This PR fixes a problem induced by the differing expected WhereFilter objects for the Batch delete objects REST endpoint, the filtering options on the Get GraphQL query, and the centralising Python-defined WhereFilter options.

Fundamentally, the GraphQL endpoint expects all keys as `value<>` determining the type based on the argument itself. The REST endpoint, however, expects the keys as `value<>Array` if they are lists. Finally, the Pythonic definition of these types is `value<>List` so conversion must be performed in each case to ensure validity of the user's request.

It also updates the Weaviate CI version to the latest PATCH.