### PR TITLE
Add config list method

### DIFF
--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -3,6 +3,8 @@ import pytest as pytest
 import weaviate
 from weaviate import Config
 from weaviate.collection.classes.config import (
+    _CollectionConfig,
+    _CollectionConfigSimple,
     ConfigFactory,
     ConfigUpdateFactory,
     Property,
@@ -25,6 +27,27 @@ def client():
     client.schema.delete_all()
     yield client
     client.schema.delete_all()
+
+
+def test_collection_list(client: weaviate.Client):
+    client.collection.create(
+        name="TestCollectionList",
+        vectorizer_config=VectorizerFactory.none(),
+        properties=[
+            Property(name="name", data_type=DataType.TEXT),
+            Property(name="age", data_type=DataType.INT),
+        ],
+    )
+
+    collections = client.collection.list()
+    assert list(collections.keys()) == ["TestCollectionList"]
+    assert isinstance(collections["TestCollectionList"], _CollectionConfigSimple)
+
+    collection = client.collection.list(False)
+    assert list(collection.keys()) == ["TestCollectionList"]
+    assert isinstance(collection["TestCollectionList"], _CollectionConfig)
+
+    client.collection.delete("TestCollectionList")
 
 
 def test_collection_config_empty(client: weaviate.Client):

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -39,11 +39,11 @@ def test_collection_list(client: weaviate.Client):
         ],
     )
 
-    collections = client.collection.list_()
+    collections = client.collection.list_all()
     assert list(collections.keys()) == ["TestCollectionList"]
     assert isinstance(collections["TestCollectionList"], _CollectionConfigSimple)
 
-    collection = client.collection.list_(False)
+    collection = client.collection.list_all(False)
     assert list(collection.keys()) == ["TestCollectionList"]
     assert isinstance(collection["TestCollectionList"], _CollectionConfig)
 

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -39,15 +39,32 @@ def test_collection_list(client: weaviate.Client):
         ],
     )
 
-    collections = client.collection.list()
+    collections = client.collection.list_()
     assert list(collections.keys()) == ["TestCollectionList"]
     assert isinstance(collections["TestCollectionList"], _CollectionConfigSimple)
 
-    collection = client.collection.list(False)
+    collection = client.collection.list_(False)
     assert list(collection.keys()) == ["TestCollectionList"]
     assert isinstance(collection["TestCollectionList"], _CollectionConfig)
 
     client.collection.delete("TestCollectionList")
+
+
+def test_collection_get_simple(client: weaviate.Client):
+    client.collection.create(
+        name="TestCollectionGetSimple",
+        vectorizer_config=VectorizerFactory.none(),
+        properties=[
+            Property(name="name", data_type=DataType.TEXT),
+            Property(name="age", data_type=DataType.INT),
+        ],
+    )
+
+    collection = client.collection.get("TestCollectionGetSimple")
+    config = collection.config.get(True)
+    assert isinstance(config, _CollectionConfigSimple)
+
+    client.collection.delete("TestCollectionGetSimple")
 
 
 def test_collection_config_empty(client: weaviate.Client):

--- a/weaviate/collection/classes/config.py
+++ b/weaviate/collection/classes/config.py
@@ -1009,6 +1009,14 @@ class _CollectionConfig:
     vectorizer: Vectorizer
 
 
+@dataclass
+class _CollectionConfigSimple:
+    name: str
+    description: Optional[str]
+    properties: List[_Property]
+    vectorizer: Vectorizer
+
+
 # class PropertyConfig(ConfigCreateModel):
 #     indexFilterable: Optional[bool] = Field(None, alias="index_filterable")
 #     indexSearchable: Optional[bool] = Field(None, alias="index_searchable")

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -115,14 +115,14 @@ class Collection(CollectionBase):
         return self._exists(_capitalize_first_letter(name))
 
     @overload
-    def list_(self, simple: Literal[False]) -> Dict[str, _CollectionConfig]:
+    def list_all(self, simple: Literal[False]) -> Dict[str, _CollectionConfig]:
         ...
 
     @overload
-    def list_(self, simple: Literal[True] = ...) -> Dict[str, _CollectionConfigSimple]:
+    def list_all(self, simple: Literal[True] = ...) -> Dict[str, _CollectionConfigSimple]:
         ...
 
-    def list_(
+    def list_all(
         self, simple: bool = True
     ) -> Union[Dict[str, _CollectionConfig], Dict[str, _CollectionConfigSimple]]:
         if simple:

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -1,7 +1,9 @@
-from typing import Generic, List, Optional, Type, Union
+from typing import Dict, Generic, List, Literal, Optional, Type, Union, overload
 
 from weaviate.collection.classes.config import (
     _CollectionConfigCreate,
+    _CollectionConfig,
+    _CollectionConfigSimple,
     ConsistencyLevel,
     _GenerativeConfig,
     _InvertedIndexConfigCreate,
@@ -110,3 +112,18 @@ class Collection(CollectionBase):
 
     def exists(self, name: str) -> bool:
         return self._exists(_capitalize_first_letter(name))
+
+    @overload
+    def list_(self, simple: Literal[False]) -> Dict[str, _CollectionConfig]:
+        ...
+
+    @overload
+    def list_(self, simple: Literal[True] = ...) -> Dict[str, _CollectionConfigSimple]:
+        ...
+
+    def list_(
+        self, simple: bool = True
+    ) -> Union[Dict[str, _CollectionConfig], Dict[str, _CollectionConfigSimple]]:
+        if simple:
+            return self._get_simple()
+        return self._get_all()

--- a/weaviate/collection/collection_base.py
+++ b/weaviate/collection/collection_base.py
@@ -5,8 +5,12 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from weaviate.collection.classes.config import (
     _CollectionConfigCreateBase,
     _CollectionConfig,
+    _CollectionConfigSimple,
 )
-from weaviate.collection.classes.config_methods import _collection_configs_from_json
+from weaviate.collection.classes.config_methods import (
+    _collection_configs_from_json,
+    _collection_configs_simple_from_json,
+)
 from weaviate.connect import Connection
 from weaviate.exceptions import UnexpectedStatusCodeException
 
@@ -56,7 +60,7 @@ class CollectionBase:
 
         UnexpectedStatusCodeException("Delete collection", response)
 
-    def get_all_collection_configs(self) -> Dict[str, _CollectionConfig]:
+    def _get_all(self) -> Dict[str, _CollectionConfig]:
         try:
             response = self._connection.get(path="/schema")
         except RequestsConnectionError as conn_err:
@@ -64,4 +68,14 @@ class CollectionBase:
         if response.status_code == 200:
             res = response.json()
             return _collection_configs_from_json(res)
+        raise UnexpectedStatusCodeException("Get schema", response)
+
+    def _get_simple(self) -> Dict[str, _CollectionConfigSimple]:
+        try:
+            response = self._connection.get(path="/schema")
+        except RequestsConnectionError as conn_err:
+            raise RequestsConnectionError("Get schema.") from conn_err
+        if response.status_code == 200:
+            res = response.json()
+            return _collection_configs_simple_from_json(res)
         raise UnexpectedStatusCodeException("Get schema", response)


### PR DESCRIPTION
This PR introduces `collection.list_` that is overloaded to return different types depending on the value of the passed argument. This overloading is then extended to `collection.config.get` to achieve an identical result there

Couldn't use have `collection.list` as that shadows Python's `list` keyword. Am open to suggestions on another naming convention