### PR TITLE
Fix batch delete with operands

### DIFF
--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -185,9 +185,7 @@ def test_delete_objects_successes(client: weaviate.Client, objs: List[dict], whe
             "Test",
             where=where,
         )
-
     res = client.data_object.get()
-
     names = [obj["properties"]["name"] for obj in res["objects"]]
     for obj in objs:
         assert obj.get("name") not in names

--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -1,6 +1,6 @@
 import uuid
 from dataclasses import dataclass
-from typing import Union, Sequence, Optional
+from typing import List, Union, Sequence, Optional
 
 import pytest
 
@@ -58,6 +58,7 @@ def client():
             "properties": [
                 {"name": "test", "dataType": ["Test"]},
                 {"name": "name", "dataType": ["string"]},
+                {"name": "names", "dataType": ["string[]"]},
             ],
             "vectorizer": "none",
         }
@@ -83,65 +84,58 @@ def test_add_data_object(client: weaviate.Client, uuid: Optional[UUID], vector: 
     assert has_batch_errors(response) is False, str(response)
 
 
-def test_delete_objects(client: weaviate.Client):
-    with client.batch as batch:
-        batch.add_data_object(data_object={"name": "one"}, class_name="Test")
-        batch.add_data_object(data_object={"name": "two"}, class_name="test")
-        batch.add_data_object(data_object={"name": "three"}, class_name="Test")
-        batch.add_data_object(data_object={"name": "four"}, class_name="test")
-        batch.add_data_object(data_object={"name": "five"}, class_name="Test")
-
-    with client.batch as batch:
-        batch.delete_objects(
-            "Test",
-            where={
+@pytest.mark.parametrize(
+    "objs,where",
+    [
+        (
+            [
+                {"name": "zero"},
+            ],
+            {
+                "path": ["name"],
+                "operator": "NotEqual",
+                "valueText": "one",
+            },
+        ),
+        (
+            [
+                {"name": "one"},
+            ],
+            {
                 "path": ["name"],
                 "operator": "Equal",
                 "valueText": "one",
             },
-        )
-    res = client.data_object.get()
-    names = [obj["properties"]["name"] for obj in res["objects"]]
-    assert "one" not in names
-
-    with client.batch as batch:
-        batch.delete_objects(
-            "test",
-            where={
+        ),
+        (
+            [{"name": "two"}, {"name": "three"}],
+            {
                 "path": ["name"],
                 "operator": "ContainsAny",
                 "valueTextArray": ["two", "three"],
             },
-        )
-    res = client.data_object.get()
-    names = [obj["properties"]["name"] for obj in res["objects"]]
-    assert "two" not in names
-    assert "three" not in names
-
-    with client.batch as batch:
-        batch.delete_objects(
-            "Test",
-            where={
-                "path": ["name"],
+        ),
+        (
+            [
+                {"names": ["Tim", "Tom"], "name": "four"},
+            ],
+            {
+                "path": ["names"],
                 "operator": "ContainsAll",
-                "valueTextArray": ["four", "five"],
+                "valueTextArray": ["Tim", "Tom"],
             },
-        )
-    res = client.data_object.get()
-    names = [obj["properties"]["name"] for obj in res["objects"]]
-    assert "four" in names
-    assert "five" in names
-
-    with client.batch as batch:
-        batch.delete_objects(
-            "Test",
-            where={
-                "operator": "Or",
+        ),
+        (
+            [
+                {"names": ["Tim", "Tom"], "name": "five"},
+            ],
+            {
+                "operator": "And",
                 "operands": [
                     {
-                        "path": ["name"],
-                        "operator": "Equal",
-                        "valueText": "four",
+                        "path": ["names"],
+                        "operator": "ContainsAll",
+                        "valueTextArray": ["Tim", "Tom"],
                     },
                     {
                         "path": ["name"],
@@ -150,10 +144,56 @@ def test_delete_objects(client: weaviate.Client):
                     },
                 ],
             },
-        )
-    res = client.data_object.get()
-    assert len(res["objects"]) == 0
+        ),
+        (
+            [{"name": "six"}, {"name": "seven"}],
+            {
+                "operator": "Or",
+                "operands": [
+                    {
+                        "path": ["name"],
+                        "operator": "Equal",
+                        "valueText": "six",
+                    },
+                    {
+                        "path": ["name"],
+                        "operator": "Equal",
+                        "valueText": "seven",
+                    },
+                ],
+            },
+        ),
+        (
+            [
+                {"name": "eight"},
+            ],
+            {
+                "path": ["name"],
+                "operator": "Like",
+                "valueText": "eig*",
+            },
+        ),
+    ],
+)
+def test_delete_objects_successes(client: weaviate.Client, objs: List[dict], where: dict):
+    with client.batch as batch:
+        for obj in objs:
+            batch.add_data_object(data_object=obj, class_name="Test")
 
+    with client.batch as batch:
+        res = batch.delete_objects(
+            "Test",
+            where=where,
+        )
+
+    res = client.data_object.get()
+
+    names = [obj["properties"]["name"] for obj in res["objects"]]
+    for obj in objs:
+        assert obj.get("name") not in names
+
+
+def test_delete_objects_errors(client: weaviate.Client):
     with pytest.raises(ValueError) as error:
         with client.batch as batch:
             batch.delete_objects(

--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -132,6 +132,28 @@ def test_delete_objects(client: weaviate.Client):
     assert "four" in names
     assert "five" in names
 
+    with client.batch as batch:
+        batch.delete_objects(
+            "Test",
+            where={
+                "operator": "Or",
+                "operands": [
+                    {
+                        "path": ["name"],
+                        "operator": "Equal",
+                        "valueText": "four",
+                    },
+                    {
+                        "path": ["name"],
+                        "operator": "Equal",
+                        "valueText": "five",
+                    },
+                ],
+            },
+        )
+    res = client.data_object.get()
+    assert len(res["objects"]) == 0
+
     with pytest.raises(ValueError) as error:
         with client.batch as batch:
             batch.delete_objects(

--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -181,7 +181,7 @@ def test_delete_objects_successes(client: weaviate.Client, objs: List[dict], whe
             batch.add_data_object(data_object=obj, class_name="Test")
 
     with client.batch as batch:
-        res = batch.delete_objects(
+        batch.delete_objects(
             "Test",
             where=where,
         )


### PR DESCRIPTION
This PR resolves the bug raised in https://github.com/weaviate/weaviate-python-client/issues/477 where the `operands` key was not being checked appropriately during batch delete operations