### PR TITLE
Support generic typed dicts in collection

### DIFF
--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -349,7 +349,7 @@ def test_ref_filters(client: weaviate.Client):
         filters=Filter(path=["ref", "TestFilterRef2", "int"]).greater_than(3)
     )
     assert len(objects) == 1
-    assert objects[0].data["name"] == "second"
+    assert objects[0].properties["name"] == "second"
 
 
 def test_ref_filters_multi_target(client: weaviate.Client):
@@ -402,10 +402,10 @@ def test_ref_filters_multi_target(client: weaviate.Client):
         filters=Filter(path=["ref", target, "int"]).greater_than(3)
     )
     assert len(objects) == 1
-    assert objects[0].data["name"] == "second"
+    assert objects[0].properties["name"] == "second"
 
     objects = from_collection.query.get_flat(
         filters=Filter(path=["ref", source, "name"]).equal("first")
     )
     assert len(objects) == 1
-    assert objects[0].data["name"] == "third"
+    assert objects[0].properties["name"] == "third"

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -52,7 +52,7 @@ def client():
 
 def test_with_existing_collection(client: weaviate.Client):
     obj = client.collection_model.get(Group).data.get_by_id(REF_TO_UUID)
-    assert obj.data.name == "Name"
+    assert obj.properties.name == "Name"
 
 
 @pytest.mark.parametrize(
@@ -84,12 +84,12 @@ def test_types(client: weaviate.Client, member_type, value, optional: bool):
     assert type(uuid_object) is uuid.UUID
 
     object_get = collection.data.get_by_id(uuid_object)
-    assert object_get.data == ModelTypes(name=value, uuid=uuid_object)
+    assert object_get.properties == ModelTypes(name=value, uuid=uuid_object)
 
     if optional:
         uuid_object_optional = collection.data.insert(ModelTypes(name=None))
         object_get_optional = collection.data.get_by_id(uuid_object_optional)
-        assert object_get_optional.data == ModelTypes(name=None, uuid=uuid_object_optional)
+        assert object_get_optional.properties == ModelTypes(name=None, uuid=uuid_object_optional)
 
 
 @pytest.mark.parametrize(
@@ -113,9 +113,9 @@ def test_types_annotates(client: weaviate.Client, member_type, annotation, value
     uuid_object = collection.data.insert(ModelTypes(name=value))
 
     object_get = collection.data.get_by_id(uuid_object)
-    assert type(object_get.data) is ModelTypes
+    assert type(object_get.properties) is ModelTypes
 
-    assert object_get.data.name == value
+    assert object_get.properties.name == value
 
 
 def test_create_and_delete(client: weaviate.Client):
@@ -145,8 +145,8 @@ def test_search(client: weaviate.Client):
     collection.data.insert(SearchTest(name="other words"))
 
     objects = collection.query.bm25_flat(query="test", return_properties=["name"])
-    assert type(objects[0].data) is SearchTest
-    assert objects[0].data.name == "test name"
+    assert type(objects[0].properties) is SearchTest
+    assert objects[0].properties.name == "test name"
 
 
 def test_tenants(client: weaviate.Client):
@@ -240,13 +240,13 @@ def test_multi_searches(client: weaviate.Client):
         return_properties=["name"],
         return_metadata=MetadataQuery(last_update_time_unix=True),
     )
-    assert objects[0].data.name == "some word"
+    assert objects[0].properties.name == "some word"
     assert objects[0].metadata.last_update_time_unix is not None
 
     objects = collection.query.bm25_flat(
         query="other", return_properties=["name"], return_metadata=MetadataQuery(uuid=True)
     )
-    assert objects[0].data.name == "other"
+    assert objects[0].properties.name == "other"
     assert objects[0].metadata.uuid is not None
     assert objects[0].metadata.last_update_time_unix is None
 
@@ -272,16 +272,16 @@ def test_multi_searches_with_references(client: weaviate.Client):
         return_properties=["name", "group"],
         return_metadata=MetadataQuery(last_update_time_unix=True),
     )
-    assert objects[0].data.name == "some word"
-    assert objects[0].data.group == REF_TO_UUID
+    assert objects[0].properties.name == "some word"
+    assert objects[0].properties.group == REF_TO_UUID
     assert objects[0].metadata.last_update_time_unix is not None
 
     objects = collection.query.bm25_flat(
         query="other",
         return_metadata=MetadataQuery(uuid=True),
     )
-    assert objects[0].data.name is None
-    assert objects[0].data.group is None
+    assert objects[0].properties.name is None
+    assert objects[0].properties.group is None
     assert objects[0].metadata.uuid is not None
     assert objects[0].metadata.last_update_time_unix is None
 
@@ -376,18 +376,18 @@ def test_update_properties(
         assert uuid_first is not None
         first = collection.data.get_by_id(uuid_first)
 
-        assert first.data.name == "first"
+        assert first.properties.name == "first"
         assert (
-            first.data.number == default
+            first.properties.number == default
             if default is not None and default != PydanticUndefined
             else default_factory()
             if default_factory is not None
-            else first.data.number is None
+            else first.properties.number is None
         )
 
         second = collection.data.get_by_id(uuid_second)
-        assert second.data.name == "second"
-        assert second.data.number == value_to_add
+        assert second.properties.name == "second"
+        assert second.properties.number == value_to_add
 
 
 def test_empty_search_returns_everything(client: weaviate.Client):
@@ -404,8 +404,8 @@ def test_empty_search_returns_everything(client: weaviate.Client):
     collection.data.insert(TestReturnEverythingORM(name="word"))
 
     objects = collection.query.bm25_flat(query="word")
-    assert objects[0].data.name is not None
-    assert objects[0].data.name == "word"
+    assert objects[0].properties.name is not None
+    assert objects[0].properties.name == "word"
     assert objects[0].metadata.uuid is not None
     assert objects[0].metadata.score is not None
     assert objects[0].metadata.last_update_time_unix is not None
@@ -427,7 +427,7 @@ def test_empty_return_properties(client: weaviate.Client):
     collection.data.insert(TestEmptyProperties(name="word"))
 
     objects = collection.query.bm25_flat(query="word", return_metadata=MetadataQuery(uuid=True))
-    assert objects[0].data.name is None
+    assert objects[0].properties.name is None
 
 
 @pytest.mark.skip(reason="ORM models do not support updating reference properties yet")
@@ -470,8 +470,8 @@ def test_model_with_datetime_property(client: weaviate.Client):
     collection.data.insert(TestDatetime(name="test", date=now))
     objects = collection.data.get()
     assert len(objects) == 1
-    assert objects[0].data.name == "test"
-    assert type(objects[0].data.date) is datetime
+    assert objects[0].properties.name == "test"
+    assert type(objects[0].properties.date) is datetime
 
     # assert objects[0].data.date == now
     # The same issue as in test_collection.py@introduce_date_parsing_to_collections occurs here

--- a/weaviate/collection/classes.py
+++ b/weaviate/collection/classes.py
@@ -11,6 +11,8 @@ from typing import (
     Set,
     TypeVar,
     Type,
+    TypeAlias,
+    TypedDict,
     Generic,
     get_args,
     get_origin,
@@ -706,12 +708,14 @@ class _MetadataReturn:
     is_consistent: Optional[bool] = None
 
 
-Properties = TypeVar("Properties")
+Properties = TypeVar("Properties", bound=Union[Dict[str, Any], TypedDict])
+
+P = TypeVar("P")
 
 
 @dataclass
-class _Object(Generic[Properties]):
-    data: Properties
+class _Object(Generic[P]):
+    properties: P
     metadata: _MetadataReturn
 
 
@@ -727,6 +731,18 @@ def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
         score=metadata.get("score"),
         is_consistent=metadata.get("isConsistent"),
     )
+
+
+Reference: TypeAlias = List[_Object[Properties]]
+
+
+def _extract_props_from_list_of_objects(typ):
+    """Extract inner type from List[_Object[T]]"""
+    if getattr(typ, "__origin__", None) == List:
+        inner_type = typ.__args__[0]
+        if getattr(inner_type, "__origin__", None) == _Object:
+            return inner_type.__args__[0]
+    return None
 
 
 @dataclass

--- a/weaviate/collection/classes.py
+++ b/weaviate/collection/classes.py
@@ -736,10 +736,10 @@ def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
 Reference: TypeAlias = List[_Object[Properties]]
 
 
-def _extract_props_from_list_of_objects(typ):
-    """Extract inner type from List[_Object[T]]"""
-    if getattr(typ, "__origin__", None) == List:
-        inner_type = typ.__args__[0]
+def _extract_props_from_list_of_objects(type_: List[_Object[Properties]]) -> Optional[Properties]:
+    """Extract inner type from List[_Object[Properties]]"""
+    if getattr(type_, "__origin__", None) == List:
+        inner_type = type_.__args__[0]
         if getattr(inner_type, "__origin__", None) == _Object:
             return inner_type.__args__[0]
     return None

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -1,61 +1,67 @@
-from typing import Optional
+from typing import Any, Dict, Generic, Optional, Type
 
-from weaviate.collection.classes import CollectionConfig
+from weaviate.collection.classes import CollectionConfig, Properties
 from weaviate.collection.collection_base import CollectionBase
 from weaviate.collection.config import _ConfigCollection
 from weaviate.collection.data import _DataCollection
-from weaviate.collection.grpc import _GrpcCollection, _RawObject
+from weaviate.collection.grpc import _GrpcCollection
 from weaviate.collection.tenants import _Tenants
 from weaviate.connect import Connection
 from weaviate.data.replication import ConsistencyLevel
 from weaviate.util import _capitalize_first_letter
 
 
-class CollectionObject:
+class CollectionObject(Generic[Properties]):
     def __init__(
         self,
         connection: Connection,
         name: str,
-        config: _ConfigCollection,
+        type_: Type[Properties],
         consistency_level: Optional[ConsistencyLevel] = None,
         tenant: Optional[str] = None,
     ) -> None:
         self._connection = connection
         self.name = name
+        self.__type = type_
 
-        self.config = config
-        self.data = _DataCollection(connection, name, config, consistency_level, tenant)
-        self.query = _GrpcCollection[_RawObject](connection, name, tenant)
+        self.config = _ConfigCollection(self._connection, name)
+        self.data = _DataCollection[Properties](
+            connection, name, self.config, consistency_level, tenant, type_
+        )
+        self.query = _GrpcCollection(connection, name, tenant)
         self.tenants = _Tenants(connection, name)
 
         self.__tenant = tenant
         self.__consistency_level = consistency_level
 
-    def with_tenant(self, tenant: Optional[str] = None) -> "CollectionObject":
-        return CollectionObject(
-            self._connection, self.name, self.config, self.__consistency_level, tenant
+    def with_tenant(self, tenant: Optional[str] = None) -> "CollectionObject[Properties]":
+        return CollectionObject[Properties](
+            self._connection, self.name, self.__type, self.__consistency_level, tenant
         )
 
     def with_consistency_level(
         self, consistency_level: Optional[ConsistencyLevel] = None
-    ) -> "CollectionObject":
-        return CollectionObject(
-            self._connection, self.name, self.config, consistency_level, self.__tenant
+    ) -> "CollectionObject[Properties]":
+        return CollectionObject[Properties](
+            self._connection, self.name, self.__type, consistency_level, self.__tenant
         )
 
 
 class Collection(CollectionBase):
-    def create(self, config: CollectionConfig) -> CollectionObject:
+    def create(
+        self, config: CollectionConfig, data_model: Type[Properties] = Dict[str, Any]
+    ) -> CollectionObject[Properties]:
         name = super()._create(config)
         if config.name != name:
             raise ValueError(
                 f"Name of created collection ({name}) does not match given name ({config.name})"
             )
-        return self.get(name)
+        return self.get(name, data_model)
 
-    def get(self, name: str) -> CollectionObject:
-        config = _ConfigCollection(self._connection, name)
-        return CollectionObject(self._connection, name, config)
+    def get(
+        self, name: str, data_model: Type[Properties] = Dict[str, Any]
+    ) -> CollectionObject[Properties]:
+        return CollectionObject[data_model](self._connection, name, data_model)
 
     def delete(self, name: str) -> None:
         """Use this method to delete a collection from the Weaviate instance by its name.

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -48,12 +48,15 @@ class CollectionObject(Generic[Properties]):
 
 
 class Collection(CollectionBase):
-    def create(self, config: CollectionConfig) -> None:
+    def create(
+        self, config: CollectionConfig, data_model: Optional[Type[Properties]] = None
+    ) -> CollectionObject[Properties]:
         name = super()._create(config)
         if config.name != name:
             raise ValueError(
                 f"Name of created collection ({name}) does not match given name ({config.name})"
             )
+        return CollectionObject[Properties](self._connection, name, data_model)
 
     def get(
         self, name: str, data_model: Optional[Type[Properties]] = None

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -61,8 +61,8 @@ class Collection(CollectionBase):
         if data_model is not None:
             try:
                 data_model()
-            except TypeError as e:
-                raise ValueError(
+            except Exception as e:
+                raise TypeError(
                     "The only generics allowed to be used in data_model are Dicts and TypedDicts"
                 ) from e
         name = _capitalize_first_letter(name)

--- a/weaviate/collection/config.py
+++ b/weaviate/collection/config.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Optional, Type, Tuple
+from typing import Dict, Any, List, Optional, Type, Tuple, cast
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
@@ -39,7 +39,7 @@ class _ConfigBase:
             ) from conn_err
         if response.status_code != 200:
             raise UnexpectedStatusCodeException("Get collection configuration", response)
-        return response.json()
+        return cast(Dict[str, Any], response.json())
 
     def get(self) -> _CollectionConfig:
         """Get the configuration for this collection from Weaviate.

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -452,7 +452,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         metadata = _metadata_from_dict(obj)
         model_object = _Object[Model](
-            data=self.__model.model_validate(
+            properties=self.__model.model_validate(
                 {
                     **obj["properties"],
                     "uuid": metadata.uuid,
@@ -467,7 +467,7 @@ class _DataCollectionModel(Generic[Model], _Data):
         self.__model.model_validate(obj)
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(obj.props_to_dict()),
+            "properties": self._serialize_properties(obj.props_to_dict()),
             "id": str(obj.uuid),
         }
         if obj.vector is not None:
@@ -496,7 +496,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(obj.props_to_dict()),
+            "properties": self._serialize_properties(obj.props_to_dict()),
         }
         if obj.vector is not None:
             weaviate_obj["vector"] = obj.vector
@@ -508,7 +508,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(obj.props_to_dict()),
+            "properties": self._serialize_properties(obj.props_to_dict()),
         }
         if obj.vector is not None:
             weaviate_obj["vector"] = obj.vector

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -323,13 +323,13 @@ class _DataCollection(Generic[Properties], _Data):
         config: _ConfigBase,
         consistency_level: Optional[ConsistencyLevel],
         tenant: Optional[str],
-        type_: Type[Properties],
+        type_: Optional[Type[Properties]] = None,
     ):
         super().__init__(connection, name, config, consistency_level, tenant)
         self.__type = type_
 
     def __deserialize_properties(self, data: Dict[str, Any]) -> Properties:
-        hints = get_type_hints(self.__type) if self.__type is not Dict[str, Any] else {}
+        hints = get_type_hints(self.__type) if self.__type else {}
         return {key: self._deserialize_primitive(val, hints.get(key)) for key, val in data.items()}
 
     def _json_to_object(self, obj: Dict[str, Any]) -> _Object[Properties]:

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -480,35 +480,35 @@ class _Grpc:
             explain_score=add_props.explain_score if add_props.explain_score_present else None,
         )
 
-
-class _GrpcCollection(_Grpc):
-    def __deserialize_primitive(self, value: Any, type_value: Any) -> Any:
+    def _deserialize_primitive(self, value: Any, type_value: Any) -> Any:
         if type_value == uuid_lib.UUID:
             return uuid_lib.UUID(value)
         if type_value == datetime.datetime:
             return datetime.datetime.fromisoformat(value)
         if isinstance(type_value, list):
             return [
-                self.__deserialize_primitive(val, type_value[idx]) for idx, val in enumerate(value)
+                self._deserialize_primitive(val, type_value[idx]) for idx, val in enumerate(value)
             ]
         return value
 
+
+class _GrpcCollection(_Grpc):
     def __parse_result(
         self,
         properties: "weaviate_pb2.ResultProperties",
         type_: Optional[Type[Properties]],
     ) -> Properties:
-        hints = get_type_hints(type_) if type_ != Dict[str, Any] and type_ is not None else {}
+        hints = get_type_hints(type_) if type_ is not None else {}
 
         result: Properties = {}
 
         for name, non_ref_prop in properties.non_ref_properties.items():
-            result[name] = self.__deserialize_primitive(non_ref_prop, hints.get(name))
+            result[name] = self._deserialize_primitive(non_ref_prop, hints.get(name))
 
         for ref_prop in properties.ref_props:
             hint = hints.get(ref_prop.prop_name)
             if hint is not None:
-                referenced_property_type = _extract_props_from_list_of_objects(hint)
+                referenced_property_type = (lambda: "TODO: implement this")()
                 result[ref_prop.prop_name] = [
                     _Object(
                         properties=self.__parse_result(prop, referenced_property_type),
@@ -527,7 +527,9 @@ class _GrpcCollection(_Grpc):
 
         return result
 
-    def __result_to_object(self, res: SearchResult, type_: Type[Properties]) -> _Object[Properties]:
+    def __result_to_object(
+        self, res: SearchResult, type_: Optional[Type[Properties]]
+    ) -> _Object[Properties]:
         properties = self.__parse_result(res.properties, type_)
         metadata = self._extract_metadata_for_object(res.additional_properties)
         return _Object[Properties](properties=properties, metadata=metadata)
@@ -540,7 +542,7 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         return [
             self.__result_to_object(obj, type_)
@@ -554,7 +556,7 @@ class _GrpcCollection(_Grpc):
         returns: ReturnValues,
         options: Optional[GetOptions],
         filters: Optional[_Filters] = None,
-        type_: Type[Properties] = dict,
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         if options is None:
             options = GetOptions()
@@ -581,7 +583,7 @@ class _GrpcCollection(_Grpc):
         autocut: Optional[int] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         return [
             self.__result_to_object(obj, type_)
@@ -603,7 +605,7 @@ class _GrpcCollection(_Grpc):
         query: str,
         returns: ReturnValues,
         options: Optional[HybridOptions] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         if options is None:
             options = HybridOptions()
@@ -630,7 +632,7 @@ class _GrpcCollection(_Grpc):
         autocut: Optional[int] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         return [
             self.__result_to_object(obj, type_)
@@ -644,7 +646,7 @@ class _GrpcCollection(_Grpc):
         query: str,
         returns: ReturnValues,
         options: Optional[BM25Options] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         if options is None:
             options = BM25Options()
@@ -668,7 +670,7 @@ class _GrpcCollection(_Grpc):
         autocut: Optional[int] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         return [
             self.__result_to_object(obj, type_)
@@ -682,7 +684,7 @@ class _GrpcCollection(_Grpc):
         vector: List[float],
         returns: ReturnValues,
         options: Optional[NearVectorOptions] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         if options is None:
             options = NearVectorOptions()
@@ -706,7 +708,7 @@ class _GrpcCollection(_Grpc):
         autocut: Optional[int] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         return [
             self.__result_to_object(obj, type_)
@@ -720,7 +722,7 @@ class _GrpcCollection(_Grpc):
         obj: UUID,
         returns: ReturnValues,
         options: Optional[NearObjectOptions] = None,
-        type_: Type[Properties] = Dict[str, Any],
+        type_: Type[Properties] = None,
     ) -> List[_Object[Properties]]:
         if options is None:
             options = NearObjectOptions()
@@ -744,6 +746,230 @@ class _GrpcCollectionModel(Generic[Model], _Grpc):
         super().__init__(connection, name, tenant)
         self.model = model
 
-    def _result_to_object(self, obj: GrpcResult) -> _Object[Model]:
-        out = self._parse_out(obj)
-        return _Object[Model](data=self.model.model_validate(out), metadata=obj.metadata)
+    def __parse_result(
+        self,
+        properties: "weaviate_pb2.ResultProperties",
+    ) -> Model:
+        hints = get_type_hints(self.model)
+
+        result: Properties = {}
+
+        for name, non_ref_prop in properties.non_ref_properties.items():
+            result[name] = self._deserialize_primitive(non_ref_prop, hints.get(name))
+
+        for ref_prop in properties.ref_props:
+            hint = hints.get(ref_prop.prop_name)
+            if hint is not None:
+                referenced_property_type = _extract_props_from_list_of_objects(hint)
+                result[ref_prop.prop_name] = [
+                    _Object(
+                        properties=self.__parse_result(prop, referenced_property_type),
+                        metadata=self._extract_metadata_for_object(prop.metadata),
+                    )
+                    for prop in ref_prop.properties
+                ]
+            else:
+                raise ValueError(
+                    f"Property {ref_prop.prop_name} is not defined with a Reference[Model] type hint in the model {self.model}"
+                )
+
+        return self.model(**result)
+
+    def __result_to_object(self, res: SearchResult) -> _Object[Properties]:
+        properties = self.__parse_result(res.properties)
+        metadata = self._extract_metadata_for_object(res.additional_properties)
+        return _Object[Model](properties=properties, metadata=metadata)
+
+    def get_flat(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        after: Optional[UUID] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[PROPERTIES] = None,
+    ) -> List[_Object[Model]]:
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().get(
+                limit, offset, after, filters, return_metadata, return_properties
+            )
+        ]
+
+    def get_options(
+        self,
+        returns: ReturnValues,
+        options: Optional[GetOptions],
+        filters: Optional[_Filters] = None,
+    ) -> List[_Object[Model]]:
+        if options is None:
+            options = GetOptions()
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().get(
+                options.limit,
+                options.offset,
+                options.after,
+                filters,
+                returns.metadata,
+                returns.properties,
+            )
+        ]
+
+    def hybrid_flat(
+        self,
+        query: str,
+        alpha: Optional[float] = None,
+        vector: Optional[List[float]] = None,
+        properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        autocut: Optional[int] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[PROPERTIES] = None,
+    ) -> List[_Object[Model]]:
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().hybrid(
+                query,
+                alpha,
+                vector,
+                properties,
+                fusion_type,
+                limit,
+                autocut,
+                return_metadata,
+                return_properties,
+            )
+        ]
+
+    def hybrid_options(
+        self,
+        query: str,
+        returns: ReturnValues,
+        options: Optional[HybridOptions] = None,
+    ) -> List[_Object[Model]]:
+        if options is None:
+            options = HybridOptions()
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().hybrid(
+                query,
+                options.alpha,
+                options.vector,
+                options.properties,
+                options.fusion_type,
+                options.limit,
+                options.autocut,
+                returns.metadata,
+                returns.properties,
+            )
+        ]
+
+    def bm25_flat(
+        self,
+        query: str,
+        properties: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        autocut: Optional[int] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[PROPERTIES] = None,
+    ) -> List[_Object[Model]]:
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().bm25(
+                query, properties, limit, autocut, return_metadata, return_properties
+            )
+        ]
+
+    def bm25_options(
+        self,
+        query: str,
+        returns: ReturnValues,
+        options: Optional[BM25Options] = None,
+    ) -> List[_Object[Model]]:
+        if options is None:
+            options = BM25Options()
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().bm25(
+                query,
+                options.properties,
+                options.limit,
+                options.autocut,
+                returns.metadata,
+                returns.properties,
+            )
+        ]
+
+    def near_vector_flat(
+        self,
+        vector: List[float],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        autocut: Optional[int] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[PROPERTIES] = None,
+    ) -> List[_Object[Model]]:
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().near_vector(
+                vector, certainty, distance, autocut, return_metadata, return_properties
+            )
+        ]
+
+    def near_vector_options(
+        self,
+        vector: List[float],
+        returns: ReturnValues,
+        options: Optional[NearVectorOptions] = None,
+    ) -> List[_Object[Model]]:
+        if options is None:
+            options = NearVectorOptions()
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().near_vector(
+                vector,
+                options.certainty,
+                options.distance,
+                options.autocut,
+                returns.metadata,
+                returns.properties,
+            )
+        ]
+
+    def near_object_flat(
+        self,
+        obj: UUID,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        autocut: Optional[int] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[PROPERTIES] = None,
+    ) -> List[_Object[Model]]:
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().near_object(
+                obj, certainty, distance, autocut, return_metadata, return_properties
+            )
+        ]
+
+    def near_object_options(
+        self,
+        obj: UUID,
+        returns: ReturnValues,
+        options: Optional[NearObjectOptions] = None,
+    ) -> List[_Object[Model]]:
+        if options is None:
+            options = NearObjectOptions()
+        return [
+            self.__result_to_object(obj)
+            for obj in self._query().near_object(
+                obj,
+                options.certainty,
+                options.distance,
+                options.autocut,
+                returns.metadata,
+                returns.properties,
+            )
+        ]

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -498,7 +498,7 @@ class _GrpcCollection(_Grpc):
         properties: "weaviate_pb2.ResultProperties",
         type_: Optional[Type[Properties]],
     ) -> Properties:
-        hints = get_type_hints(type_) if type_ is not None else {}
+        hints = get_type_hints(type_) if type_ != Dict[str, Any] and type_ is not None else {}
 
         result: Properties = {}
 
@@ -508,7 +508,7 @@ class _GrpcCollection(_Grpc):
         for ref_prop in properties.ref_props:
             hint = hints.get(ref_prop.prop_name)
             if hint is not None:
-                referenced_property_type = (lambda: "TODO: implement this")()
+                referenced_property_type = _extract_props_from_list_of_objects(hint)
                 result[ref_prop.prop_name] = [
                     _Object(
                         properties=self.__parse_result(prop, referenced_property_type),
@@ -760,7 +760,7 @@ class _GrpcCollectionModel(Generic[Model], _Grpc):
         for ref_prop in properties.ref_props:
             hint = hints.get(ref_prop.prop_name)
             if hint is not None:
-                referenced_property_type = _extract_props_from_list_of_objects(hint)
+                referenced_property_type = (lambda: "TODO: implement this")()
                 result[ref_prop.prop_name] = [
                     _Object(
                         properties=self.__parse_result(prop, referenced_property_type),


### PR DESCRIPTION
This PR adds generic capability to the `client.collection` API for users to specify custom classes that inherit from `TypedDict` in order to customise the expected returns of their method calls.

The primary decision was to isolate ORM-like behaviour into the `client.collection_model` API and leave the classic API as TypeScript-y as possible. As such, all data structures in `client.collection` are dictionaries with custom type sprinkling allowed through `TypedDict` at the end without the need for heavy serialization/deserialization of JSON to classes.

Through this PR, the hierarchy of `gRPC` classes is decoupled also so that the `collection` and `collection_model` do not depend on each others implementations with common functionality uniquely abstracted into a generic-agnostic base class. 