### PR TITLE
ensure client functionality is aligned with docs usage

### DIFF
--- a/test/gql/test_filter.py
+++ b/test/gql/test_filter.py
@@ -626,9 +626,6 @@ class TestWhere(unittest.TestCase):
         value_is_not_list_err = (
             lambda v, t: f"Must provide a list when constructing where filter for {t} with {v}"
         )
-        value_is_list_err = (
-            lambda v, t: f"Cannot provide a list when constructing where filter for {t} with {v}"
-        )
 
         test_filter = {"path": ["name"], "operator": "Equal", "valueString": "A"}
         result = str(Where(test_filter))
@@ -760,26 +757,6 @@ class TestWhere(unittest.TestCase):
         with self.assertRaises(TypeError) as error:
             str(Where(test_filter))
         check_error_message(self, error, value_is_not_list_err("A", "valueTextArray"))
-
-        test_filter = {
-            "path": ["name"],
-            "operator": "GreaterThan",
-            "valueInt": [1, 2],
-        }
-        with self.assertRaises(TypeError) as error:
-            str(Where(test_filter))
-        check_error_message(self, error, value_is_list_err([1, 2], "valueInt"))
-
-        test_filter = {
-            "path": ["name"],
-            "operator": "Equal",
-            "valueDate": ["test-2021-02-02", "test-2021-02-03"],
-        }
-        with self.assertRaises(TypeError) as error:
-            str(Where(test_filter))
-        check_error_message(
-            self, error, value_is_list_err(["test-2021-02-02", "test-2021-02-03"], "valueDate")
-        )
 
         test_filter = {
             "path": ["name"],

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -835,33 +835,53 @@ class Where(Filter):
     def __str__(self):
         if self.is_filter:
             gql = f"where: {{path: {self.path} operator: {self.operator} {_convert_value_type(self.value_type)}: "
-            if self.value_type in ["valueInt", "valueNumber"]:
-                _check_is_not_list(self.value, self.value_type)
+            if self.value_type in [
+                "valueInt",
+                "valueNumber",
+                "valueIntArray",
+                "valueNumberArray",
+                "valueIntList",
+                "valueNumberList",
+            ]:
+                if self.value_type in [
+                    "valueIntList",
+                    "valueNumberList",
+                    "valueIntList",
+                    "valueNumberList",
+                ]:
+                    _check_is_list(self.value, self.value_type)
                 gql += f"{self.value}}}"
-            elif self.value_type in ["valueIntArray", "valueNumberArray"]:
-                _check_is_list(self.value, self.value_type)
-                gql += f"{self.value}}}"
-            elif self.value_type in ["valueText", "valueString"]:
-                _check_is_not_list(self.value, self.value_type)
-                gql += f"{_sanitize_str(self.value)}}}"
-            elif self.value_type in ["valueTextArray", "valueStringArray"]:
-                _check_is_list(self.value, self.value_type)
-                val = [_sanitize_str(v) for v in self.value]
-                gql += f"{_render_list(val)}}}"
-            elif self.value_type == "valueBoolean":
-                _check_is_not_list(self.value, self.value_type)
-                gql += f"{_bool_to_str(self.value)}}}"
-            elif self.value_type == "valueBooleanArray":
-                _check_is_list(self.value, self.value_type)
-                gql += f"{_render_list(self.value)}}}"
-            elif self.value_type == "valueDateArray":
-                _check_is_list(self.value, self.value_type)
-                gql += f"{_render_list(self.value)}}}"
+            elif self.value_type in [
+                "valueText",
+                "valueString",
+                "valueTextList",
+                "valueStringList",
+                "valueTextArray",
+                "valueStringArray",
+            ]:
+                if self.value_type in [
+                    "valueTextList",
+                    "valueStringList",
+                    "valueTextArray",
+                    "valueStringArray",
+                ]:
+                    _check_is_list(self.value, self.value_type)
+                if isinstance(self.value, list):
+                    val = [_sanitize_str(v) for v in self.value]
+                    gql += f"{_render_list(val)}}}"
+                else:
+                    gql += f"{_sanitize_str(self.value)}}}"
+            elif self.value_type in ["valueBoolean", "valueBooleanArray", "valueBooleanList"]:
+                if self.value_type in ["valueBooleanArray", "valueBooleanList"]:
+                    _check_is_list(self.value, self.value_type)
+                if isinstance(self.value, list):
+                    gql += f"{_render_list(self.value)}}}"
+                else:
+                    gql += f"{_bool_to_str(self.value)}}}"
             elif self.value_type == "valueGeoRange":
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_geo_range_to_str(self.value)}}}"
             else:
-                _check_is_not_list(self.value, self.value_type)
                 gql += f'"{self.value}"}}'
             return gql + " "
 

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -882,7 +882,7 @@ class Where(Filter):
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_geo_range_to_str(self.value)}}}"
             else:
-                gql += f'"{self.value}"}}'
+                gql += f"{self.value}}}"
             return gql + " "
 
         operands_str = []

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -882,7 +882,7 @@ class Where(Filter):
                 _check_is_not_list(self.value, self.value_type)
                 gql += f"{_geo_range_to_str(self.value)}}}"
             else:
-                gql += f"{self.value}}}"
+                gql += f'"{self.value}"}}'
             return gql + " "
 
         operands_str = []


### PR DESCRIPTION
This PR fixes problems surrounding passing lists to `value<>` fields and is an artefact of the previous confusions surrounding how data types must be passed to Weaviate through the GraphQL and REST functionalities.

In the previous release, the hard requirement was added to the GraphQL filters when this was neither necessary nor required. This PR undoes a final aspect that was missed from the latest patch and is causing confusing errors upon usage due to the difference between the available library and the valid documentation.

A user reported the following problem in the community Slack:
>Hi all,  what is the correct way to use the new ContainsAll/Any operator in the python client when filtering ? I see there have been some patches in the last few days but I can’t seem to make it work. I’m currently building up a list of operands with my containsAll one looking like:
```python
operands.append(
    {
        "operator": "ContainsAll",
        "valueText": [tag],
        "path": ["tags"],
    }
)
```
>But this always gives me the error `Cannot provide a list when constructing where filter for valueText with ['myTag'] `, however from what I can see in the docs for `containsAll/Any` this is the recommended structure. Any help would be appreciated.

The problem is [these conditions](https://github.com/weaviate/weaviate-python-client/pull/452/files#diff-d6a221fd36e69aa4e597a9fdb7fee921404cb0e9b44c5bd4b3f2d9eeb8976b5fL838-L842) that I added originally when I thought it was a requirement that the argument `value<>` match the value when making a where filter. This is only true of `batch.delete_objects` and not of `gql.filter` so it is leading to bugs since the docs report that `value<>` is used with an array argument `[]` , e.g. `"valueInt": [1]` _etc._

So it will no longer throw a client error when users say `"valueText": [tag]`, only throwing an error if they say `"valueTextArray": tag`, since that is demonstrably incorrect whereas the first is only semantically incorrect (it still works with Weaviate despite having confusing wording).
