### PR TITLE
Mypy fixes 0409

### DIFF
--- a/weaviate/collection/classes/config.py
+++ b/weaviate/collection/classes/config.py
@@ -136,55 +136,55 @@ class PQEncoderConfigUpdate(ConfigUpdateModel):
 
 
 class PQConfigCreate(ConfigCreateModel):
-    bitCompression: bool = Field(False, alias="bit_compression")
+    bitCompression: bool = Field(default=False, alias="bit_compression")
     centroids: int = 256
     enabled: bool = False
     segments: int = 0
-    trainingLimit: int = Field(10000, alias="training_limit")
+    trainingLimit: int = Field(default=10000, alias="training_limit")
     encoder: PQEncoderConfigCreate = PQEncoderConfigCreate()
 
 
 class PQConfigUpdate(ConfigUpdateModel):
-    bitCompression: Optional[bool] = Field(None, alias="bit_compression")
+    bitCompression: Optional[bool] = Field(default=None, alias="bit_compression")
     centroids: Optional[int] = None
     enabled: Optional[bool] = None
     segments: Optional[int] = None
-    trainingLimit: Optional[int] = Field(None, alias="training_limit")
+    trainingLimit: Optional[int] = Field(default=None, alias="training_limit")
     encoder: Optional[PQEncoderConfigUpdate] = None
 
 
 class VectorIndexConfigCreate(ConfigCreateModel):
-    cleanupIntervalSeconds: int = Field(300, alias="cleanup_interval_seconds")
+    cleanupIntervalSeconds: int = Field(default=300, alias="cleanup_interval_seconds")
     distance: VectorDistance = VectorDistance.COSINE
-    dynamicEfMin: int = Field(100, alias="dynamic_ef_min")
-    dynamicEfMax: int = Field(500, alias="dynamic_ef_max")
-    dynamicEfFactor: int = Field(8, alias="dynamic_ef_factor")
-    efConstruction: int = Field(128, alias="ef_construction")
+    dynamicEfMin: int = Field(default=100, alias="dynamic_ef_min")
+    dynamicEfMax: int = Field(default=500, alias="dynamic_ef_max")
+    dynamicEfFactor: int = Field(default=8, alias="dynamic_ef_factor")
+    efConstruction: int = Field(default=128, alias="ef_construction")
     ef: int = -1
-    flatSearchCutoff: int = Field(40000, alias="flat_search_cutoff")
-    maxConnections: int = Field(64, alias="max_connections")
+    flatSearchCutoff: int = Field(default=40000, alias="flat_search_cutoff")
+    maxConnections: int = Field(default=64, alias="max_connections")
     pq: PQConfigCreate = PQConfigCreate(bit_compression=False, training_limit=10000)
     skip: bool = False
-    vectorCacheMaxObjects: int = Field(1000000000000, alias="vector_cache_max_objects")
+    vectorCacheMaxObjects: int = Field(default=1000000000000, alias="vector_cache_max_objects")
 
 
 class VectorIndexConfigUpdate(ConfigUpdateModel):
-    dynamicEfFactor: Optional[int] = Field(None, alias="dynamic_ef_factor")
-    dynamicEfMin: Optional[int] = Field(None, alias="dynamic_ef_min")
-    dynamicEfMax: Optional[int] = Field(None, alias="dynamic_ef_max")
+    dynamicEfFactor: Optional[int] = Field(default=None, alias="dynamic_ef_factor")
+    dynamicEfMin: Optional[int] = Field(default=None, alias="dynamic_ef_min")
+    dynamicEfMax: Optional[int] = Field(default=None, alias="dynamic_ef_max")
     ef: Optional[int] = None
-    flatSearchCutoff: Optional[int] = Field(None, alias="flat_search_cutoff")
+    flatSearchCutoff: Optional[int] = Field(default=None, alias="flat_search_cutoff")
     skip: Optional[bool] = None
-    vectorCacheMaxObjects: Optional[int] = Field(None, alias="vector_cache_max_objects")
+    vectorCacheMaxObjects: Optional[int] = Field(default=None, alias="vector_cache_max_objects")
     pq: Optional[PQConfigUpdate] = None
 
 
 class ShardingConfigCreate(ConfigCreateModel):
-    virtualPerPhysical: int = Field(128, alias="virtual_per_physical")
-    desiredCount: int = Field(1, alias="desired_count")
-    actualCount: int = Field(1, alias="actual_count")
-    desiredVirtualCount: int = Field(128, alias="desired_virtual_count")
-    actualVirtualCount: int = Field(128, alias="actual_virtual_count")
+    virtualPerPhysical: int = Field(default=128, alias="virtual_per_physical")
+    desiredCount: int = Field(default=1, alias="desired_count")
+    actualCount: int = Field(default=1, alias="actual_count")
+    desiredVirtualCount: int = Field(default=128, alias="desired_virtual_count")
+    actualVirtualCount: int = Field(default=128, alias="actual_virtual_count")
     key: str = "_id"
     strategy: str = "hash"
     function: str = "murmur3"
@@ -209,33 +209,33 @@ class BM25ConfigUpdate(ConfigUpdateModel):
 
 
 class StopwordsCreate(ConfigCreateModel):
-    preset: StopwordsPreset = StopwordsPreset.EN
-    additions: Optional[List[str]] = None
-    removals: Optional[List[str]] = None
+    preset: StopwordsPreset = Field(default=StopwordsPreset.EN)
+    additions: Optional[List[str]] = Field(default=None)
+    removals: Optional[List[str]] = Field(default=None)
 
 
 class StopwordsUpdate(ConfigUpdateModel):
-    preset: Optional[StopwordsPreset] = None
+    preset: Optional[StopwordsPreset] = Field(default=None)
     additions: Optional[List[str]] = None
     removals: Optional[List[str]] = None
 
 
 class InvertedIndexConfigCreate(ConfigCreateModel):
     bm25: BM25ConfigCreate = BM25ConfigCreate()
-    cleanupIntervalSeconds: int = Field(60, alias="cleanup_interval_seconds")
-    indexTimestamps: bool = Field(False, alias="index_timestamps")
-    indexPropertyLength: bool = Field(False, alias="index_property_length")
-    indexNullState: bool = Field(False, alias="index_null_state")
+    cleanupIntervalSeconds: int = Field(default=60, alias="cleanup_interval_seconds")
+    indexTimestamps: bool = Field(default=False, alias="index_timestamps")
+    indexPropertyLength: bool = Field(default=False, alias="index_property_length")
+    indexNullState: bool = Field(default=False, alias="index_null_state")
     stopwords: StopwordsCreate = StopwordsCreate()
 
 
 class InvertedIndexConfigUpdate(ConfigUpdateModel):
-    bm25: Optional[BM25ConfigUpdate] = None
-    cleanupIntervalSeconds: Optional[int] = Field(None, alias="cleanup_interval_seconds")
-    indexTimestamps: Optional[bool] = Field(None, alias="index_timestamps")
-    indexPropertyLength: Optional[bool] = Field(None, alias="index_property_length")
-    indexNullState: Optional[bool] = Field(None, alias="index_null_state")
-    stopwords: Optional[StopwordsUpdate] = None
+    bm25: Optional[BM25ConfigUpdate] = Field(default=None)
+    cleanupIntervalSeconds: Optional[int] = Field(default=None, alias="cleanup_interval_seconds")
+    indexTimestamps: Optional[bool] = Field(default=None, alias="index_timestamps")
+    indexPropertyLength: Optional[bool] = Field(default=None, alias="index_property_length")
+    indexNullState: Optional[bool] = Field(default=None, alias="index_null_state")
+    stopwords: Optional[StopwordsUpdate] = Field(default=None)
 
 
 class MultiTenancyConfig(ConfigCreateModel):
@@ -248,33 +248,37 @@ class VectorizerConfig(ConfigCreateModel):
 
 class PropertyVectorizerConfig(ConfigCreateModel):
     skip: bool = False
-    vectorizePropertyName: bool = Field(True, alias="vectorize_property_name")
+    vectorizePropertyName: bool = Field(default=True, alias="vectorize_property_name")
 
 
 class Text2VecContextionaryConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_CONTEXTIONARY, frozen=True, exclude=True)
-    vectorizeClassName: bool = Field(True, alias="vectorize_class_name")
+    vectorizer: Vectorizer = Field(
+        default=Vectorizer.TEXT2VEC_CONTEXTIONARY, frozen=True, exclude=True
+    )
+    vectorizeClassName: bool = Field(default=True, alias="vectorize_class_name")
 
 
 class Text2VecCohereConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_COHERE, frozen=True, exclude=True)
-    model: Literal["embed_multilingual_v2.0"] = "embed_multilingual_v2.0"
-    truncate: Literal["RIGHT", "NONE"] = "RIGHT"
+    vectorizer: Vectorizer = Field(default=Vectorizer.TEXT2VEC_COHERE, frozen=True, exclude=True)
+    model: Literal["embed_multilingual_v2.0"] = Field(default="embed_multilingual_v2.0")
+    truncate: Literal["RIGHT", "NONE"] = Field(default="RIGHT")
 
 
 class Text2VecHuggingFaceConfigOptions(ConfigCreateModel):
     waitForModel: Optional[bool] = Field(None, alias="wait_for_model")
-    useGPU: Optional[bool] = Field(None, alias="use_gpu")
-    useCache: Optional[bool] = Field(None, alias="use_cache")
+    useGPU: Optional[bool] = Field(default=None, alias="use_gpu")
+    useCache: Optional[bool] = Field(default=None, alias="use_cache")
 
 
 class Text2VecHuggingFaceConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_HUGGINGFACE, frozen=True, exclude=True)
-    model: Optional[str] = Field(None)
-    passageModel: Optional[str] = Field(None, alias="passage_model")
-    queryModel: Optional[str] = Field(None, alias="query_model")
-    endpointURL: Optional[str] = Field(None, alias="endpoint_url")
-    options: Optional[Text2VecHuggingFaceConfigOptions] = None
+    vectorizer: Vectorizer = Field(
+        default=Vectorizer.TEXT2VEC_HUGGINGFACE, frozen=True, exclude=True
+    )
+    model: Optional[str] = Field(default=None)
+    passageModel: Optional[str] = Field(default=None, alias="passage_model")
+    queryModel: Optional[str] = Field(default=None, alias="query_model")
+    endpointURL: Optional[str] = Field(default=None, alias="endpoint_url")
+    options: Optional[Text2VecHuggingFaceConfigOptions] = Field(default=None)
 
     @model_validator(mode="before")
     def validate_mutually_exclusive_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -293,11 +297,11 @@ class Text2VecHuggingFaceConfig(VectorizerConfig):
 
 
 class Text2VecOpenAIConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_OPENAI, frozen=True, exclude=True)
+    vectorizer: Vectorizer = Field(default=Vectorizer.TEXT2VEC_OPENAI, frozen=True, exclude=True)
     model: Optional[Literal["ada", "babbage", "curie", "davinci"]] = None
-    modelVersion: Optional[str] = Field(None, alias="model_version")
+    modelVersion: Optional[str] = Field(default=None, alias="model_version")
     type_: Optional[Literal["text", "code"]] = None
-    vectorizeClassName: bool = Field(True, alias="vectorize_class_name")
+    vectorizeClassName: bool = Field(default=True, alias="vectorize_class_name")
 
     def to_dict(self) -> Dict[str, Any]:
         ret_dict = super().to_dict()
@@ -309,33 +313,37 @@ class Text2VecOpenAIConfig(VectorizerConfig):
 
 
 class Text2VecAzureOpenAIConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_OPENAI, frozen=True, exclude=True)
-    resourceName: str = Field(..., alias="resource_name")
-    deploymentId: str = Field(..., alias="deployment_id")
+    vectorizer: Vectorizer = Field(default=Vectorizer.TEXT2VEC_OPENAI, frozen=True, exclude=True)
+    resourceName: str = Field(default=..., alias="resource_name")
+    deploymentId: str = Field(default=..., alias="deployment_id")
 
 
 class Text2VecPalmConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_PALM, frozen=True, exclude=True)
-    projectId: str = Field(..., alias="project_id")
-    apiEndpoint: Optional[str] = Field(None, alias="api_endpoint")
-    modelId: Optional[str] = Field(None, alias="model_id")
-    vectorizeClassName: bool = Field(True, alias="vectorize_class_name")
+    vectorizer: Vectorizer = Field(default=Vectorizer.TEXT2VEC_PALM, frozen=True, exclude=True)
+    projectId: str = Field(default=..., alias="project_id")
+    apiEndpoint: Optional[str] = Field(default=None, alias="api_endpoint")
+    modelId: Optional[str] = Field(default=None, alias="model_id")
+    vectorizeClassName: bool = Field(default=True, alias="vectorize_class_name")
 
 
 class Text2VecTransformersConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_TRANSFORMERS, frozen=True, exclude=True)
-    poolingStrategy: Literal["masked_mean", "cls"] = Field("masked_mean", alias="pooling_strategy")
-    vectorizeClassName: bool = Field(True, alias="vectorize_class_name")
+    vectorizer: Vectorizer = Field(
+        default=Vectorizer.TEXT2VEC_TRANSFORMERS, frozen=True, exclude=True
+    )
+    poolingStrategy: Literal["masked_mean", "cls"] = Field(
+        default="masked_mean", alias="pooling_strategy"
+    )
+    vectorizeClassName: bool = Field(default=True, alias="vectorize_class_name")
 
 
 class Text2VecGPT4AllConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_GPT4ALL, frozen=True, exclude=True)
-    vectorizeClassName: bool = Field(True, alias="vectorize_class_name")
+    vectorizer: Vectorizer = Field(default=Vectorizer.TEXT2VEC_GPT4ALL, frozen=True, exclude=True)
+    vectorizeClassName: bool = Field(default=True, alias="vectorize_class_name")
 
 
 class Img2VecNeuralConfig(VectorizerConfig):
-    vectorizer: Vectorizer = Field(Vectorizer.IMG2VEC_NEURAL, frozen=True, exclude=True)
-    imageFields: List[str] = Field(..., alias="image_fields")
+    vectorizer: Vectorizer = Field(default=Vectorizer.IMG2VEC_NEURAL, frozen=True, exclude=True)
+    imageFields: List[str] = Field(default=..., alias="image_fields")
 
 
 class Multi2VecClipConfigWeights(ConfigCreateModel):
@@ -387,7 +395,7 @@ class VectorizerFactory:
         return VectorizerConfig(vectorizer=Vectorizer.NONE)
 
     @classmethod
-    def auto(cls):
+    def auto(cls) -> None:
         """Returns a `VectorizerConfig` object with the `Vectorizer` auto-detected from the environment
         variables of the client or Weaviate itself"""
         # TODO: Can this be done?

--- a/weaviate/collection/classes/config.py
+++ b/weaviate/collection/classes/config.py
@@ -7,7 +7,6 @@ from pydantic import (
     ConfigDict,
     Field,
     model_validator,
-    confloat,
 )
 
 from weaviate.warnings import _Warnings
@@ -254,7 +253,7 @@ class PropertyVectorizerConfig(ConfigCreateModel):
 
 class Text2VecContextionaryConfig(VectorizerConfig):
     vectorizer: Vectorizer = Field(Vectorizer.TEXT2VEC_CONTEXTIONARY, frozen=True, exclude=True)
-    vectorizeClassName: bool = Field(True, alias="vectorize_property_name")
+    vectorizeClassName: bool = Field(True, alias="vectorize_class_name")
 
 
 class Text2VecCohereConfig(VectorizerConfig):
@@ -340,8 +339,8 @@ class Img2VecNeuralConfig(VectorizerConfig):
 
 
 class Multi2VecClipConfigWeights(ConfigCreateModel):
-    imageFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="image_fields")
-    textFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="text_fields")
+    imageFields: Optional[List[float]] = Field(None, alias="image_fields", ge=0, le=1)
+    textFields: Optional[List[float]] = Field(None, alias="text_fields", ge=0, le=1)
 
 
 class Multi2VecClipConfig(VectorizerConfig):
@@ -353,13 +352,13 @@ class Multi2VecClipConfig(VectorizerConfig):
 
 
 class Multi2VecBindConfigWeights(ConfigCreateModel):
-    audioFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="audio_fields")
-    depthFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="depth_fields")
-    imageFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="image_fields")
-    IMUFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="imu_fields")
-    textFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="text_fields")
-    thermalFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="thermal_fields")
-    videoFields: Optional[List[confloat(ge=0, le=1)]] = Field(None, alias="video_fields")
+    audioFields: Optional[List[float]] = Field(None, alias="audio_fields", ge=0, le=1)
+    depthFields: Optional[List[float]] = Field(None, alias="depth_fields", ge=0, le=1)
+    imageFields: Optional[List[float]] = Field(None, alias="image_fields", ge=0, le=1)
+    IMUFields: Optional[List[float]] = Field(None, alias="imu_fields", ge=0, le=1)
+    textFields: Optional[List[float]] = Field(None, alias="text_fields", ge=0, le=1)
+    thermalFields: Optional[List[float]] = Field(None, alias="thermal_fields", ge=0, le=1)
+    videoFields: Optional[List[float]] = Field(None, alias="video_fields", ge=0, le=1)
 
 
 class Multi2VecBindConfig(VectorizerConfig):
@@ -388,7 +387,7 @@ class VectorizerFactory:
         return VectorizerConfig(vectorizer=Vectorizer.NONE)
 
     @classmethod
-    def auto(cls) -> "VectorizerConfig":
+    def auto(cls):
         """Returns a `VectorizerConfig` object with the `Vectorizer` auto-detected from the environment
         variables of the client or Weaviate itself"""
         # TODO: Can this be done?

--- a/weaviate/collection/classes/grpc.py
+++ b/weaviate/collection/classes/grpc.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, Generic, List, Optional, Type, Union
 
 from pydantic import BaseModel
 
@@ -149,7 +149,7 @@ PROPERTIES = Union[List[Union[str, LinkTo]], str]
 
 
 @dataclass
-class ReturnValues:
+class ReturnValues(Generic[Properties]):
     properties: Optional[Union[PROPERTIES, Type[Properties]]] = None
     metadata: Optional[MetadataQuery] = None
 

--- a/weaviate/collection/classes/grpc.py
+++ b/weaviate/collection/classes/grpc.py
@@ -4,7 +4,7 @@ from typing import Dict, Generic, List, Optional, Type, Union
 from pydantic import BaseModel
 
 from weaviate.collection.classes.filters import _Filters
-from weaviate.collection.classes.types import Properties
+from weaviate.collection.classes.types import P
 from weaviate.util import BaseEnum
 from weaviate.weaviate_types import UUID
 
@@ -149,8 +149,8 @@ PROPERTIES = Union[List[Union[str, LinkTo]], str]
 
 
 @dataclass
-class ReturnValues(Generic[Properties]):
-    properties: Optional[Union[PROPERTIES, Type[Properties]]] = None
+class ReturnValues(Generic[P]):
+    properties: Optional[Union[PROPERTIES, Type[P]]] = None
     metadata: Optional[MetadataQuery] = None
 
 

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -53,6 +53,8 @@ class Reference(Generic[P]):
         return cls(None, target_collection, uuids)
 
     def _to_beacons(self) -> List[Dict[str, str]]:
+        if self.__uuids is None:
+            return []
         return _to_beacons(self.__uuids, self.__target_collection)
 
     @classmethod

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -1,7 +1,7 @@
 import sys
 import uuid as uuid_package
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, List, Optional, Union
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union, cast
 
 if sys.version_info < (3, 9):
     from typing_extensions import Annotated, get_type_hints, get_origin
@@ -40,7 +40,7 @@ class Reference(Generic[P]):
         target_collection: Optional[str],
         uuids: Optional[UUIDS],
     ):
-        self.objects = objects
+        self.__objects = objects
         self.__target_collection = target_collection if target_collection else ""
         self.__uuids = uuids
 
@@ -76,6 +76,10 @@ class Reference(Generic[P]):
     def target_collection(self) -> str:
         return self.__target_collection
 
+    @property
+    def objects(self) -> List[_Object[P]]:
+        return self.__objects or []
+
 
 def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
     return _MetadataReturn(
@@ -91,24 +95,27 @@ def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
     )
 
 
-def _extract_property_type_from_reference(type_: Reference[P]) -> Optional[P]:
+def _extract_property_type_from_reference(type_: Reference[P]) -> Type[P]:
     """Extract inner type from Reference[Properties]"""
     if getattr(type_, "__origin__", None) == Reference:
-        return type_.__args__[0]
-    return None
+        args = cast(List[Type[P]], getattr(type_, "__args__", None))
+        return args[0]
+    raise ValueError("Type is not Reference[Properties]")
 
 
 def _extract_property_type_from_annotated_reference(
     type_: Union[
         Annotated[Reference[P], MetadataQuery], Annotated[Reference[P], MetadataQuery, str]
     ]
-) -> Optional[P]:
+) -> Type[P]:
     """Extract inner type from Annotated[Reference[Properties]]"""
     if get_origin(type_) is Annotated:
-        inner_type = type_.__args__[0]
+        args = cast(List[Reference[Type[P]]], getattr(type_, "__args__", None))
+        inner_type = args[0]
         if get_origin(inner_type) is Reference:
-            return inner_type.__args__[0]
-    return None
+            inner_args = cast(List[Type[P]], getattr(inner_type, "__args__", None))
+            return inner_args[0]
+    raise ValueError("Type is not Annotated[Reference[Properties]]")
 
 
 def __create_link_to_from_annotated_reference(
@@ -120,11 +127,17 @@ def __create_link_to_from_annotated_reference(
 ) -> Union[LinkTo, LinkToMultiTarget]:
     """Create LinkTo or LinkToMultiTarget from Annotated[Reference[Properties]]"""
     assert get_origin(value) is Annotated
-    inner_type = value.__args__[0]
+    args = cast(List[Reference[Properties]], getattr(value, "__args__", None))
+    inner_type = args[0]
     assert get_origin(inner_type) is Reference
-    metadata = value.__metadata__[0]
-    try:
-        target_collection = value.__metadata__[1]
+    inner_type_metadata = cast(
+        Union[Tuple[MetadataQuery], Tuple[MetadataQuery, str]], getattr(value, "__metadata__", None)
+    )
+    metadata = inner_type_metadata[0]
+    if len(inner_type_metadata) == 2:
+        target_collection = cast(Tuple[MetadataQuery, str], inner_type_metadata)[
+            1
+        ]  # https://github.com/python/mypy/issues/1178
         return LinkToMultiTarget(
             link_on=link_on,
             metadata=metadata,
@@ -133,7 +146,7 @@ def __create_link_to_from_annotated_reference(
             ),
             target_collection=target_collection,
         )
-    except IndexError:
+    else:
         return LinkTo(
             link_on=link_on,
             metadata=metadata,
@@ -146,7 +159,7 @@ def __create_link_to_from_annotated_reference(
 def __create_link_to_from_reference(
     link_on: str,
     value: Reference[Properties],
-) -> Union[LinkTo, None]:
+) -> LinkTo:
     """Create LinkTo from Reference[Properties]"""
     return LinkTo(
         link_on=link_on,
@@ -157,7 +170,7 @@ def __create_link_to_from_reference(
     )
 
 
-def _extract_properties_from_data_model(type_: Properties) -> PROPERTIES:
+def _extract_properties_from_data_model(type_: Type[Properties]) -> PROPERTIES:
     """Extract properties of Properties recursively from Properties"""
     return [
         __create_link_to_from_annotated_reference(key, value)

--- a/weaviate/collection/classes/orm.py
+++ b/weaviate/collection/classes/orm.py
@@ -27,6 +27,7 @@ from weaviate.collection.classes.config import (
     ReferencePropertyMultiTarget,
     DataType,
 )
+from weaviate.collection.classes.types import T
 from weaviate.util import _capitalize_first_letter, _to_beacons
 from weaviate.weaviate_types import PYTHON_TYPE_TO_DATATYPE, UUID
 
@@ -188,16 +189,16 @@ class BaseProperty(BaseModel):
         }
 
     @staticmethod
-    def remove_optional_type(python_type: type) -> type:
-        is_list = get_origin(python_type) == list
+    def remove_optional_type(python_type: T) -> Union[Any, List[Any], T]:
         args = get_args(python_type)
         if len(args) == 0:
             return python_type
 
         return_type = [t for t in args if t is not None][0]
 
+        is_list = get_origin(python_type) == list
         if is_list:
-            return List[return_type]
+            return List[Any]
         else:
             return return_type
 

--- a/weaviate/collection/classes/types.py
+++ b/weaviate/collection/classes/types.py
@@ -15,5 +15,8 @@ To be clear: `_DataCollection[Properties]().with_data_model(TProperties) -> _Dat
 """
 
 P = TypeVar("P")
-"""`P` is a completely general type that is used wherever generic objects are defined that can be used
+"""`P` is a completely general type that is used wherever generic properties objects are defined that can be used
 within the non-ORM and ORM APIs interchangeably"""
+
+T = TypeVar("T")
+"""`T` is a completely general type that is used in any kind of generic"""

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from weaviate.collection.classes.config import CollectionConfig
-from weaviate.collection.classes.internal import Properties
 from weaviate.collection.collection_base import CollectionBase
 from weaviate.collection.config import _ConfigCollection
 from weaviate.collection.data import _DataCollection
@@ -24,14 +23,14 @@ class CollectionObject:
         self.name = name
 
         self.config = _ConfigCollection(self._connection, name)
-        self.data = _DataCollection(connection, name, consistency_level, tenant)
+        self.data = _DataCollection(connection, name, consistency_level, tenant)  # type: ignore
         self.query = _GrpcCollection(connection, name, tenant)
         self.tenants = _Tenants(connection, name)
 
         self.__tenant = tenant
         self.__consistency_level = consistency_level
 
-    def with_tenant(self, tenant: Optional[str] = None) -> "CollectionObject[Properties]":
+    def with_tenant(self, tenant: Optional[str] = None) -> "CollectionObject":
         return CollectionObject(self._connection, self.name, self.__consistency_level, tenant)
 
     def with_consistency_level(

--- a/weaviate/collection/config.py
+++ b/weaviate/collection/config.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, List, Optional, Type, Tuple
+from typing import Dict, Any, List, Optional, Type, Tuple, cast
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
@@ -39,7 +39,7 @@ class _ConfigBase:
             ) from conn_err
         if response.status_code != 200:
             raise UnexpectedStatusCodeException("Get collection configuration", response)
-        return response.json()
+        return cast(Dict[str, Any], response.json())
 
     def get(self) -> _CollectionConfig:
         """Get the configuration for this collection from Weaviate.

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -525,11 +525,11 @@ class _DataCollectionModel(Generic[Model], _Data):
             self.__model.model_validate(obj)
 
         data_objects = [
-            DataObject(
-                properties=obj.props_to_dict(),
-                uuid=obj.uuid,
-                vector=obj.vector,
-            )
+            {
+                "properties": obj.props_to_dict(),
+                "uuid": obj.uuid,
+                "vector": obj.vector,
+            }
             for obj in objects
         ]
 

--- a/weaviate/collection/tenants.py
+++ b/weaviate/collection/tenants.py
@@ -102,7 +102,7 @@ class _Tenants:
         tenant_resp: List[Dict[str, Any]] = response.json()
         return {tenant["name"]: Tenant(**tenant) for tenant in tenant_resp}
 
-    def update(self, tenants: List[Tenant]):
+    def update(self, tenants: List[Tenant]) -> None:
         loaded_tenants = [tenant.model_dump() for tenant in tenants]
 
         path = "/schema/" + self.__name + "/tenants"


### PR DESCRIPTION
This PR fixes a number of `mypy` errors that have developed within the `weaviate.collection` API. There are a few instances where `cast` is necessary due to issues with `mypy`, which are commented, and due to issues around accessing Python internal magic vars that are not stubbed.