### PR TITLE
Remove `IncludesModel` and its subclasses

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -31,7 +31,6 @@ from weaviate.collection.classes.config import (
 from weaviate.collection.classes.data import (
     DataObject,
     Error,
-    GetObjectsMetadata,
 )
 from weaviate.collection.classes.internal import Reference
 from weaviate.collection.classes.tenants import Tenant, TenantActivityStatus
@@ -380,12 +379,12 @@ def test_replace_overwrites_vector(client: weaviate.Client):
         vectorizer_config=VectorizerFactory.none(),
     )
     uuid = collection.data.insert(properties={"name": "some name"}, vector=[1, 2, 3])
-    obj = collection.data.get_by_id(uuid, metadata=GetObjectsMetadata(vector=True))
+    obj = collection.data.get_by_id(uuid, include_vector=True)
     assert obj.properties["name"] == "some name"
     assert obj.metadata.vector == [1, 2, 3]
 
     collection.data.replace(properties={"name": "other name"}, uuid=uuid)
-    obj = collection.data.get_by_id(uuid, metadata=GetObjectsMetadata(vector=True))
+    obj = collection.data.get_by_id(uuid, include_vector=True)
     assert obj.properties["name"] == "other name"
     assert obj.metadata.vector is None
 
@@ -656,7 +655,7 @@ def test_near_vector(client: weaviate.Client):
     collection.data.insert({"Name": "car"})
     collection.data.insert({"Name": "Mountain"})
 
-    banana = collection.data.get_by_id(uuid_banana, metadata=GetObjectsMetadata(vector=True))
+    banana = collection.data.get_by_id(uuid_banana, include_vector=True)
 
     full_objects = collection.query.near_vector(
         banana.metadata.vector, return_metadata=MetadataQuery(distance=True, certainty=True)

--- a/weaviate/collection/classes/data.py
+++ b/weaviate/collection/classes/data.py
@@ -2,30 +2,9 @@ import uuid as uuid_package
 from dataclasses import dataclass
 from typing import List, Optional, Dict, Union, Generic
 
-from pydantic import BaseModel, Field
 from weaviate.collection.classes.internal import Properties
 from weaviate.util import _to_beacons
 from weaviate.weaviate_types import UUID, UUIDS
-
-
-class _IncludesModel(BaseModel):
-    def to_include(self) -> str:
-        include: List[str] = []
-        for field, value in self:
-            if value:
-                include.append(field)
-        return ",".join(include)
-
-
-class _GetObjectByIdMetadata(_IncludesModel):
-    classification: bool = Field(default=False)
-    vector: bool = Field(default=False)
-
-
-class _GetObjectsMetadata(_IncludesModel):
-    classification: bool = Field(default=False)
-    featureProjection: bool = Field(default=False, alias="feature_projection")
-    vector: bool = Field(default=False)
 
 
 @dataclass

--- a/weaviate/collection/classes/data.py
+++ b/weaviate/collection/classes/data.py
@@ -18,14 +18,14 @@ class _IncludesModel(BaseModel):
 
 
 class _GetObjectByIdMetadata(_IncludesModel):
-    classification: bool = False
-    vector: bool = False
+    classification: bool = Field(default=False)
+    vector: bool = Field(default=False)
 
 
 class _GetObjectsMetadata(_IncludesModel):
-    classification: bool = False
-    featureProjection: bool = Field(False, alias="feature_projection")
-    vector: bool = False
+    classification: bool = Field(default=False)
+    featureProjection: bool = Field(default=False, alias="feature_projection")
+    vector: bool = Field(default=False)
 
 
 @dataclass

--- a/weaviate/collection/classes/data.py
+++ b/weaviate/collection/classes/data.py
@@ -8,7 +8,7 @@ from weaviate.util import _to_beacons
 from weaviate.weaviate_types import UUID, UUIDS
 
 
-class IncludesModel(BaseModel):
+class _IncludesModel(BaseModel):
     def to_include(self) -> str:
         include: List[str] = []
         for field, value in self:
@@ -17,12 +17,12 @@ class IncludesModel(BaseModel):
         return ",".join(include)
 
 
-class GetObjectByIdMetadata(IncludesModel):
+class _GetObjectByIdMetadata(_IncludesModel):
     classification: bool = False
     vector: bool = False
 
 
-class GetObjectsMetadata(IncludesModel):
+class _GetObjectsMetadata(_IncludesModel):
     classification: bool = False
     featureProjection: bool = Field(False, alias="feature_projection")
     vector: bool = False

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -22,9 +22,9 @@ from weaviate.collection.classes.data import (
     BatchReference,
     DataObject,
     Error,
-    GetObjectByIdMetadata,
-    GetObjectsMetadata,
-    IncludesModel,
+    _GetObjectsMetadata,
+    _GetObjectByIdMetadata,
+    _IncludesModel,
     _BatchReturn,
 )
 from weaviate.collection.classes.internal import _Object, _metadata_from_dict, Reference
@@ -153,7 +153,7 @@ class _Data:
         raise UnexpectedStatusCodeException("Update object", response)
 
     def _get_by_id(
-        self, uuid: UUID, metadata: Optional[GetObjectByIdMetadata]
+        self, uuid: UUID, metadata: Optional[_GetObjectByIdMetadata]
     ) -> Optional[Dict[str, Any]]:
         path = f"/objects/{self.name}/{uuid}"
 
@@ -162,7 +162,7 @@ class _Data:
         )
 
     def _get(
-        self, limit: Optional[int], metadata: Optional[GetObjectsMetadata]
+        self, limit: Optional[int], metadata: Optional[_GetObjectsMetadata]
     ) -> Optional[Dict[str, Any]]:
         path = "/objects"
         params: Dict[str, Any] = {"class": self.name}
@@ -174,7 +174,7 @@ class _Data:
         )
 
     def _get_from_weaviate(
-        self, params: Dict[str, Any], path: str, includes: Optional[IncludesModel]
+        self, params: Dict[str, Any], path: str, includes: Optional[_IncludesModel]
     ) -> Optional[Dict[str, Any]]:
         if includes is not None:
             params["include"] = includes.to_include()
@@ -443,18 +443,16 @@ class _DataCollection(Generic[Properties], _Data):
 
         self._update(weaviate_obj, uuid=uuid)
 
-    def get_by_id(
-        self, uuid: UUID, metadata: Optional[GetObjectByIdMetadata] = None
-    ) -> Optional[_Object[Properties]]:
-        ret = self._get_by_id(uuid=uuid, metadata=metadata)
+    def get_by_id(self, uuid: UUID, include_vector: bool = False) -> Optional[_Object[Properties]]:
+        ret = self._get_by_id(uuid=uuid, metadata=_GetObjectByIdMetadata(vector=include_vector))
         if ret is None:
             return ret
         return self._json_to_object(ret)
 
     def get(
-        self, limit: Optional[int] = None, metadata: Optional[GetObjectsMetadata] = None
+        self, limit: Optional[int] = None, include_vector: bool = False
     ) -> List[_Object[Properties]]:
-        ret = self._get(limit=limit, metadata=metadata)
+        ret = self._get(limit=limit, metadata=_GetObjectsMetadata(vector=include_vector))
         if ret is None:
             return []
 
@@ -580,18 +578,16 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         self._update(weaviate_obj, uuid)
 
-    def get_by_id(
-        self, uuid: UUID, metadata: Optional[GetObjectByIdMetadata] = None
-    ) -> Optional[_Object[Model]]:
-        ret = self._get_by_id(uuid=uuid, metadata=metadata)
+    def get_by_id(self, uuid: UUID, include_vector: bool = False) -> Optional[_Object[Model]]:
+        ret = self._get_by_id(uuid=uuid, metadata=_GetObjectByIdMetadata(vector=include_vector))
         if ret is None:
             return None
         return self._json_to_object(ret)
 
     def get(
-        self, limit: Optional[int] = None, metadata: Optional[GetObjectsMetadata] = None
+        self, limit: Optional[int] = None, include_vector: bool = False
     ) -> List[_Object[Model]]:
-        ret = self._get(limit=limit, metadata=metadata)
+        ret = self._get(limit=limit, metadata=_GetObjectsMetadata(vector=include_vector))
         if ret is None:
             return []
 

--- a/weaviate/weaviate_classes.py
+++ b/weaviate/weaviate_classes.py
@@ -14,8 +14,6 @@ from weaviate.collection.classes.config import (
 )
 from weaviate.collection.classes.data import (
     DataObject,
-    GetObjectByIdMetadata,
-    GetObjectsMetadata,
     ReferenceTo,
     ReferenceToMultiTarget,
 )
@@ -40,8 +38,6 @@ __all__ = [
     "DataType",
     "HybridFusion",
     "GenerativeFactory",
-    "GetObjectByIdMetadata",
-    "GetObjectsMetadata",
     "LinkTo",
     "LinkToMultiTarget",
     "MetadataQuery",


### PR DESCRIPTION
This PR removes classes that inherit from `IncludesModel` so that methods involving them define arguments in a flat way in the function itself, rather than the previously experimented way with options