### PR TITLE
Rename data to properties in _Object and DataObject

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -162,7 +162,7 @@ def test_insert(client: weaviate.Client, use_typed_dict: bool):
     else:
         collection = client.collection.create(collection_config)
         uuid = collection.data.insert(data=insert_data)
-    name = collection.data.get_by_id(uuid).data["name"]
+    name = collection.data.get_by_id(uuid).properties["name"]
     assert name == insert_data["name"]
 
 
@@ -176,14 +176,14 @@ def test_insert_many(client: weaviate.Client):
     collection = client.collection.create(collection_config)
     ret = collection.data.insert_many(
         [
-            DataObject(data={"name": "some name"}, vector=[1, 2, 3]),
-            DataObject(data={"name": "some other name"}, uuid=uuid.uuid4()),
+            DataObject(properties={"name": "some name"}, vector=[1, 2, 3]),
+            DataObject(properties={"name": "some other name"}, uuid=uuid.uuid4()),
         ]
     )
     obj1 = collection.data.get_by_id(ret.uuids[0])
     obj2 = collection.data.get_by_id(ret.uuids[1])
-    assert obj1.data["name"] == "some name"
-    assert obj2.data["name"] == "some other name"
+    assert obj1.properties["name"] == "some name"
+    assert obj2.properties["name"] == "some other name"
 
     client.collection.delete(name)
 
@@ -216,7 +216,7 @@ def test_insert_many_with_refs(client: weaviate.Client):
     ret = collection.data.insert_many(
         [
             DataObject(
-                data={
+                properties={
                     "name": "some name",
                     "ref_single": ReferenceTo(uuids=[uuid_to1, uuid_to2]),
                     "ref_many": ReferenceToMultiTarget(uuids=uuid_from, target_collection=name),
@@ -224,7 +224,7 @@ def test_insert_many_with_refs(client: weaviate.Client):
                 vector=[1, 2, 3],
             ),
             DataObject(
-                data={
+                properties={
                     "name": "some other name",
                     "ref_single": ReferenceTo(uuids=uuid_to2),
                     "ref_many": ReferenceToMultiTarget(
@@ -236,15 +236,15 @@ def test_insert_many_with_refs(client: weaviate.Client):
         ]
     )
     obj1 = collection.data.get_by_id(ret.uuids[0])
-    assert obj1.data["name"] == "some name"
-    assert obj1.data["ref_single"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to1}"
-    assert obj1.data["ref_single"][1]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to2}"
-    assert obj1.data["ref_many"][0]["beacon"] == BEACON_START + f"/{name}/{uuid_from}"
+    assert obj1.properties["name"] == "some name"
+    assert obj1.properties["ref_single"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to1}"
+    assert obj1.properties["ref_single"][1]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to2}"
+    assert obj1.properties["ref_many"][0]["beacon"] == BEACON_START + f"/{name}/{uuid_from}"
 
     obj1 = collection.data.get_by_id(ret.uuids[1])
-    assert obj1.data["name"] == "some other name"
-    assert obj1.data["ref_single"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to2}"
-    assert obj1.data["ref_many"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to1}"
+    assert obj1.properties["name"] == "some other name"
+    assert obj1.properties["ref_single"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to2}"
+    assert obj1.properties["ref_many"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to1}"
 
 
 def test_insert_many_error(client: weaviate.Client):
@@ -257,15 +257,15 @@ def test_insert_many_error(client: weaviate.Client):
     collection = client.collection.create(collection_config)
     ret = collection.data.insert_many(
         [
-            DataObject(data={"wrong_name": "some name"}, vector=[1, 2, 3]),
-            DataObject(data={"name": "some other name"}, uuid=uuid.uuid4()),
-            DataObject(data={"other_thing": "is_wrong"}, vector=[1, 2, 3]),
+            DataObject(properties={"wrong_name": "some name"}, vector=[1, 2, 3]),
+            DataObject(properties={"name": "some other name"}, uuid=uuid.uuid4()),
+            DataObject(properties={"other_thing": "is_wrong"}, vector=[1, 2, 3]),
         ]
     )
     assert ret.has_errors
 
     obj = collection.data.get_by_id(ret.uuids[1])
-    assert obj.data["name"] == "some other name"
+    assert obj.properties["name"] == "some other name"
 
     assert len(ret.errors) == 2
     assert 0 in ret.errors and 2 in ret.errors
@@ -292,15 +292,15 @@ def test_insert_many_with_tenant(client: weaviate.Client):
 
     ret = tenant1.data.insert_many(
         [
-            DataObject(data={"name": "some name"}, vector=[1, 2, 3]),
-            DataObject(data={"name": "some other name"}, uuid=uuid.uuid4()),
+            DataObject(properties={"name": "some name"}, vector=[1, 2, 3]),
+            DataObject(properties={"name": "some other name"}, uuid=uuid.uuid4()),
         ]
     )
     assert not ret.has_errors
     obj1 = tenant1.data.get_by_id(ret.uuids[0])
     obj2 = tenant1.data.get_by_id(ret.uuids[1])
-    assert obj1.data["name"] == "some name"
-    assert obj2.data["name"] == "some other name"
+    assert obj1.properties["name"] == "some name"
+    assert obj2.properties["name"] == "some other name"
     assert tenant2.data.get_by_id(ret.uuids[0]) is None
     assert tenant2.data.get_by_id(ret.uuids[1]) is None
 
@@ -317,7 +317,7 @@ def test_replace(client: weaviate.Client):
     collection = client.collection.create(collection_config)
     uuid = collection.data.insert(data={"name": "some name"})
     collection.data.replace(data={"name": "other name"}, uuid=uuid)
-    assert collection.data.get_by_id(uuid).data["name"] == "other name"
+    assert collection.data.get_by_id(uuid).properties["name"] == "other name"
 
     client.collection.delete(name)
 
@@ -332,12 +332,12 @@ def test_replace_overwrites_vector(client: weaviate.Client):
     collection = client.collection.create(collection_config)
     uuid = collection.data.insert(data={"name": "some name"}, vector=[1, 2, 3])
     obj = collection.data.get_by_id(uuid, metadata=GetObjectsMetadata(vector=True))
-    assert obj.data["name"] == "some name"
+    assert obj.properties["name"] == "some name"
     assert obj.metadata.vector == [1, 2, 3]
 
     collection.data.replace(data={"name": "other name"}, uuid=uuid)
     obj = collection.data.get_by_id(uuid, metadata=GetObjectsMetadata(vector=True))
-    assert obj.data["name"] == "other name"
+    assert obj.properties["name"] == "other name"
     assert obj.metadata.vector is None
 
     client.collection.delete(name)
@@ -359,7 +359,7 @@ def test_replace_with_tenant(client: weaviate.Client):
 
     uuid = tenant1.data.insert(data={"name": "some name"})
     tenant1.data.replace(data={"name": "other name"}, uuid=uuid)
-    assert tenant1.data.get_by_id(uuid).data["name"] == "other name"
+    assert tenant1.data.get_by_id(uuid).properties["name"] == "other name"
     assert tenant2.data.get_by_id(uuid) is None
 
     client.collection.delete(name)
@@ -375,7 +375,7 @@ def test_update(client: weaviate.Client):
     collection = client.collection.create(collection_config)
     uuid = collection.data.insert(data={"name": "some name"})
     collection.data.update(data={"name": "other name"}, uuid=uuid)
-    assert collection.data.get_by_id(uuid).data["name"] == "other name"
+    assert collection.data.get_by_id(uuid).properties["name"] == "other name"
 
     client.collection.delete(name)
 
@@ -396,7 +396,7 @@ def test_update_with_tenant(client: weaviate.Client):
 
     uuid = tenant1.data.insert(data={"name": "some name"})
     tenant1.data.update(data={"name": "other name"}, uuid=uuid)
-    assert tenant1.data.get_by_id(uuid).data["name"] == "other name"
+    assert tenant1.data.get_by_id(uuid).properties["name"] == "other name"
     assert tenant2.data.get_by_id(uuid) is None
 
     client.collection.delete(name)
@@ -424,7 +424,7 @@ def test_types(client: weaviate.Client, data_type, value):
     uuid_object = collection.data.insert(data={name: value})
 
     object_get = collection.data.get_by_id(uuid_object)
-    assert object_get.data[name] == value
+    assert object_get.properties[name] == value
 
     client.collection.delete("Something")
 
@@ -448,24 +448,24 @@ def test_reference_add_delete_replace(client: weaviate.Client):
     )
     objects = collection.data.get()
     for obj in objects:
-        assert str(uuid_to) in "".join([ref["beacon"] for ref in obj.data["ref"]])
+        assert str(uuid_to) in "".join([ref["beacon"] for ref in obj.properties["ref"]])
 
     collection.data.reference_delete(
         from_uuid=uuid_from1, from_property="ref", ref=ReferenceTo(uuids=uuid_to)
     )
-    assert len(collection.data.get_by_id(uuid_from1).data["ref"]) == 0
+    assert len(collection.data.get_by_id(uuid_from1).properties["ref"]) == 0
 
     collection.data.reference_add(
         from_uuid=uuid_from2, from_property="ref", ref=ReferenceTo(uuids=uuid_to)
     )
     obj = collection.data.get_by_id(uuid_from2)
-    assert len(obj.data["ref"]) == 2
-    assert str(uuid_to) in "".join([ref["beacon"] for ref in obj.data["ref"]])
+    assert len(obj.properties["ref"]) == 2
+    assert str(uuid_to) in "".join([ref["beacon"] for ref in obj.properties["ref"]])
 
     collection.data.reference_replace(
         from_uuid=uuid_from2, from_property="ref", ref=ReferenceTo(uuids=[])
     )
-    assert len(collection.data.get_by_id(uuid_from2).data["ref"]) == 0
+    assert len(collection.data.get_by_id(uuid_from2).properties["ref"]) == 0
 
     client.collection.delete("SomethingElse")
     client.collection.delete("RefClass2")
@@ -699,10 +699,10 @@ def test_mono_references_grcp(client: weaviate.Client):
             ),
         ],
     )
-    assert objects[0].data["name"] == "find me"
-    assert objects[0].data["ref"][0].data["name"] == "B"
-    assert objects[0].data["ref"][0].data["ref"][0].data["name"] == "A1"
-    assert objects[0].data["ref"][0].data["ref"][1].data["name"] == "A2"
+    assert objects[0].properties["name"] == "find me"
+    assert objects[0].properties["ref"][0].properties["name"] == "B"
+    assert objects[0].properties["ref"][0].properties["ref"][0].properties["name"] == "A1"
+    assert objects[0].properties["ref"][0].properties["ref"][1].properties["name"] == "A2"
 
 
 def test_mono_references_grcp_typed_dicts(client: weaviate.Client):
@@ -791,16 +791,18 @@ def test_mono_references_grcp_typed_dicts(client: weaviate.Client):
         ],
         # type_=CPropsGet,
     )
-    assert objects[0].data["name"] == "find me"  # happy path (in type and in return_properties)
     assert (
-        objects[0].data.get("not_specified") is None
+        objects[0].properties["name"] == "find me"
+    )  # happy path (in type and in return_properties)
+    assert (
+        objects[0].properties.get("not_specified") is None
     )  # type is str but instance is None (in type but not in return_properties)
     assert (
-        objects[0].data.get("age") == 10
+        objects[0].properties.get("age") == 10
     )  # type is Any | None but instance is 10 (not in type but in return_properties)
-    assert objects[0].data["ref"][0].data["name"] == "B"
-    assert objects[0].data["ref"][0].data["ref"][0].data["name"] == "A1"
-    assert objects[0].data["ref"][0].data["ref"][1].data["name"] == "A2"
+    assert objects[0].properties["ref"][0].properties["name"] == "B"
+    assert objects[0].properties["ref"][0].properties["ref"][0].properties["name"] == "A1"
+    assert objects[0].properties["ref"][0].properties["ref"][1].properties["name"] == "A2"
 
 
 def test_multi_references_grcp(client: weaviate.Client):
@@ -859,9 +861,9 @@ def test_multi_references_grcp(client: weaviate.Client):
             ),
         ],
     )
-    assert objects[0].data["name"] == "first"
-    assert len(objects[0].data["ref"]) == 1
-    assert objects[0].data["ref"][0].data["name"] == "A"
+    assert objects[0].properties["name"] == "first"
+    assert len(objects[0].properties["ref"]) == 1
+    assert objects[0].properties["ref"][0].properties["name"] == "A"
 
     objects = C.query.bm25_flat(
         query="second",
@@ -877,9 +879,9 @@ def test_multi_references_grcp(client: weaviate.Client):
             ),
         ],
     )
-    assert objects[0].data["name"] == "second"
-    assert len(objects[0].data["ref"]) == 1
-    assert objects[0].data["ref"][0].data["name"] == "B"
+    assert objects[0].properties["name"] == "second"
+    assert len(objects[0].properties["ref"]) == 1
+    assert objects[0].properties["ref"][0].properties["name"] == "B"
 
     client.collection.delete("A")
     client.collection.delete("B")
@@ -929,11 +931,11 @@ def test_multi_searches(client: weaviate.Client):
         return_properties=["name"],
         return_metadata=MetadataQuery(last_update_time_unix=True),
     )
-    assert "name" in objects[0].data
+    assert "name" in objects[0].properties
     assert objects[0].metadata.last_update_time_unix is not None
 
     objects = collection.query.bm25_flat(query="other", return_metadata=MetadataQuery(uuid=True))
-    assert "name" not in objects[0].data
+    assert "name" not in objects[0].properties
     assert objects[0].metadata.uuid is not None
     assert objects[0].metadata.last_update_time_unix is None
 
@@ -980,14 +982,14 @@ def test_get_by_id_with_tenant(client: weaviate.Client):
 
     uuid1 = tenant1.data.insert({"name": "some name"})
     obj1 = tenant1.data.get_by_id(uuid1)
-    assert obj1.data["name"] == "some name"
+    assert obj1.properties["name"] == "some name"
 
     obj2 = tenant2.data.get_by_id(uuid1)
     assert obj2 is None
 
     uuid2 = tenant2.data.insert({"name": "some other name"})
     obj3 = tenant2.data.get_by_id(uuid2)
-    assert obj3.data["name"] == "some other name"
+    assert obj3.properties["name"] == "some other name"
 
     obj4 = tenant1.data.get_by_id(uuid2)
     assert obj4 is None
@@ -1012,7 +1014,7 @@ def test_get_with_tenant(client: weaviate.Client):
     tenant1.data.insert({"name": "some name"})
     objs = tenant1.data.get()
     assert len(objs) == 1
-    assert objs[0].data["name"] == "some name"
+    assert objs[0].properties["name"] == "some name"
 
     objs = tenant2.data.get()
     assert len(objs) == 0
@@ -1020,7 +1022,7 @@ def test_get_with_tenant(client: weaviate.Client):
     tenant2.data.insert({"name": "some other name"})
     objs = tenant2.data.get()
     assert len(objs) == 1
-    assert objs[0].data["name"] == "some other name"
+    assert objs[0].properties["name"] == "some other name"
 
     client.collection.delete("TestTenantGetWithTenant")
 
@@ -1038,9 +1040,9 @@ def test_add_property(client: weaviate.Client):
     uuid2 = collection.data.insert({"name": "second", "number": 5})
     obj1 = collection.data.get_by_id(uuid1)
     obj2 = collection.data.get_by_id(uuid2)
-    assert "name" in obj1.data
-    assert "name" in obj2.data
-    assert "number" in obj2.data
+    assert "name" in obj1.properties
+    assert "name" in obj2.properties
+    assert "number" in obj2.properties
 
     client.collection.delete("TestAddProperty")
 
@@ -1156,8 +1158,8 @@ def test_empty_search_returns_everything(client: weaviate.Client):
     collection.data.insert(data={"name": "word"})
 
     objects = collection.query.bm25_flat(query="word")
-    assert "name" in objects[0].data
-    assert objects[0].data["name"] == "word"
+    assert "name" in objects[0].properties
+    assert objects[0].properties["name"] == "word"
     assert objects[0].metadata.uuid is not None
     assert objects[0].metadata.score is not None
     assert objects[0].metadata.last_update_time_unix is not None
@@ -1187,7 +1189,9 @@ def test_insert_date_property(client: weaviate.Client, hours: int, minutes: int,
     assert (
         datetime.datetime.strptime(
             "".join(
-                obj.data["date"].rsplit(":", 1) if obj.data["date"][-1] != "Z" else obj.data["date"]
+                obj.properties["date"].rsplit(":", 1)
+                if obj.properties["date"][-1] != "Z"
+                else obj.properties["date"]
             ),
             "%Y-%m-%dT%H:%M:%S.%f%z",
         )
@@ -1292,9 +1296,9 @@ def test_return_list_properties(client: weaviate.Client):
     assert len(objects) == 1
 
     # remove dates because of problems comparing dates
-    dates_from_weaviate = objects[0].data.pop("dates")
+    dates_from_weaviate = objects[0].properties.pop("dates")
     dates2 = [datetime.datetime.fromisoformat(date) for date in dates_from_weaviate]
     dates = data.pop("dates")
     assert dates2 == dates
 
-    assert objects[0].data == data
+    assert objects[0].properties == data

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -353,7 +353,7 @@ def test_ref_filters(client: weaviate.Client):
         filters=Filter(path=["ref", "TestFilterRef2", "int"]).greater_than(3)
     )
     assert len(objects) == 1
-    assert objects[0].data["name"] == "second"
+    assert objects[0].properties["name"] == "second"
 
 
 def test_ref_filters_multi_target(client: weaviate.Client):
@@ -406,10 +406,10 @@ def test_ref_filters_multi_target(client: weaviate.Client):
         filters=Filter(path=["ref", target, "int"]).greater_than(3)
     )
     assert len(objects) == 1
-    assert objects[0].data["name"] == "second"
+    assert objects[0].properties["name"] == "second"
 
     objects = from_collection.query.get_flat(
         filters=Filter(path=["ref", source, "name"]).equal("first")
     )
     assert len(objects) == 1
-    assert objects[0].data["name"] == "third"
+    assert objects[0].properties["name"] == "third"

--- a/weaviate/collection/classes/data.py
+++ b/weaviate/collection/classes/data.py
@@ -84,6 +84,6 @@ class BatchReference:
 
 @dataclass
 class DataObject:
-    data: Dict[str, Any]
+    properties: Dict[str, Any]
     uuid: Optional[UUID] = None
     vector: Optional[List[float]] = None

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -23,7 +23,7 @@ class _MetadataReturn:
 
 @dataclass
 class _Object(Generic[P]):
-    data: P
+    properties: P
     metadata: _MetadataReturn
 
 

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -69,7 +69,7 @@ class _Data:
                 class_name=self.name,
                 vector=obj.vector if obj.vector is not None else None,
                 uuid=str(obj.uuid) if obj.uuid is not None else str(uuid_package.uuid4()),
-                properties=self.__parse_properties_grpc(obj.data),
+                properties=self.__parse_properties_grpc(obj.properties),
                 tenant=self._tenant,
             )
             for obj in objects
@@ -337,7 +337,7 @@ class _DataCollection(Generic[Properties], _Data):
     def _json_to_object(self, obj: Dict[str, Any]) -> _Object[Properties]:
         props = self.__deserialize_properties(obj["properties"])
         return _Object(
-            data=cast(Properties, props),
+            properties=cast(Properties, props),
             metadata=_metadata_from_dict(obj),
         )
 
@@ -454,7 +454,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         metadata = _metadata_from_dict(obj)
         model_object = _Object[Model](
-            data=self.__model.model_validate(
+            properties=self.__model.model_validate(
                 {
                     **obj["properties"],
                     "uuid": metadata.uuid,
@@ -484,7 +484,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         data_objects = [
             DataObject(
-                data=obj.props_to_dict(),
+                properties=obj.props_to_dict(),
                 uuid=obj.uuid,
                 vector=obj.vector,
             )

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -681,7 +681,7 @@ class _GrpcCollection(Generic[Properties], _Grpc[Properties]):
 
     def _result_to_object(self, obj: GrpcResult) -> _Object[Properties]:
         out = self._parse_out(obj)
-        return _Object[Properties](data=cast(Properties, out), metadata=obj.metadata)
+        return _Object[Properties](properties=cast(Properties, out), metadata=obj.metadata)
 
 
 class _GrpcCollectionModel(Generic[Model], _Grpc[Model]):
@@ -693,4 +693,4 @@ class _GrpcCollectionModel(Generic[Model], _Grpc[Model]):
 
     def _result_to_object(self, obj: GrpcResult) -> _Object[Model]:
         out = self._parse_out(obj)
-        return _Object[Model](data=self.model.model_validate(out), metadata=obj.metadata)
+        return _Object[Model](properties=self.model.model_validate(out), metadata=obj.metadata)


### PR DESCRIPTION
This PR renames the `data` attribute within `_Object` and `DataObject` for clarity on its role in relation to the created Collection configurations. Since these map directly to the properties within the Class schema, naming it properties seems more appropriate.