### PR TITLE
change Filter to be basic class rather than dataclass

### DIFF
--- a/weaviate/collection/classes/filters.py
+++ b/weaviate/collection/classes/filters.py
@@ -46,18 +46,17 @@ class _FilterValue(_Filters):
     operator: weaviate_pb2.Filters.Operator
 
 
-@dataclass
 class Filter:
-    path: Union[str, List[str]]
     length: bool = False
+    __internal_path: Union[str, List[str]]
 
-    def __post_init__(self):
-        if isinstance(self.path, str):
-            path = [self.path]
+    def __init__(self, path: Union[str, List[str]], length: bool = False):
+        if isinstance(path, str):
+            path = [path]
         else:
-            path = self.path
+            path = path
 
-        if self.length:
+        if length:
             self.__internal_path = "len(" + path[-1] + ")"
         else:
             self.__internal_path = path


### PR DESCRIPTION
This PR changes `Filter` to be a basic class rather than a dataclass

This is done so that `mypy` can be safely applied to the object without requiring convoluted type casting due to the fact that private variables, e.g. `__internal_path`, are forbidden in dataclasses