### PR TITLE
move client-side filter check and error from gql.get to batch.delete_objects

### DIFF
--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -556,9 +556,6 @@ class TestWhere(unittest.TestCase):
         operator_error_msg = (
             lambda op: f"Operator {op} is not allowed. Allowed operators are: {', '.join(WHERE_OPERATORS)}"
         )
-        contains_operator_value_type_mismatch_msg = (
-            lambda op, vt: f"Operator {op} requires a value of type {vt}List. Given value type: {vt}"
-        )
         geo_operator_value_type_mismatch_msg = (
             lambda op, vt: f"Operator {op} requires a value of type valueGeoRange. Given value type: {vt}"
         )
@@ -602,18 +599,6 @@ class TestWhere(unittest.TestCase):
         with self.assertRaises(ValueError) as error:
             Where({"path": "some_path", "operator": "NotValid"})
         check_error_message(self, error, operator_error_msg("NotValid"))
-
-        with self.assertRaises(ValueError) as error:
-            Where({"path": "some_path", "operator": "ContainsAll", "valueString": "A"})
-        check_error_message(
-            self, error, contains_operator_value_type_mismatch_msg("ContainsAll", "valueString")
-        )
-
-        with self.assertRaises(ValueError) as error:
-            Where({"path": "some_path", "operator": "ContainsAny", "valueInt": 1})
-        check_error_message(
-            self, error, contains_operator_value_type_mismatch_msg("ContainsAny", "valueInt")
-        )
 
         with self.assertRaises(ValueError) as error:
             Where({"path": "some_path", "operator": "WithinGeoRange", "valueBoolean": True})

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -552,7 +552,7 @@ class TestWhere(unittest.TestCase):
         content_error_msg = lambda dt: f"Where filter is expected to be type dict but is {dt}"
         content_key_error_msg = "Filter is missing required fields `path` or `operands`. Given: "
         path_key_error = "Filter is missing required field `operator`. Given: "
-        dtype_no_value_error_msg = "Filter is missing required field 'value<TYPE>': "
+        dtype_no_value_error_msg = "'value<TYPE>' field is either missing or incorrect: "
         dtype_multiple_value_error_msg = "Multiple fields 'value<TYPE>' are not supported: "
         operator_error_msg = (
             lambda op: f"Operator {op} is not allowed. Allowed operators are: {', '.join(WHERE_OPERATORS)}"

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -790,7 +790,7 @@ class TestWhere(unittest.TestCase):
             str(Where(test_filter))
         assert (
             error.exception.args[0]
-            == f"Filter is missing required field 'value<TYPE>': {test_filter}. Valid values are: {VALUE_TYPES}."
+            == f"'value<TYPE>' field is either missing or incorrect: {test_filter}. Valid values are: {VALUE_TYPES}."
         )
 
 

--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -15,6 +15,7 @@ from weaviate.gql.filter import (
     Where,
     Ask,
     WHERE_OPERATORS,
+    VALUE_TYPES,
 )
 
 
@@ -780,15 +781,17 @@ class TestWhere(unittest.TestCase):
             self, error, value_is_list_err(["test-2021-02-02", "test-2021-02-03"], "valueDate")
         )
 
-        # test_filter = {
-        #     "path": ["name"],
-        #     "operator": "Equal",
-        #     "valueText": "😃",
-        # }
-        # result = str(Where(test_filter))
-        # self.assertEqual(
-        #     'where: {path: ["name"] operator: Equal valueText: "\\ud83d\\ude03"} ', str(result)
-        # )
+        test_filter = {
+            "path": ["name"],
+            "operator": "Equal",
+            "valueWrong": "whatever",
+        }
+        with self.assertRaises(ValueError) as error:
+            str(Where(test_filter))
+        assert (
+            error.exception.args[0]
+            == f"Filter is missing required field 'value<TYPE>': {test_filter}. Valid values are: {VALUE_TYPES}."
+        )
 
 
 class TestAskFilter(unittest.TestCase):

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -796,15 +796,6 @@ class Where(Filter):
         self.value_type = _find_value_type(content)
         self.value = content[self.value_type]
 
-        if (
-            self.operator in ["ContainsAny", "ContainsAll"]
-            and self.value_type not in VALUE_LIST_TYPES
-        ):
-            raise ValueError(
-                f"Operator {self.operator} requires a value of type {self.value_type}List. "
-                f"Given value type: {self.value_type}"
-            )
-
         if self.operator == "WithinGeoRange" and self.value_type != "valueGeoRange":
             raise ValueError(
                 f"Operator {self.operator} requires a value of type valueGeoRange. "

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -17,18 +17,21 @@ from weaviate.exceptions import UnexpectedStatusCodeException
 from weaviate.util import get_vector, _sanitize_str
 
 VALUE_LIST_TYPES = {
-    "valueStringArray",
-    "valueTextArray",
-    "valueIntArray",
-    "valueNumberArray",
-    "valueBooleanArray",
-    "valueDateArray",
     "valueStringList",
     "valueTextList",
     "valueIntList",
     "valueNumberList",
     "valueBooleanList",
     "valueDateList",
+}
+
+VALUE_ARRAY_TYPES = {
+    "valueStringArray",
+    "valueTextArray",
+    "valueIntArray",
+    "valueNumberArray",
+    "valueBooleanArray",
+    "valueDateArray",
 }
 
 VALUE_PRIMITIVE_TYPES = {
@@ -41,7 +44,7 @@ VALUE_PRIMITIVE_TYPES = {
     "valueGeoRange",
 }
 
-VALUE_TYPES = VALUE_LIST_TYPES.union(VALUE_PRIMITIVE_TYPES)
+VALUE_TYPES = VALUE_LIST_TYPES.union(VALUE_ARRAY_TYPES).union(VALUE_PRIMITIVE_TYPES)
 
 WHERE_OPERATORS = [
     "And",

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -22,7 +22,6 @@ VALUE_LIST_TYPES = {
     "valueIntList",
     "valueNumberList",
     "valueBooleanList",
-    "valueDateList",
 }
 
 VALUE_ARRAY_TYPES = {
@@ -31,7 +30,6 @@ VALUE_ARRAY_TYPES = {
     "valueIntArray",
     "valueNumberArray",
     "valueBooleanArray",
-    "valueDateArray",
 }
 
 VALUE_PRIMITIVE_TYPES = {

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -42,7 +42,8 @@ VALUE_PRIMITIVE_TYPES = {
     "valueGeoRange",
 }
 
-VALUE_TYPES = VALUE_LIST_TYPES.union(VALUE_ARRAY_TYPES).union(VALUE_PRIMITIVE_TYPES)
+ALL_VALUE_TYPES = VALUE_LIST_TYPES.union(VALUE_ARRAY_TYPES).union(VALUE_PRIMITIVE_TYPES)
+VALUE_TYPES = VALUE_ARRAY_TYPES.union(VALUE_PRIMITIVE_TYPES)
 
 WHERE_OPERATORS = [
     "And",
@@ -1139,7 +1140,7 @@ def _find_value_type(content: dict) -> str:
         If missing required fields.
     """
 
-    value_type = VALUE_TYPES & set(content.keys())
+    value_type = ALL_VALUE_TYPES & set(content.keys())
 
     if len(value_type) == 0:
         raise ValueError(

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -1144,7 +1144,7 @@ def _find_value_type(content: dict) -> str:
 
     if len(value_type) == 0:
         raise ValueError(
-            f"Filter is missing required field 'value<TYPE>': {content}. Valid values are: {VALUE_TYPES}."
+            f"'value<TYPE>' field is either missing or incorrect: {content}. Valid values are: {VALUE_TYPES}."
         )
     if len(value_type) != 1:
         raise ValueError(f"Multiple fields 'value<TYPE>' are not supported: {content}")


### PR DESCRIPTION
This PR removes a client-side conditional check on the the `Contains<>` filters due to its potentially confusing nature with respect to implementation of the `Where` filter in the underlying GraphQL request

It then reimplements this client-side check on the `batch.delete_objects` method where it is crucial that the user supplies the correct `value<>` type for the relevant filter, i.e. `value<>Array` with `Contains<>`