### PR TITLE
Run mypy over whole code in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,14 +21,14 @@ repos:
         'flake8-builtins==2.0.1'
       ]
 
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.5.1"
+-   repo: local
     hooks:
     - id: mypy
-      entry: mypy ./weaviate
-      pass_filenames: false
-      additional_dependencies: [
-        'types-requests==2.31.0.2',
-        'types-urllib3==1.26.25.14',
-        'typing_extensions==4.7.1',
-      ]
+      name: mypy
+      entry: ./run-mypy.sh
+      language: python
+      # use require_serial so that script
+      # is only called once per commit
+      require_serial: true
+      # Print the number of files as a sanity-check
+      verbose: true

--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -o errexist
-
-pip install -r requirements-devel.txt
+pip install -r requirements-devel.txt >/dev/null 2>&1
 
 mypy --config-file ./pyproject.toml ./weaviate

--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexist
+
+pip install -r requirements-devel.txt
+
+mypy --config-file ./pyproject.toml ./weaviate


### PR DESCRIPTION
Sets up `mypy` in `pre-commit` hook to run over the entire library rather than just diffed files helping to avoid typing regressions that are not caught just by checking small individual changes

@dirkkul, this setup also avoids using `additional_dependencies` in the `pre-commit` config 😁 