### PR TITLE
Add TypedDict generics as previously opened in PR #446

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -75,7 +75,7 @@ def test_create_and_delete_with_dict_generic(client: weaviate.Client):
         properties=[Property(name="Name", data_type=DataType.TEXT)],
         vectorizer=Vectorizer.NONE,
     )
-    client.collection.create(collection_config)
+    client.collection.create(collection_config, Dict[str, str])
 
     client.collection.get(name, Dict[str, str])
     assert client.collection.exists(name)
@@ -90,18 +90,18 @@ def test_create_get_and_delete_with_typed_dict_generic(client: weaviate.Client):
         properties=[Property(name="Name", data_type=DataType.TEXT)],
         vectorizer=Vectorizer.NONE,
     )
-    client.collection.create(collection_config)
 
     class Right(TypedDict):
         name: str
 
+    client.collection.create(collection_config, Right)
     client.collection.get(name, Right)
     assert client.collection.exists(name)
     client.collection.delete(name)
     assert not client.collection.exists(name)
 
 
-wrong_generic_error_msg = "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
+WRONG_GENERIC_ERROR_MSG = "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
 
 
 def test_get_with_empty_class_generic(client: weaviate.Client):
@@ -110,7 +110,7 @@ def test_get_with_empty_class_generic(client: weaviate.Client):
 
     with pytest.raises(TypeError) as error:
         client.collection.get("NotImportant", Wrong)
-    assert error.value.args[0] == wrong_generic_error_msg
+    assert error.value.args[0] == WRONG_GENERIC_ERROR_MSG
 
 
 def test_get_with_dataclass_generic(client: weaviate.Client):
@@ -120,7 +120,7 @@ def test_get_with_dataclass_generic(client: weaviate.Client):
 
     with pytest.raises(TypeError) as error:
         client.collection.get("NotImportant", Wrong)
-    assert error.value.args[0] == wrong_generic_error_msg
+    assert error.value.args[0] == WRONG_GENERIC_ERROR_MSG
 
 
 def test_get_with_initialisable_class_generic(client: weaviate.Client):
@@ -132,7 +132,7 @@ def test_get_with_initialisable_class_generic(client: weaviate.Client):
 
     with pytest.raises(TypeError) as error:
         client.collection.get("NotImportant", Wrong)
-    assert error.value.args[0] == wrong_generic_error_msg
+    assert error.value.args[0] == WRONG_GENERIC_ERROR_MSG
 
 
 def test_get_with_pydantic_class_generic(client: weaviate.Client):
@@ -141,7 +141,7 @@ def test_get_with_pydantic_class_generic(client: weaviate.Client):
 
     with pytest.raises(TypeError) as error:
         client.collection.get("NotImportant", Wrong)
-    assert error.value.args[0] == wrong_generic_error_msg
+    assert error.value.args[0] == WRONG_GENERIC_ERROR_MSG
 
 
 def test_get_with_pydantic_dataclass_generic(client: weaviate.Client):
@@ -151,7 +151,7 @@ def test_get_with_pydantic_dataclass_generic(client: weaviate.Client):
 
     with pytest.raises(TypeError) as error:
         client.collection.get("NotImportant", NotAnotherOne)
-    assert error.value.args[0] == wrong_generic_error_msg
+    assert error.value.args[0] == WRONG_GENERIC_ERROR_MSG
 
 
 @pytest.mark.parametrize(

--- a/weaviate/collection/classes/data.py
+++ b/weaviate/collection/classes/data.py
@@ -1,8 +1,9 @@
 import uuid as uuid_package
 from dataclasses import dataclass
-from typing import Any, List, Optional, Dict, Union
+from typing import List, Optional, Dict, Union, Generic
 
 from pydantic import BaseModel, Field
+from weaviate.collection.classes.internal import Properties
 from weaviate.util import _to_beacons
 from weaviate.weaviate_types import UUID, UUIDS
 
@@ -83,7 +84,7 @@ class BatchReference:
 
 
 @dataclass
-class DataObject:
-    properties: Dict[str, Any]
+class DataObject(Generic[Properties]):
+    properties: Properties
     uuid: Optional[UUID] = None
     vector: Optional[List[float]] = None

--- a/weaviate/collection/classes/data.py
+++ b/weaviate/collection/classes/data.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Dict, Union
 
 from pydantic import BaseModel, Field
 from weaviate.util import _to_beacons
-from weaviate.weaviate_types import UUID
+from weaviate.weaviate_types import UUID, UUIDS
 
 
 class IncludesModel(BaseModel):
@@ -55,7 +55,7 @@ class _BatchReturn:
 
 @dataclass
 class ReferenceTo:
-    uuids: Union[List[UUID], UUID]
+    uuids: UUIDS
 
     @property
     def uuids_str(self) -> List[str]:

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -42,12 +42,3 @@ def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
         score=metadata.get("score"),
         is_consistent=metadata.get("isConsistent"),
     )
-
-
-def _extract_props_from_list_of_objects(type_: Any) -> Optional[Any]:
-    """Extract inner type from List[_Object[Properties]]"""
-    if getattr(type_, "__origin__", None) == List:
-        inner_type = type_.__args__[0]
-        if getattr(inner_type, "__origin__", None) == _Object:
-            return inner_type.__args__[0]
-    return None

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -3,8 +3,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, Generic, List, Mapping, Optional
 from typing_extensions import TypeAlias, TypeVar
 
-from weaviate.weaviate_types import UUIDS
-
 Properties = TypeVar("Properties", bound=Mapping[str, Any], default=Dict[str, Any])
 
 P = TypeVar("P")
@@ -53,15 +51,3 @@ def _extract_props_from_list_of_objects(type_: Any) -> Optional[Any]:
         if getattr(inner_type, "__origin__", None) == _Object:
             return inner_type.__args__[0]
     return None
-
-
-def _to_beacons(uuids: UUIDS, to_class: str = "") -> List[Dict[str, str]]:
-    if isinstance(uuids, uuid_package.UUID) or isinstance(
-        uuids, str
-    ):  # replace with isinstance(uuids, UUID) in 3.10
-        uuids = [uuids]
-
-    if len(to_class) > 0:
-        to_class = to_class + "/"
-
-    return [{"beacon": f"weaviate://localhost/{to_class}{uuid_to}"} for uuid_to in uuids]

--- a/weaviate/collection/classes/orm.py
+++ b/weaviate/collection/classes/orm.py
@@ -33,7 +33,7 @@ from weaviate.weaviate_types import PYTHON_TYPE_TO_DATATYPE, UUID
 
 @dataclass
 class CrossReference:
-    ref_type: Union[Type, str]
+    ref_type: Union[type, str]
 
     @property
     def name(self) -> str:

--- a/weaviate/collection/classes/orm.py
+++ b/weaviate/collection/classes/orm.py
@@ -33,7 +33,7 @@ from weaviate.weaviate_types import PYTHON_TYPE_TO_DATATYPE, UUID
 
 @dataclass
 class CrossReference:
-    ref_type: Union[type, str]
+    ref_type: Union[Type, str]
 
     @property
     def name(self) -> str:

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -63,12 +63,11 @@ class Collection(CollectionBase):
         self, name: str, data_model: Optional[Type[Properties]] = None
     ) -> CollectionObject[Properties]:
         if data_model is not None:
-            print(data_model, data_model.__bases__)
             try:
                 assert data_model.__bases__[0] == dict
             except Exception as e:
                 raise TypeError(
-                    "data_model can only be a dict or a class that inherits from TypedDict"
+                    "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
                 ) from e
         name = _capitalize_first_letter(name)
         return (

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -63,11 +63,12 @@ class Collection(CollectionBase):
         self, name: str, data_model: Optional[Type[Properties]] = None
     ) -> CollectionObject[Properties]:
         if data_model is not None:
+            print(data_model, data_model.__bases__)
             try:
-                data_model()
+                assert data_model.__bases__[0] == dict
             except Exception as e:
                 raise TypeError(
-                    "The only generics allowed to be used in data_model are Dicts and TypedDicts"
+                    "data_model can only be a dict or a class that inherits from TypedDict"
                 ) from e
         name = _capitalize_first_letter(name)
         return (

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -62,14 +62,13 @@ class Collection(CollectionBase):
     def get(
         self, name: str, data_model: Optional[Type[Properties]] = None
     ) -> CollectionObject[Properties]:
-        if data_model is not None:
-            if get_origin(data_model) is not dict:
-                try:
-                    assert data_model.__bases__[0] == dict
-                except Exception as e:
-                    raise TypeError(
-                        "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
-                    ) from e
+        if data_model is not None and get_origin(data_model) is not dict:
+            try:
+                assert data_model.__bases__[0] == dict
+            except Exception as e:
+                raise TypeError(
+                    "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
+                ) from e
         name = _capitalize_first_letter(name)
         return (
             CollectionObject[Properties](self._connection, name, data_model)

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -1,67 +1,86 @@
-from typing import Optional
+from typing import Generic, Optional, Type
 
 from weaviate.collection.classes.config import CollectionConfig
+from weaviate.collection.classes.internal import Properties
 from weaviate.collection.collection_base import CollectionBase
 from weaviate.collection.config import _ConfigCollection
 from weaviate.collection.data import _DataCollection
-from weaviate.collection.grpc import _GrpcCollection, _RawObject
+from weaviate.collection.grpc import _GrpcCollection
 from weaviate.collection.tenants import _Tenants
 from weaviate.connect import Connection
 from weaviate.data.replication import ConsistencyLevel
 from weaviate.util import _capitalize_first_letter
 
 
-class CollectionObject:
+class CollectionObject(Generic[Properties]):
     def __init__(
         self,
         connection: Connection,
         name: str,
-        config: _ConfigCollection,
+        type_: Optional[Type[Properties]] = None,
         consistency_level: Optional[ConsistencyLevel] = None,
         tenant: Optional[str] = None,
     ) -> None:
         self._connection = connection
         self.name = name
+        self.__type = type_
 
-        self.config = config
-        self.data = _DataCollection(connection, name, config, consistency_level, tenant)
-        self.query = _GrpcCollection[_RawObject](connection, name, tenant)
+        self.config = _ConfigCollection(self._connection, name)
+        self.data = _DataCollection[Properties](
+            connection, name, self.config, consistency_level, tenant, type_
+        )
+        self.query = _GrpcCollection(connection, name, tenant)
         self.tenants = _Tenants(connection, name)
 
         self.__tenant = tenant
         self.__consistency_level = consistency_level
 
-    def with_tenant(self, tenant: Optional[str] = None) -> "CollectionObject":
-        return CollectionObject(
-            self._connection, self.name, self.config, self.__consistency_level, tenant
+    def with_tenant(self, tenant: Optional[str] = None) -> "CollectionObject[Properties]":
+        return CollectionObject[Properties](
+            self._connection, self.name, self.__type, self.__consistency_level, tenant
         )
 
     def with_consistency_level(
         self, consistency_level: Optional[ConsistencyLevel] = None
-    ) -> "CollectionObject":
-        return CollectionObject(
-            self._connection, self.name, self.config, consistency_level, self.__tenant
+    ) -> "CollectionObject[Properties]":
+        return CollectionObject[Properties](
+            self._connection, self.name, self.__type, consistency_level, self.__tenant
         )
 
 
 class Collection(CollectionBase):
-    def create(self, config: CollectionConfig) -> CollectionObject:
+    def create(
+        self, config: CollectionConfig, data_model: Optional[Type[Properties]] = None
+    ) -> CollectionObject[Properties]:
         name = super()._create(config)
         if config.name != name:
             raise ValueError(
                 f"Name of created collection ({name}) does not match given name ({config.name})"
             )
-        return self.get(name)
+        return self.get(name, data_model)
 
-    def get(self, name: str) -> CollectionObject:
-        config = _ConfigCollection(self._connection, name)
-        return CollectionObject(self._connection, name, config)
+    def get(
+        self, name: str, data_model: Optional[Type[Properties]] = None
+    ) -> CollectionObject[Properties]:
+        if data_model is not None:
+            try:
+                data_model()
+            except Exception as e:
+                raise TypeError(
+                    "The only generics allowed to be used in data_model are Dicts and TypedDicts"
+                ) from e
+        name = _capitalize_first_letter(name)
+        return (
+            CollectionObject[Properties](self._connection, name, data_model)
+            if data_model
+            else CollectionObject(self._connection, name)
+        )
 
     def delete(self, name: str) -> None:
         """Use this method to delete a collection from the Weaviate instance by its name.
 
-        WARNING: If you have instances of client.collection_model.get() or client.collection_model.create()
-        for this collection within your code, they will be cease to function correctly after this operation.
+        WARNING: If you have instances of client.collection.get() or client.collection.create()
+        for this collection within your code, they will cease to function correctly after this operation.
 
         Parameters:
         - name: The name of the collection to delete.

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -1,4 +1,4 @@
-from typing import Generic, Optional, Type
+from typing import Generic, Optional, Type, get_origin
 
 from weaviate.collection.classes.config import CollectionConfig
 from weaviate.collection.classes.internal import Properties
@@ -63,12 +63,13 @@ class Collection(CollectionBase):
         self, name: str, data_model: Optional[Type[Properties]] = None
     ) -> CollectionObject[Properties]:
         if data_model is not None:
-            try:
-                assert data_model.__bases__[0] == dict
-            except Exception as e:
-                raise TypeError(
-                    "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
-                ) from e
+            if get_origin(data_model) is not dict:
+                try:
+                    assert data_model.__bases__[0] == dict
+                except Exception as e:
+                    raise TypeError(
+                        "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
+                    ) from e
         name = _capitalize_first_letter(name)
         return (
             CollectionObject[Properties](self._connection, name, data_model)

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -1,5 +1,17 @@
 import datetime
-from typing import Dict, Any, Optional, List, Tuple, Union, Generic, Type, cast, get_type_hints
+from typing import (
+    Dict,
+    Any,
+    Optional,
+    List,
+    Tuple,
+    Union,
+    Generic,
+    Type,
+    cast,
+    get_type_hints,
+    get_origin,
+)
 
 import uuid as uuid_package
 from google.protobuf.struct_pb2 import Struct
@@ -328,7 +340,11 @@ class _DataCollection(Generic[Properties], _Data):
         self.__type = type_
 
     def __deserialize_properties(self, data: Dict[str, Any]) -> Properties:
-        hints = get_type_hints(self.__type) if self.__type else {}
+        hints = (
+            get_type_hints(self.__type)
+            if self.__type and not get_origin(self.__type) == dict
+            else {}
+        )
         return cast(
             Properties,
             {key: self._deserialize_primitive(val, hints.get(key)) for key, val in data.items()},

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -337,19 +337,19 @@ class _DataCollection(Generic[Properties], _Data):
     def _json_to_object(self, obj: Dict[str, Any]) -> _Object[Properties]:
         props = self.__deserialize_properties(obj["properties"])
         return _Object(
-            data=cast(Properties, props),
+            properties=cast(Properties, props),
             metadata=_metadata_from_dict(obj),
         )
 
     def insert(
         self,
-        data: Properties,
+        properties: Properties,
         uuid: Optional[UUID] = None,
         vector: Optional[List[float]] = None,
     ) -> uuid_package.UUID:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._serialize_properties(data),
+            "properties": self._serialize_properties(properties),
             "id": str(uuid if uuid is not None else uuid_package.uuid4()),
         }
 
@@ -361,20 +361,24 @@ class _DataCollection(Generic[Properties], _Data):
     def insert_many(self, objects: List[DataObject]) -> _BatchReturn:
         return self._insert_many(objects)
 
-    def replace(self, data: Properties, uuid: UUID, vector: Optional[List[float]] = None) -> None:
+    def replace(
+        self, properties: Properties, uuid: UUID, vector: Optional[List[float]] = None
+    ) -> None:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._serialize_properties(data),
+            "properties": self._serialize_properties(properties),
         }
         if vector is not None:
             weaviate_obj["vector"] = vector
 
         self._replace(weaviate_obj, uuid=uuid)
 
-    def update(self, data: Properties, uuid: UUID, vector: Optional[List[float]] = None) -> None:
+    def update(
+        self, properties: Properties, uuid: UUID, vector: Optional[List[float]] = None
+    ) -> None:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._serialize_properties(data),
+            "properties": self._serialize_properties(properties),
         }
         if vector is not None:
             weaviate_obj["vector"] = vector

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -68,7 +68,7 @@ class _Data:
             weaviate_pb2.BatchObject(
                 class_name=self.name,
                 vector=obj["vector"] if obj["vector"] is not None else None,
-                uuid=str(obj["vector"]) if obj["vector"] is not None else str(uuid_package.uuid4()),
+                uuid=str(obj["uuid"]) if obj["uuid"] is not None else str(uuid_package.uuid4()),
                 properties=self.__parse_properties_grpc(obj["properties"]),
                 tenant=self._tenant,
             )
@@ -85,7 +85,7 @@ class _Data:
 
         for idx, obj in enumerate(weaviate_objs):
             if idx in errors:
-                error = Error(errors[idx], original_uuid=objects[idx].uuid)
+                error = Error(errors[idx], original_uuid=objects[idx].get("uuid"))
                 return_errors[idx] = error
                 all_responses[idx] = error
             else:

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, Any, Optional, List, Tuple, Union, Generic, Type, cast
+from typing import Dict, Any, Optional, List, Tuple, Union, Generic, Type, cast, get_type_hints
 
 import uuid as uuid_package
 from google.protobuf.struct_pb2 import Struct
@@ -16,10 +16,7 @@ from weaviate.collection.classes.data import (
     ReferenceToMultiTarget,
     _BatchReturn,
 )
-from weaviate.collection.classes.internal import (
-    _Object,
-    _metadata_from_dict,
-)
+from weaviate.collection.classes.internal import _Object, _metadata_from_dict, Properties
 from weaviate.collection.classes.orm import (
     Model,
 )
@@ -256,13 +253,15 @@ class _Data:
             params["consistency_level"] = self.__consistency_level
         return params, obj
 
-    def _parse_properties(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def _serialize_properties(self, data: Properties) -> Dict[str, Any]:
         return {
-            key: val.to_beacons() if isinstance(val, ReferenceTo) else self.__convert_primitive(val)
+            key: val.to_beacons()
+            if isinstance(val, ReferenceTo)
+            else self.__serialize_primitive(val)
             for key, val in data.items()
         }
 
-    def __convert_primitive(self, value: Any) -> Any:
+    def __serialize_primitive(self, value: Any) -> Any:
         if isinstance(value, uuid_package.UUID):
             return str(value)
         if isinstance(value, datetime.datetime):
@@ -271,7 +270,20 @@ class _Data:
                 value = value.replace(tzinfo=datetime.timezone.utc)
             return value.isoformat(sep="T", timespec="microseconds")
         if isinstance(value, list):
-            return [self.__convert_primitive(val) for val in value]
+            return [self.__serialize_primitive(val) for val in value]
+        return value
+
+    def _deserialize_primitive(self, value: Any, type_value: Optional[Any]) -> Any:
+        if type_value is None:
+            return value
+        if type_value == uuid_package.UUID:
+            return uuid_package.UUID(value)
+        if type_value == datetime.datetime:
+            return datetime.datetime.fromisoformat(value)
+        if isinstance(type_value, list):
+            return [
+                self._deserialize_primitive(val, type_value[idx]) for idx, val in enumerate(value)
+            ]
         return value
 
     @staticmethod
@@ -302,22 +314,42 @@ class _Data:
         )
 
 
-class _DataCollection(_Data):
-    def _json_to_object(self, obj: Dict[str, Any]) -> _Object:
+class _DataCollection(Generic[Properties], _Data):
+    def __init__(
+        self,
+        connection: Connection,
+        name: str,
+        config: _ConfigBase,
+        consistency_level: Optional[ConsistencyLevel],
+        tenant: Optional[str],
+        type_: Optional[Type[Properties]] = None,
+    ):
+        super().__init__(connection, name, config, consistency_level, tenant)
+        self.__type = type_
+
+    def __deserialize_properties(self, data: Dict[str, Any]) -> Properties:
+        hints = get_type_hints(self.__type) if self.__type else {}
+        return cast(
+            Properties,
+            {key: self._deserialize_primitive(val, hints.get(key)) for key, val in data.items()},
+        )
+
+    def _json_to_object(self, obj: Dict[str, Any]) -> _Object[Properties]:
+        props = self.__deserialize_properties(obj["properties"])
         return _Object(
-            data={prop: val for prop, val in obj["properties"].items()},
+            data=cast(Properties, props),
             metadata=_metadata_from_dict(obj),
         )
 
     def insert(
         self,
-        data: Dict[str, Any],
+        data: Properties,
         uuid: Optional[UUID] = None,
         vector: Optional[List[float]] = None,
     ) -> uuid_package.UUID:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(data),
+            "properties": self._serialize_properties(data),
             "id": str(uuid if uuid is not None else uuid_package.uuid4()),
         }
 
@@ -329,24 +361,20 @@ class _DataCollection(_Data):
     def insert_many(self, objects: List[DataObject]) -> _BatchReturn:
         return self._insert_many(objects)
 
-    def replace(
-        self, data: Dict[str, Any], uuid: UUID, vector: Optional[List[float]] = None
-    ) -> None:
+    def replace(self, data: Properties, uuid: UUID, vector: Optional[List[float]] = None) -> None:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(data),
+            "properties": self._serialize_properties(data),
         }
         if vector is not None:
             weaviate_obj["vector"] = vector
 
         self._replace(weaviate_obj, uuid=uuid)
 
-    def update(
-        self, data: Dict[str, Any], uuid: UUID, vector: Optional[List[float]] = None
-    ) -> None:
+    def update(self, data: Properties, uuid: UUID, vector: Optional[List[float]] = None) -> None:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(data),
+            "properties": self._serialize_properties(data),
         }
         if vector is not None:
             weaviate_obj["vector"] = vector
@@ -355,13 +383,13 @@ class _DataCollection(_Data):
 
     def get_by_id(
         self, uuid: UUID, metadata: Optional[GetObjectByIdMetadata] = None
-    ) -> Optional[_Object]:
+    ) -> Optional[_Object[Properties]]:
         ret = self._get_by_id(uuid=uuid, metadata=metadata)
         if ret is None:
             return ret
         return self._json_to_object(ret)
 
-    def get(self, metadata: Optional[GetObjectsMetadata] = None) -> List[_Object]:
+    def get(self, metadata: Optional[GetObjectsMetadata] = None) -> List[_Object[Properties]]:
         ret = self._get(metadata=metadata)
         if ret is None:
             return []
@@ -441,7 +469,7 @@ class _DataCollectionModel(Generic[Model], _Data):
         self.__model.model_validate(obj)
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(obj.props_to_dict()),
+            "properties": self._serialize_properties(obj.props_to_dict()),
             "id": str(obj.uuid),
         }
         if obj.vector is not None:
@@ -470,7 +498,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(obj.props_to_dict()),
+            "properties": self._serialize_properties(obj.props_to_dict()),
         }
         if obj.vector is not None:
             weaviate_obj["vector"] = obj.vector
@@ -482,7 +510,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
-            "properties": self._parse_properties(obj.props_to_dict()),
+            "properties": self._serialize_properties(obj.props_to_dict()),
         }
         if obj.vector is not None:
             weaviate_obj["vector"] = obj.vector

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -456,7 +456,7 @@ class _Grpc(SupportsResultToObject, Generic[Properties]):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> List[_Object]:
+    ) -> List[_Object[Properties]]:
         return [
             self._result_to_object(obj)
             for obj in self.__create_query().get(
@@ -616,7 +616,7 @@ class _Grpc(SupportsResultToObject, Generic[Properties]):
         autocut: Optional[int] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> List[_Object]:
+    ) -> List[_Object[Properties]]:
 
         return [
             self._result_to_object(obj)

--- a/weaviate/weaviate_classes.py
+++ b/weaviate/weaviate_classes.py
@@ -34,6 +34,7 @@ from weaviate.collection.classes.grpc import (
     NearVectorOptions,
     ReturnValues,
 )
+from weaviate.collection.classes.internal import Reference
 from weaviate.collection.classes.orm import (
     BaseProperty,
     CollectionModelConfig,
@@ -62,6 +63,7 @@ __all__ = [
     "ReferenceProperty",
     "ReferencePropertyMultiTarget",
     "Property",
+    "Reference",
     "ReferenceTo",
     "ReferenceToMultiTarget",
     "ReturnValues",


### PR DESCRIPTION
This PR adds generic capability to the client.collection API for users to specify custom classes that inherit from TypedDict in order to customise the expected returns of their method calls.

The primary decision was to isolate ORM-like behaviour into the client.collection_model API and leave the classic API as TypeScript-y as possible. As such, all data structures in `client.collection` are dictionaries with custom type sprinkling allowed through TypedDict at the end without the need for heavy serialization/deserialization of JSON to classes.