### PR TITLE
Catch JsonDecodeException and raise exception with response content

### DIFF
--- a/mock_tests/conftest.py
+++ b/mock_tests/conftest.py
@@ -30,6 +30,8 @@ def ready_mock(httpserver: HTTPServer):
 @pytest.fixture(scope="function")
 def weaviate_mock(ready_mock):
     ready_mock.expect_request("/v1/meta").respond_with_json({"version": "1.16"})
+    ready_mock.expect_request("/v1/nodes").respond_with_json({"nodes": [{"gitHash": "ABC"}]})
+
     yield ready_mock
 
 

--- a/mock_tests/test_automatic_retries.py
+++ b/mock_tests/test_automatic_retries.py
@@ -49,11 +49,14 @@ def test_automatic_retry_obs(weaviate_mock, error):
     n = (
         50 * batch_size
     )  # multiple of the batch size, otherwise it is difficult to calculate the number of expected errors
-    with client.batch(
+    client.batch.configure(
         batch_size=batch_size,
         num_workers=2,
         weaviate_error_retries=WeaviateErrorRetryConf(number_retries=3),
-    ) as batch:
+        dynamic=False,
+    )
+
+    with client.batch as batch:
         for i in range(n):
             added_uuids.append(uuid.uuid4())
             batch.add_data_object({"name": "test" + str(i)}, "test", added_uuids[-1])

--- a/mock_tests/test_batching_manual.py
+++ b/mock_tests/test_batching_manual.py
@@ -5,7 +5,7 @@ from mock_tests.conftest import MOCK_SERVER_URL
 
 
 def test_manual_batching_warning_object(recwarn, weaviate_mock):
-    weaviate_mock.expect_request("/v1/batch/objects").respond_with_json({})
+    weaviate_mock.expect_request("/v1/batch/objects").respond_with_json([])
 
     client = weaviate.Client(url=MOCK_SERVER_URL)
 
@@ -20,7 +20,7 @@ def test_manual_batching_warning_object(recwarn, weaviate_mock):
 
 
 def test_manual_batching_warning_ref(recwarn, weaviate_mock):
-    weaviate_mock.expect_request("/v1/batch/references").respond_with_json({})
+    weaviate_mock.expect_request("/v1/batch/references").respond_with_json([])
 
     client = weaviate.Client(url=MOCK_SERVER_URL)
     client.batch.configure(batch_size=None, dynamic=False)

--- a/mock_tests/test_exception.py
+++ b/mock_tests/test_exception.py
@@ -18,7 +18,7 @@ def test_json_decode_exception_dict(weaviate_mock):
 
 
 def test_json_decode_exception_list(weaviate_mock):
-    """Tests that expected timeout exception is raised."""
+    """Tests that JsonDecodeException is raised containing the correct error."""
 
     weaviate_mock.expect_request("/v1/schema/Test/shards").respond_with_data("JsonCannotParseThis")
 

--- a/mock_tests/test_exception.py
+++ b/mock_tests/test_exception.py
@@ -1,0 +1,28 @@
+import pytest
+
+import weaviate
+from mock_tests.conftest import MOCK_SERVER_URL
+from weaviate.exceptions import ResponseCannotBeDecodedException
+
+
+def test_json_decode_exception_dict(weaviate_mock):
+    """Tests that JsonDecodeException is raised containing the correct error."""
+
+    weaviate_mock.expect_request("/v1/schema").respond_with_data("JsonCannotParseThis")
+
+    client = weaviate.Client(url=MOCK_SERVER_URL)
+    with pytest.raises(ResponseCannotBeDecodedException) as e:
+        client.schema.get()
+
+        assert "JsonCannotParseThis" in e.value
+
+
+def test_json_decode_exception_list(weaviate_mock):
+    """Tests that expected timeout exception is raised."""
+
+    weaviate_mock.expect_request("/v1/schema/Test/shards").respond_with_data("JsonCannotParseThis")
+
+    client = weaviate.Client(url=MOCK_SERVER_URL)
+    with pytest.raises(ResponseCannotBeDecodedException) as e:
+        client.schema.get_class_shards("Test")
+        assert "JsonCannotParseThis" in e.value

--- a/mock_tests/test_resend.py
+++ b/mock_tests/test_resend.py
@@ -54,7 +54,7 @@ def test_retry_on_timeout(weaviate_no_auth_mock):
             # 75% of objects have to be resent
             assert len(request.json["objects"]) == n / 4 * 3
 
-        return Response(json.dumps({}))
+        return Response(json.dumps([]))
 
     weaviate_no_auth_mock.expect_request("/v1/batch/objects").respond_with_handler(
         handler_batch_objects
@@ -101,7 +101,7 @@ def test_retry_on_timeout_all_succesfull(weaviate_no_auth_mock):
         nonlocal n
         assert len(request.json["objects"]) == n  # all objects are send the first time
         time.sleep(1)  # cause timeout
-        return Response(json.dumps({}))
+        return Response(json.dumps([]))
 
     weaviate_no_auth_mock.expect_oneshot_request("/v1/batch/objects").respond_with_handler(
         handler_batch_objects

--- a/test/classification/test_classification.py
+++ b/test/classification/test_classification.py
@@ -47,9 +47,9 @@ class TestClassification(unittest.TestCase):
         check_startswith_error_message(self, error, unexpected_error_message)
 
         # valid calls
-        mock_conn = mock_connection_func("get", return_json="OK!", status_code=200)
+        mock_conn = mock_connection_func("get", return_json={"OK": "GOOD"}, status_code=200)
         result = Classification(mock_conn).get("d087b7c6-a115-5c89-8cb2-f25bdeb9bf92")
-        self.assertEqual(result, "OK!")
+        self.assertEqual(result, {"OK": "GOOD"})
 
     @patch("weaviate.classification.classification.Classification._check_status")
     def test_is_complete(self, mock_check_status):

--- a/test/gql/test_aggregate.py
+++ b/test/gql/test_aggregate.py
@@ -1,6 +1,6 @@
 import unittest
-from unittest.mock import patch
 from typing import List, Callable, Tuple
+from unittest.mock import patch
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
@@ -174,7 +174,7 @@ class TestAggregateBuilder(unittest.TestCase):
         check_error_message(self, error, requests_error_message)
 
         # weaviate.UnexpectedStatusCodeException
-        mock_obj = mock_connection_func("post", status_code=204)
+        mock_obj = mock_connection_func("post", status_code=404)
         self.aggregate._connection = mock_obj
         with self.assertRaises(UnexpectedStatusCodeException) as error:
             self.aggregate.do()

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -3,13 +3,13 @@ import signal
 import socket
 import tarfile
 import time
-import uuid
 from pathlib import Path
 from sys import platform
 from unittest.mock import patch
 
 import pytest
 import requests
+import uuid
 from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
@@ -18,7 +18,7 @@ from weaviate import embedded, EmbeddedOptions
 from weaviate.embedded import EmbeddedDB
 from weaviate.exceptions import WeaviateEmbeddedInvalidVersion, WeaviateStartUpError
 
-if platform != "linux":
+if platform != "linux" and platform != "darwin":
     pytest.skip("Currently only supported on linux", allow_module_level=True)
 
 

--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -8,11 +8,10 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.connect import Connection
 from weaviate.exceptions import (
-    UnexpectedStatusCodeException,
     BackupFailedException,
     EmptyResponseException,
 )
-from weaviate.util import _capitalize_first_letter, _type_request_response
+from weaviate.util import _capitalize_first_letter, _decode_json_response_dict
 
 STORAGE_NAMES = {
     "filesystem",
@@ -117,11 +116,8 @@ class Backup:
             raise RequestsConnectionError(
                 "Backup creation failed due to connection error."
             ) from conn_err
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Backup creation", response)
 
-        create_status: dict = response.json()
-
+        create_status = _decode_json_response_dict(response, "Backup creation")
         if wait_for_completion:
             while True:
                 status: dict = self.get_create_status(
@@ -171,10 +167,8 @@ class Backup:
             raise RequestsConnectionError(
                 "Backup creation status failed due to connection error."
             ) from conn_err
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Backup status check", response)
 
-        typed_response = _type_request_response(response.json())
+        typed_response = _decode_json_response_dict(response, "Backup status check")
         if typed_response is None:
             raise EmptyResponseException()
         return typed_response
@@ -251,10 +245,7 @@ class Backup:
             raise RequestsConnectionError(
                 "Backup restore failed due to connection error."
             ) from conn_err
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Backup restore", response)
-
-        restore_status: dict = response.json()
+        restore_status = _decode_json_response_dict(response, "Backup restore")
 
         if wait_for_completion:
             while True:
@@ -304,9 +295,8 @@ class Backup:
             raise RequestsConnectionError(
                 "Backup restore status failed due to connection error."
             ) from conn_err
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Backup restore status check", response)
-        typed_response = _type_request_response(response.json())
+
+        typed_response = _decode_json_response_dict(response, "Backup restore status check")
         if typed_response is None:
             raise EmptyResponseException()
         return typed_response

--- a/weaviate/classification/classification.py
+++ b/weaviate/classification/classification.py
@@ -4,8 +4,7 @@ Classification class definition.
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.connect import Connection
-from weaviate.exceptions import UnexpectedStatusCodeException
-from weaviate.util import get_valid_uuid
+from weaviate.util import get_valid_uuid, _decode_json_response_dict
 from .config_builder import ConfigBuilder
 
 
@@ -74,9 +73,8 @@ class Classification:
             raise RequestsConnectionError(
                 "Classification status could not be retrieved."
             ) from conn_err
-        if response.status_code == 200:
-            return response.json()
-        raise UnexpectedStatusCodeException("Get classification status", response)
+
+        return _decode_json_response_dict(response, "Get classification status")
 
     def is_complete(self, classification_uuid: str) -> bool:
         """

--- a/weaviate/cluster/cluster.py
+++ b/weaviate/cluster/cluster.py
@@ -7,11 +7,9 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.connect import Connection
 from weaviate.exceptions import (
-    UnexpectedStatusCodeException,
     EmptyResponseException,
 )
-
-from ..util import _capitalize_first_letter
+from ..util import _capitalize_first_letter, _decode_json_response_dict
 
 
 class Cluster:
@@ -65,9 +63,8 @@ class Cluster:
                 "Get nodes status failed due to connection error"
             ) from conn_err
 
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Nodes status", response)
-        nodes = response.json().get("nodes")
+        response_typed = _decode_json_response_dict(response, "Nodes status")
+        nodes = response_typed.get("nodes")
         if nodes is None or nodes == []:
             raise EmptyResponseException("Nodes status response returned empty")
         return nodes

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -13,6 +13,7 @@ from weaviate.auth import (
     AuthClientCredentials,
 )
 from weaviate.exceptions import MissingScopeException, AuthenticationFailedException
+from ..util import _decode_json_response_dict
 from ..warnings import _Warnings
 
 if TYPE_CHECKING:
@@ -65,9 +66,10 @@ class _Auth:
 
     def _get_token_endpoint(self) -> str:
         response_auth = requests.get(self._open_id_config_url, proxies=self._connection.proxies)
-        response = response_auth.json()["token_endpoint"]
-        assert isinstance(response, str)
-        return response
+        response_auth_json = _decode_json_response_dict(response_auth, "Get token endpoint")
+        token_endpoint = response_auth_json["token_endpoint"]
+        assert isinstance(token_endpoint, str)
+        return token_endpoint
 
     def get_auth_session(self) -> OAuth2Session:
         if isinstance(self._credentials, AuthBearerToken):

--- a/weaviate/contextionary/crud_contextionary.py
+++ b/weaviate/contextionary/crud_contextionary.py
@@ -5,6 +5,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.connect import Connection
 from weaviate.exceptions import UnexpectedStatusCodeException
+from weaviate.util import _decode_json_response_dict
 
 
 class Contextionary:
@@ -151,6 +152,4 @@ class Contextionary:
                 "text2vec-contextionary vector was not retrieved."
             ) from conn_err
         else:
-            if response.status_code == 200:
-                return response.json()
-            raise UnexpectedStatusCodeException("text2vec-contextionary vector", response)
+            return _decode_json_response_dict(response, "text2vec-contextionary vector")

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -80,7 +80,7 @@ class EmbeddedDB:
             response = requests.get(
                 "https://api.github.com/repos/weaviate/weaviate/releases/latest"
             )
-            latest = _decode_json_response_dict(response)
+            latest = _decode_json_response_dict(response, "get tag of latest weaviate release")
             self._set_download_url_from_version_tag(latest["tag_name"])
         else:
             raise exceptions.WeaviateEmbeddedInvalidVersion(self.options.version)

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -19,6 +19,7 @@ import validators as validators
 
 from weaviate import exceptions
 from weaviate.exceptions import WeaviateStartUpError
+from weaviate.util import _decode_json_response_dict
 
 DEFAULT_BINARY_PATH = str(Path.home() / ".cache/weaviate-embedded/")
 DEFAULT_PERSISTENCE_DATA_PATH = str(Path.home() / ".local/share/weaviate")
@@ -76,9 +77,10 @@ class EmbeddedDB:
             self._parsed_weaviate_version = version_tag
             self._set_download_url_from_version_tag(version_tag)
         elif self.options.version == "latest":
-            latest = requests.get(
+            response = requests.get(
                 "https://api.github.com/repos/weaviate/weaviate/releases/latest"
-            ).json()
+            )
+            latest = _decode_json_response_dict(response)
             self._set_download_url_from_version_tag(latest["tag_name"])
         else:
             raise exceptions.WeaviateEmbeddedInvalidVersion(self.options.version)

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -76,13 +76,13 @@ class UnexpectedStatusCodeException(WeaviateBaseError):
 class ResponseCannotBeDecodedException(WeaviateBaseError):
     def __init__(self, location: str, response: Response):
         """Raised when a weaviate response cannot be decoded to json
-        +
-            Parameters
-            ----------
-            location: str
-                From which code path the exception was raised.
-            response: requests.Response
-                The request response of which the status code was unexpected.
+
+        Parameters
+        ----------
+        location: str
+            From which code path the exception was raised.
+        response: requests.Response
+            The request response of which the status code was unexpected.
         """
         msg = f"Cannot decode response from weaviate {response} with content {response.content} for request from {location}"
         super().__init__(msg)

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -79,6 +79,8 @@ class ResponseCannotBeDecodedException(WeaviateBaseError):
         +
             Parameters
             ----------
+            location: str
+                From which code path the exception was raised.
             response: requests.Response
                 The request response of which the status code was unexpected.
         """

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -73,6 +73,24 @@ class UnexpectedStatusCodeException(WeaviateBaseError):
         return self._status_code
 
 
+class ResponseCannotBeDecodedException(WeaviateBaseError):
+    def __init__(self, location: str, response: Response):
+        """Raised when a weaviate response cannot be decoded to json
+        +
+            Parameters
+            ----------
+            response: requests.Response
+                The request response of which the status code was unexpected.
+        """
+        msg = f"Cannot decode response from weaviate {response} with content {response.content} for request from {location}"
+        super().__init__(msg)
+        self._status_code: int = response.status_code
+
+    @property
+    def status_code(self) -> int:
+        return self._status_code
+
+
 class ObjectAlreadyExistsException(WeaviateBaseError):
     """
     Object Already Exists Exception.

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -5,16 +5,15 @@ GraphQL abstract class for GraphQL commands to inherit from.
 import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from enum import Enum
 from json import dumps
 from typing import Any, Union
-from enum import Enum
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.connect import Connection
 from weaviate.error_msgs import FILTER_BEACON_V14_CLS_NS_W
-from weaviate.exceptions import UnexpectedStatusCodeException
-from weaviate.util import get_vector, _sanitize_str
+from weaviate.util import get_vector, _sanitize_str, _decode_json_response_dict
 
 VALUE_LIST_TYPES = {
     "valueStringList",
@@ -121,9 +120,8 @@ class GraphQL(ABC):
             response = self._connection.post(path="/graphql", weaviate_object={"query": query})
         except RequestsConnectionError as conn_err:
             raise RequestsConnectionError("Query was not successful.") from conn_err
-        if response.status_code == 200:
-            return response.json()  # success
-        raise UnexpectedStatusCodeException("Query was not successful", response)
+
+        return _decode_json_response_dict(response, "Query was not successful")
 
 
 class Filter(ABC):

--- a/weaviate/gql/query.py
+++ b/weaviate/gql/query.py
@@ -6,10 +6,10 @@ from typing import List, Any, Dict, Optional
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.connect import Connection
-from weaviate.exceptions import UnexpectedStatusCodeException
 from .aggregate import AggregateBuilder
 from .get import GetBuilder, PROPERTIES
 from .multi_get import MultiGetBuilder
+from ..util import _decode_json_response_dict
 
 
 class Query:
@@ -168,6 +168,5 @@ class Query:
             response = self._connection.post(path="/graphql", weaviate_object=json_query)
         except RequestsConnectionError as conn_err:
             raise RequestsConnectionError("Query not executed.") from conn_err
-        if response.status_code == 200:
-            return response.json()  # Successfully queried
-        raise UnexpectedStatusCodeException("GQL query failed", response)
+
+        return _decode_json_response_dict(response, "GQL query failed")

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -20,6 +20,8 @@ from weaviate.util import (
     _get_dict_from_object,
     _is_sub_schema,
     _capitalize_first_letter,
+    _decode_json_response_dict,
+    _decode_json_response_list,
 )
 
 _PRIMITIVE_WEAVIATE_TYPES_SET = {
@@ -551,9 +553,8 @@ class Schema:
             response = self._connection.get(path=path)
         except RequestsConnectionError as conn_err:
             raise RequestsConnectionError("Schema could not be retrieved.") from conn_err
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Get schema", response)
-        return response.json()
+
+        return _decode_json_response_dict(response, "Get schema")
 
     def get_class_shards(self, class_name: str) -> list:
         """
@@ -596,9 +597,8 @@ class Schema:
             raise RequestsConnectionError(
                 "Class shards' status could not be retrieved due to connection error."
             ) from conn_err
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Get shards' status", response)
-        return response.json()
+
+        return _decode_json_response_list(response, "Get shards' status")
 
     def update_class_shard(
         self,
@@ -691,12 +691,10 @@ class Schema:
                     f"Class shards' status could not be updated for shard '{_shard_name}' due to "
                     "connection error."
                 ) from conn_err
-            if response.status_code != 200:
-                raise UnexpectedStatusCodeException(
-                    f"Update shard '{_shard_name}' status",
-                    response,
-                )
-            to_return.append(response.json())
+
+            to_return.append(
+                _decode_json_response_dict(response, f"Update shard '{_shard_name}' status")
+            )
 
         if shard_name is None:
             return to_return
@@ -908,10 +906,8 @@ class Schema:
             response = self._connection.get(path=path)
         except RequestsConnectionError as conn_err:
             raise RequestsConnectionError("Could not get class tenants.") from conn_err
-        if response.status_code != 200:
-            raise UnexpectedStatusCodeException("Get classes tenants", response)
 
-        tenant_resp = response.json()
+        tenant_resp = _decode_json_response_list(response, "Get class tenants")
         return [Tenant._from_weaviate_object(tenant) for tenant in tenant_resp]
 
     def update_class_tenants(self, class_name: str, tenants: List[Tenant]) -> None:

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -785,7 +785,7 @@ def _decode_json_response_dict(
     if response is None:
         return None
 
-    if response.status_code == 200:
+    if 200 <= response.status_code < 300:
         try:
             json_response = response.json()
             return json_response
@@ -801,7 +801,7 @@ def _decode_json_response_list(
     if response is None:
         return None
 
-    if response.status_code == 200:
+    if 200 <= response.status_code < 300:
         try:
             json_response = response.json()
             return json_response

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -5,15 +5,20 @@ import base64
 import json
 import os
 import re
-import uuid as uuid_lib
 from enum import Enum, EnumMeta
 from io import BufferedReader
 from typing import Union, Sequence, Any, Optional, List, Dict, Tuple
 
 import requests
+import uuid as uuid_lib
 import validators
+from requests.exceptions import JSONDecodeError
 
-from weaviate.exceptions import SchemaValidationException
+from weaviate.exceptions import (
+    SchemaValidationException,
+    UnexpectedStatusCodeException,
+    ResponseCannotBeDecodedException,
+)
 from weaviate.types import NUMBERS
 
 PYPI_PACKAGE_URL = "https://pypi.org/pypi/weaviate-client/json"
@@ -772,3 +777,36 @@ def _type_request_response(json_response: Any) -> Optional[Dict[str, Any]]:
         return None
     assert isinstance(json_response, dict)
     return json_response
+
+
+def _decode_json_response_dict(
+    response: requests.Response, location: str
+) -> Optional[Dict[str, Any]]:
+    if response is None:
+        return None
+
+    if response.status_code == 200:
+        try:
+            json_response = response.json()
+            assert isinstance(json_response, dict)
+            return json_response
+        except JSONDecodeError:
+            raise ResponseCannotBeDecodedException(location, response)
+
+    raise UnexpectedStatusCodeException(location, response)
+
+
+def _decode_json_response_list(
+    response: requests.Response, location: str
+) -> Optional[List[Dict[str, Any]]]:
+    if response is None:
+        return None
+
+    if response.status_code == 200:
+        try:
+            json_response = response.json()
+            assert isinstance(json_response, list)
+            return json_response
+        except JSONDecodeError:
+            raise ResponseCannotBeDecodedException(location, response)
+    raise UnexpectedStatusCodeException(location, response)

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -788,7 +788,6 @@ def _decode_json_response_dict(
     if response.status_code == 200:
         try:
             json_response = response.json()
-            assert isinstance(json_response, dict)
             return json_response
         except JSONDecodeError:
             raise ResponseCannotBeDecodedException(location, response)
@@ -805,7 +804,6 @@ def _decode_json_response_list(
     if response.status_code == 200:
         try:
             json_response = response.json()
-            assert isinstance(json_response, list)
             return json_response
         except JSONDecodeError:
             raise ResponseCannotBeDecodedException(location, response)


### PR DESCRIPTION
Catches JsonDecode errors, raises a custom exception `ResponseCannotBeDecodedException` that contains the response.

Stack trace will look like this
```
            except JSONDecodeError:
>               raise ResponseCannotBeDecodedException(location, response)
E               weaviate.exceptions.ResponseCannotBeDecodedException: Cannot decode response from weaviate <Response [200]> with content b'JsonCannotParseThis' for request from Get shards' status
```
where `JsonCannotParseThis` was the response that is not valid Json