### PR TITLE
bring uniformity between query and generative returns

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -525,7 +525,7 @@ def test_search_hybrid(client: weaviate.Client, fusion_type):
     )
     collection.data.insert({"Name": "some name"}, uuid.uuid4())
     collection.data.insert({"Name": "other word"}, uuid.uuid4())
-    res = collection.query.hybrid(alpha=0, query="name", fusion_type=fusion_type)
+    res = collection.query.hybrid(alpha=0, query="name", fusion_type=fusion_type).objects
     assert len(res) == 1
     client.collection.delete("Testing")
 
@@ -540,7 +540,7 @@ def test_search_limit(client: weaviate.Client, limit):
     for i in range(5):
         collection.data.insert({"Name": str(i)})
 
-    assert len(collection.query.get(limit=limit)) == limit
+    assert len(collection.query.get(limit=limit).objects) == limit
 
     client.collection.delete("TestLimit")
 
@@ -557,7 +557,7 @@ def test_search_offset(client: weaviate.Client, offset):
     for i in range(nr_objects):
         collection.data.insert({"Name": str(i)})
 
-    objects = collection.query.get(offset=offset)
+    objects = collection.query.get(offset=offset).objects
     assert len(objects) == nr_objects - offset
 
     client.collection.delete("TestOffset")
@@ -574,9 +574,9 @@ def test_search_after(client: weaviate.Client):
     for i in range(nr_objects):
         collection.data.insert({"Name": str(i)})
 
-    objects = collection.query.get(return_metadata=MetadataQuery(uuid=True))
+    objects = collection.query.get(return_metadata=MetadataQuery(uuid=True)).objects
     for i, obj in enumerate(objects):
-        objects_after = collection.query.get(after=obj.metadata.uuid)
+        objects_after = collection.query.get(after=obj.metadata.uuid).objects
         assert len(objects_after) == nr_objects - 1 - i
 
     client.collection.delete("TestOffset")
@@ -596,19 +596,19 @@ def test_auto_limit(client: weaviate.Client):
         collection.data.insert({"Name": ""})
 
     # match all objects with rain
-    objects = collection.query.bm25(query="rain", auto_limit=0)
+    objects = collection.query.bm25(query="rain", auto_limit=0).objects
     assert len(objects) == 2 * 4
     objects = collection.query.hybrid(
         query="rain", auto_limit=0, alpha=0, fusion_type=HybridFusion.RELATIVE_SCORE
-    )
+    ).objects
     assert len(objects) == 2 * 4
 
     # match only objects with two rains
-    objects = collection.query.bm25(query="rain", auto_limit=1)
+    objects = collection.query.bm25(query="rain", auto_limit=1).objects
     assert len(objects) == 1 * 4
     objects = collection.query.hybrid(
         query="rain", auto_limit=1, alpha=0, fusion_type=HybridFusion.RELATIVE_SCORE
-    )
+    ).objects
     assert len(objects) == 1 * 4
 
     client.collection.delete("TestAutoLimit")
@@ -629,18 +629,18 @@ def test_query_properties(client: weaviate.Client):
     collection.data.insert({"Name": "snow", "Age": 4})
     collection.data.insert({"Name": "hail", "Age": 5})
 
-    objects = collection.query.bm25(query="rain", query_properties=["name"])
+    objects = collection.query.bm25(query="rain", query_properties=["name"]).objects
     assert len(objects) == 1
     assert objects[0].properties["age"] == 1
 
-    objects = collection.query.bm25(query="sleet", query_properties=["name"])
+    objects = collection.query.bm25(query="sleet", query_properties=["name"]).objects
     assert len(objects) == 0
 
-    objects = collection.query.hybrid(query="cloud", query_properties=["name"], alpha=0)
+    objects = collection.query.hybrid(query="cloud", query_properties=["name"], alpha=0).objects
     assert len(objects) == 1
     assert objects[0].properties["age"] == 3
 
-    objects = collection.query.hybrid(query="sleet", query_properties=["name"], alpha=0)
+    objects = collection.query.hybrid(query="sleet", query_properties=["name"], alpha=0).objects
     assert len(objects) == 0
 
     client.collection.delete("TestQueryProperties")
@@ -661,17 +661,17 @@ def test_near_vector(client: weaviate.Client):
 
     full_objects = collection.query.near_vector(
         banana.metadata.vector, return_metadata=MetadataQuery(distance=True, certainty=True)
-    )
+    ).objects
     assert len(full_objects) == 4
 
     objects_distance = collection.query.near_vector(
         banana.metadata.vector, distance=full_objects[2].metadata.distance
-    )
+    ).objects
     assert len(objects_distance) == 3
 
     objects_distance = collection.query.near_vector(
         banana.metadata.vector, certainty=full_objects[2].metadata.certainty
-    )
+    ).objects
     assert len(objects_distance) == 3
 
     client.collection.delete("TestNearVector")
@@ -690,17 +690,17 @@ def test_near_object(client: weaviate.Client):
 
     full_objects = collection.query.near_object(
         uuid_banana, return_metadata=MetadataQuery(distance=True, certainty=True)
-    )
+    ).objects
     assert len(full_objects) == 4
 
     objects_distance = collection.query.near_object(
         uuid_banana, distance=full_objects[2].metadata.distance
-    )
+    ).objects
     assert len(objects_distance) == 3
 
     objects_certainty = collection.query.near_object(
         uuid_banana, certainty=full_objects[2].metadata.certainty
-    )
+    ).objects
     assert len(objects_certainty) == 3
 
     client.collection.delete("TestNearObject")
@@ -717,7 +717,7 @@ def test_mono_references_grpc(client: weaviate.Client):
     uuid_A1 = A.data.insert(properties={"Name": "A1"})
     uuid_A2 = A.data.insert(properties={"Name": "A2"})
 
-    objects = A.query.bm25(query="A1", return_properties="name")
+    objects = A.query.bm25(query="A1", return_properties="name").objects
     assert objects[0].properties["name"] == "A1"
 
     B = client.collection.create(
@@ -739,7 +739,7 @@ def test_mono_references_grpc(client: weaviate.Client):
             link_on="ref",
             return_properties=["name"],
         ),
-    )
+    ).objects
     assert objects[0].properties["ref"].objects[0].properties["name"] == "A1"
     assert objects[0].properties["ref"].objects[1].properties["name"] == "A2"
 
@@ -752,7 +752,7 @@ def test_mono_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True),
             )
         ],
-    )
+    ).objects
     assert objects[0].properties["ref"].objects[0].properties["name"] == "A1"
     assert objects[0].properties["ref"].objects[0].metadata.uuid == uuid_A1
     assert objects[0].properties["ref"].objects[1].properties["name"] == "A2"
@@ -785,7 +785,7 @@ def test_mono_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True, last_update_time_unix=True),
             ),
         ],
-    )
+    ).objects
     assert objects[0].properties["name"] == "find me"
     assert objects[0].properties["ref"].objects[0].properties["name"] == "B"
     assert (
@@ -853,9 +853,13 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.Client):
     C = client.collection.get("CTypedDicts", CProps)
     C.data.insert(properties=CProps(name="find me", ref=ReferenceFactory[BProps].to(uuids=uuid_B)))
 
-    objects = client.collection.get("CTypedDicts").query.bm25(
-        query="find",
-        return_properties=CProps,
+    objects = (
+        client.collection.get("CTypedDicts")
+        .query.bm25(
+            query="find",
+            return_properties=CProps,
+        )
+        .objects
     )
     assert (
         objects[0].properties["name"] == "find me"
@@ -939,7 +943,7 @@ def test_multi_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True, last_update_time_unix=True),
             ),
         ],
-    )
+    ).objects
     assert objects[0].properties["name"] == "first"
     assert len(objects[0].properties["ref"].objects) == 1
     assert objects[0].properties["ref"].objects[0].properties["name"] == "A"
@@ -957,7 +961,7 @@ def test_multi_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True, last_update_time_unix=True),
             ),
         ],
-    )
+    ).objects
     assert objects[0].properties["name"] == "second"
     assert len(objects[0].properties["ref"].objects) == 1
     assert objects[0].properties["ref"].objects[0].properties["name"] == "B"
@@ -1005,11 +1009,11 @@ def test_multi_searches(client: weaviate.Client):
         query="word",
         return_properties=["name"],
         return_metadata=MetadataQuery(last_update_time_unix=True),
-    )
+    ).objects
     assert "name" in objects[0].properties
     assert objects[0].metadata.last_update_time_unix is not None
 
-    objects = collection.query.bm25(query="other", return_metadata=MetadataQuery(uuid=True))
+    objects = collection.query.bm25(query="other", return_metadata=MetadataQuery(uuid=True)).objects
     assert "name" not in objects[0].properties
     assert objects[0].metadata.uuid is not None
     assert objects[0].metadata.last_update_time_unix is None
@@ -1029,11 +1033,11 @@ def test_search_with_tenant(client: weaviate.Client):
     tenant1 = collection.with_tenant("Tenant1")
     tenant2 = collection.with_tenant("Tenant2")
     uuid1 = tenant1.data.insert({"name": "some name"})
-    objects1 = tenant1.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True))
+    objects1 = tenant1.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True)).objects
     assert len(objects1) == 1
     assert objects1[0].metadata.uuid == uuid1
 
-    objects2 = tenant2.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True))
+    objects2 = tenant2.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True)).objects
     assert len(objects2) == 0
 
     client.collection.delete("TestTenantSearch")
@@ -1160,7 +1164,7 @@ def test_empty_search_returns_everything(client: weaviate.Client):
 
     collection.data.insert(properties={"name": "word"})
 
-    objects = collection.query.bm25(query="word")
+    objects = collection.query.bm25(query="word").objects
     assert "name" in objects[0].properties
     assert objects[0].properties["name"] == "word"
     assert objects[0].metadata.uuid is not None
@@ -1285,7 +1289,7 @@ def test_return_list_properties(client: weaviate.Client):
         "uuids": [uuid.uuid4(), uuid.uuid4()],
     }
     collection.data.insert(properties=data)
-    objects = collection.query.get()
+    objects = collection.query.get().objects
     assert len(objects) == 1
 
     # remove dates because of problems comparing dates
@@ -1335,7 +1339,7 @@ def test_near_text(
         move_away=Move(force=0.5, concepts=concepts),
         return_metadata=MetadataQuery(uuid=True),
         return_properties=["value"],
-    )
+    ).objects
 
     assert objs[0].metadata.uuid == batch_return.uuids[2]
     assert objs[0].properties["value"] == "apple cake"
@@ -1370,7 +1374,7 @@ def test_near_image(client: weaviate.Client, distance: Optional[float], certaint
 
     objects = collection.query.near_image(
         WEAVIATE_LOGO_OLD_ENCODED, distance=distance, certainty=certainty
-    )
+    ).objects
     assert len(objects) == 2
     assert objects[0].metadata.uuid == uuid1
 
@@ -1397,7 +1401,7 @@ def test_return_properties_with_typed_dict(client: weaviate.Client, which_case: 
         class DataModel(TypedDict):
             int_: int
 
-        objects = collection.query.get(return_properties=DataModel)
+        objects = collection.query.get(return_properties=DataModel).objects
         assert len(objects) == 1
         assert objects[0].properties == {"int_": 1}
     elif which_case == 1:
@@ -1405,7 +1409,7 @@ def test_return_properties_with_typed_dict(client: weaviate.Client, which_case: 
         class DataModel(TypedDict):
             ints: List[int]
 
-        objects = collection.query.get(return_properties=DataModel)
+        objects = collection.query.get(return_properties=DataModel).objects
         assert len(objects) == 1
         assert objects[0].properties == {"ints": [1, 2, 3]}
     elif which_case == 2:
@@ -1414,7 +1418,7 @@ def test_return_properties_with_typed_dict(client: weaviate.Client, which_case: 
             int_: int
             ints: List[int]
 
-        objects = collection.query.get(return_properties=DataModel)
+        objects = collection.query.get(return_properties=DataModel).objects
         assert len(objects) == 1
         assert objects[0].properties == data
     elif which_case == 3:
@@ -1510,7 +1514,7 @@ def test_sort(client: weaviate.Client, sort: Union[Sort, List[Sort]], expected: 
         collection.data.insert(properties={"name": "C", "age": 22}),
     ]
 
-    objects = collection.query.get(sort=sort)
+    objects = collection.query.get(sort=sort).objects
     assert len(objects) == len(expected)
 
     expected_uuids = [uuids_from[result] for result in expected]
@@ -1540,7 +1544,7 @@ def test_optional_ref_returns(client: weaviate.Client):
     )
     collection.data.insert(properties={"ref": ReferenceFactory.to(uuid_to1)})
 
-    objects = collection.query.get(return_properties=[LinkTo(link_on="ref")])
+    objects = collection.query.get(return_properties=[LinkTo(link_on="ref")]).objects
 
     assert objects[0].properties["ref"].objects[0].properties["text"] == "ref text"
     assert objects[0].properties["ref"].objects[0].metadata.uuid is not None

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -63,7 +63,7 @@ def test_filters_text(client: weaviate.Client, weaviate_filter: _FilterValue, re
         collection.data.insert({"name": "Mountain"}),
     ]
 
-    objects = collection.query.get(filters=weaviate_filter)
+    objects = collection.query.get(filters=weaviate_filter).objects
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -112,7 +112,7 @@ def test_filters_nested(
 
     objects = collection.query.get(
         filters=weaviate_filter, return_metadata=MetadataQuery(uuid=True)
-    )
+    ).objects
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -133,7 +133,7 @@ def test_length_filter(client: weaviate.Client):
         collection.data.insert({"field": "three"}),
         collection.data.insert({"field": "four"}),
     ]
-    objects = collection.query.get(filters=Filter(path="field", length=True).equal(3))
+    objects = collection.query.get(filters=Filter(path="field", length=True).equal(3)).objects
 
     results = [0, 1]
     assert len(objects) == len(results)
@@ -166,7 +166,7 @@ def test_filters_comparison(
         collection.data.insert({"number": None}),
     ]
 
-    objects = collection.query.get(filters=weaviate_filter)
+    objects = collection.query.get(filters=weaviate_filter).objects
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -299,7 +299,7 @@ def test_filters_contains(
 
     objects = collection.query.get(
         filters=weaviate_filter, return_metadata=MetadataQuery(uuid=True)
-    )
+    ).objects
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -345,7 +345,7 @@ def test_ref_filters(client: weaviate.Client, weaviate_filter: _FilterValue, res
 
     objects = from_collection.query.get(
         filters=weaviate_filter, return_metadata=MetadataQuery(uuid=True)
-    )
+    ).objects
     assert len(objects) == len(results)
 
     uuids = [uuids_from[result] for result in results]
@@ -404,10 +404,14 @@ def test_ref_filters_multi_target(client: weaviate.Client):
         }
     )
 
-    objects = from_collection.query.get(filters=Filter(path=["ref", target, "int"]).greater_than(3))
+    objects = from_collection.query.get(
+        filters=Filter(path=["ref", target, "int"]).greater_than(3)
+    ).objects
     assert len(objects) == 1
     assert objects[0].properties["name"] == "second"
 
-    objects = from_collection.query.get(filters=Filter(path=["ref", source, "name"]).equal("first"))
+    objects = from_collection.query.get(
+        filters=Filter(path=["ref", source, "name"]).equal("first")
+    ).objects
     assert len(objects) == 1
     assert objects[0].properties["name"] == "third"

--- a/integration/test_collection_multi_node.py
+++ b/integration/test_collection_multi_node.py
@@ -44,6 +44,6 @@ def test_consistency_on_multinode(client: weaviate.Client, level: ConsistencyLev
     )
     assert not ret.has_errors
 
-    objects = collection.query.get(return_metadata=MetadataQuery(is_consistent=True))
+    objects = collection.query.get(return_metadata=MetadataQuery(is_consistent=True)).objects
     for obj in objects:
         assert obj.metadata.is_consistent

--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -11,6 +11,7 @@ from weaviate.collection.classes.config import (
     VectorizerFactory,
 )
 from weaviate.collection.classes.data import DataObject
+from weaviate.collection.classes.grpc import Generate
 from weaviate.exceptions import WeaviateGRPCException
 
 
@@ -51,11 +52,13 @@ def test_generative_search_single(client: weaviate.Client, parameter: str, answe
     )
 
     res = collection.query.generative(
-        prompt_per_object=f"is it good or bad based on {{{parameter}}}? Just answer with yes or no without punctuation"
+        generate=Generate(
+            single_prompt=f"is it good or bad based on {{{parameter}}}? Just answer with yes or no without punctuation"
+        )
     )
     for obj in res.objects:
         assert obj.metadata.generative == answer
-    assert res.generative_combined_result is None
+    assert res.generated is None
 
 
 @pytest.mark.parametrize(
@@ -82,10 +85,12 @@ def test_generative_search_grouped(client: weaviate.Client, prop: str, answer: s
     )
 
     res = collection.query.generative(
-        prompt_combined_results="What is big and what is small? write the name of the big thing first and then the name of the small thing after a space.",
-        combined_results_properties=prop,
+        generate=Generate(
+            grouped_task="What is big and what is small? write the name of the big thing first and then the name of the small thing after a space.",
+            grouped_properties=prop,
+        )
     )
-    assert res.generative_combined_result == answer
+    assert res.generated == answer
 
 
 def test_generative_search_grouped_all_props(client: weaviate.Client):
@@ -119,9 +124,11 @@ def test_generative_search_grouped_all_props(client: weaviate.Client):
     )
 
     res = collection.query.generative(
-        prompt_combined_results="What is the biggest and what is the smallest? Only write the names separated by a space"
+        generate=Generate(
+            grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space"
+        )
     )
-    assert res.generative_combined_result == "Teddy cats"
+    assert res.generated == "Teddy cats"
 
 
 def test_generative_with_everything(client: weaviate.Client):
@@ -155,10 +162,12 @@ def test_generative_with_everything(client: weaviate.Client):
     )
 
     res = collection.query.generative(
-        prompt_per_object="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
-        prompt_combined_results="What is the biggest and what is the smallest? Only write the names separated by a space",
+        generate=Generate(
+            single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
+            grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space",
+        )
     )
-    assert res.generative_combined_result == "Teddy cats"
+    assert res.generated == "Teddy cats"
     for obj in res.objects:
         assert obj.metadata.generative == "Yes"
 
@@ -220,6 +229,6 @@ def test_openai_batch_upload(client: weaviate.Client):
     )
     assert not ret.has_errors
 
-    objects = collection.query.get()
+    objects = collection.query.get().objects
     assert objects[0].metadata.vector is not None
     assert len(objects[0].metadata.vector) > 0

--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -188,7 +188,7 @@ def test_openapi_invalid_key():
     )
     collection.data.insert(properties={"text": "test"})
     with pytest.raises(WeaviateGRPCException):
-        collection.query.generative(prompt_per_object="tell a joke based on {text}")
+        collection.query.generative(Generate(single_prompt="tell a joke based on {text}"))
 
 
 def test_openapi_no_module():
@@ -207,7 +207,7 @@ def test_openapi_no_module():
     )
     collection.data.insert(properties={"text": "test"})
     with pytest.raises(WeaviateGRPCException):
-        collection.query.generative(prompt_per_object="tell a joke based on {text}")
+        collection.query.generative(Generate(single_prompt="tell a joke based on {text}"))
 
 
 def test_openai_batch_upload(client: weaviate.Client):

--- a/weaviate/collection/classes/grpc.py
+++ b/weaviate/collection/classes/grpc.py
@@ -64,9 +64,9 @@ class MetadataQuery(WeaviateInput):
 
 
 class Generate(WeaviateInput):
-    single_prompt: Optional[str]
-    grouped_task: Optional[str]
-    grouped_properties: Optional[List[str]]
+    single_prompt: Optional[str] = Field(default=None)
+    grouped_task: Optional[str] = Field(default=None)
+    grouped_properties: Optional[List[str]] = Field(default=None)
 
 
 class Sort(WeaviateInput):

--- a/weaviate/collection/classes/grpc.py
+++ b/weaviate/collection/classes/grpc.py
@@ -52,20 +52,26 @@ class Move:
 
 
 class MetadataQuery(WeaviateInput):
-    uuid: bool = False
-    vector: bool = False
-    creation_time_unix: bool = False
-    last_update_time_unix: bool = False
-    distance: bool = False
-    certainty: bool = False
-    score: bool = False
-    explain_score: bool = False
-    is_consistent: bool = False
+    uuid: bool = Field(default=False)
+    vector: bool = Field(default=False)
+    creation_time_unix: bool = Field(default=False)
+    last_update_time_unix: bool = Field(default=False)
+    distance: bool = Field(default=False)
+    certainty: bool = Field(default=False)
+    score: bool = Field(default=False)
+    explain_score: bool = Field(default=False)
+    is_consistent: bool = Field(default=False)
+
+
+class Generate(WeaviateInput):
+    single_prompt: Optional[str]
+    grouped_task: Optional[str]
+    grouped_properties: Optional[List[str]]
 
 
 class Sort(WeaviateInput):
     prop: str
-    ascending: bool = True
+    ascending: bool = Field(default=True)
 
 
 class LinkTo(WeaviateInput):

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -39,7 +39,12 @@ class _Object(Generic[P]):
 @dataclass
 class _GenerativeReturn(Generic[P]):
     objects: List[_Object[P]]
-    generative_combined_result: Optional[str] = None
+    generated: Optional[str] = None
+
+
+@dataclass
+class _QueryReturn(Generic[P]):
+    objects: List[_Object[P]]
 
 
 class ReferenceFactory(Generic[P]):

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -1,18 +1,7 @@
 import datetime
 import sys
 from dataclasses import dataclass
-from typing import (
-    Any,
-    Dict,
-    Set,
-    List,
-    Optional,
-    Union,
-    Tuple,
-    Type,
-    Generic,
-    cast,
-)
+from typing import Any, Dict, Set, List, Optional, Union, Tuple, Type, Generic, cast
 
 from typing_extensions import TypeAlias
 
@@ -33,13 +22,14 @@ from weaviate.collection.classes.filters import (
     _Filters,
 )
 from weaviate.collection.classes.grpc import (
-    MetadataQuery,
+    Generate,
     HybridFusion,
-    PROPERTY,
-    PROPERTIES,
     LinkTo,
     LinkToMultiTarget,
+    MetadataQuery,
     Move,
+    PROPERTY,
+    PROPERTIES,
     Sort,
 )
 from weaviate.collection.classes.internal import (
@@ -50,6 +40,7 @@ from weaviate.collection.classes.internal import (
     _extract_property_type_from_reference,
     _extract_properties_from_data_model,
     _GenerativeReturn,
+    _QueryReturn,
 )
 from weaviate.collection.classes.orm import Model
 from weaviate.collection.classes.types import (
@@ -717,20 +708,22 @@ class _GrpcCollection(_Grpc):
         sort: Optional[Union[Sort, List[Sort]]] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().get(
-                limit=limit,
-                offset=offset,
-                after=after,
-                filters=filters,
-                sort=sort,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().get(
+                    limit=limit,
+                    offset=offset,
+                    after=after,
+                    filters=filters,
+                    sort=sort,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def hybrid(
         self,
@@ -744,23 +737,25 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().hybrid(
-                query=query,
-                alpha=alpha,
-                vector=vector,
-                properties=query_properties,
-                fusion_type=fusion_type,
-                limit=limit,
-                autocut=auto_limit,
-                filters=filters,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().hybrid(
+                    query=query,
+                    alpha=alpha,
+                    vector=vector,
+                    properties=query_properties,
+                    fusion_type=fusion_type,
+                    limit=limit,
+                    autocut=auto_limit,
+                    filters=filters,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def bm25(
         self,
@@ -771,20 +766,22 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().bm25(
-                query=query,
-                properties=query_properties,
-                limit=limit,
-                autocut=auto_limit,
-                filters=filters,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().bm25(
+                    query=query,
+                    properties=query_properties,
+                    limit=limit,
+                    autocut=auto_limit,
+                    filters=filters,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def near_vector(
         self,
@@ -795,20 +792,22 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().near_vector(
-                near_vector=near_vector,
-                certainty=certainty,
-                distance=distance,
-                autocut=auto_limit,
-                filters=filters,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().near_vector(
+                    near_vector=near_vector,
+                    certainty=certainty,
+                    distance=distance,
+                    autocut=auto_limit,
+                    filters=filters,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def near_object(
         self,
@@ -819,20 +818,22 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().near_object(
-                near_object=near_object,
-                certainty=certainty,
-                distance=distance,
-                autocut=auto_limit,
-                filters=filters,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().near_object(
+                    near_object=near_object,
+                    certainty=certainty,
+                    distance=distance,
+                    autocut=auto_limit,
+                    filters=filters,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def near_text(
         self,
@@ -845,22 +846,24 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().near_text(
-                near_text=query,
-                certainty=certainty,
-                distance=distance,
-                move_to=move_to,
-                move_away=move_away,
-                autocut=auto_limit,
-                filters=filters,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().near_text(
+                    near_text=query,
+                    certainty=certainty,
+                    distance=distance,
+                    move_to=move_to,
+                    move_away=move_away,
+                    autocut=auto_limit,
+                    filters=filters,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def near_image(
         self,
@@ -871,20 +874,22 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().near_image(
-                image=near_image,
-                certainty=certainty,
-                distance=distance,
-                filters=filters,
-                autocut=auto_limit,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().near_image(
+                    image=near_image,
+                    certainty=certainty,
+                    distance=distance,
+                    filters=filters,
+                    autocut=auto_limit,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def near_audio(
         self,
@@ -895,20 +900,22 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().near_audio(
-                audio=near_audio,
-                certainty=certainty,
-                distance=distance,
-                filters=filters,
-                autocut=auto_limit,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().near_audio(
+                    audio=near_audio,
+                    certainty=certainty,
+                    distance=distance,
+                    filters=filters,
+                    autocut=auto_limit,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def near_video(
         self,
@@ -919,26 +926,26 @@ class _GrpcCollection(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> List[_Object[Properties]]:
+    ) -> _QueryReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
-        return [
-            self.__result_to_object(obj, ret_type)
-            for obj in self._query().near_video(
-                video=near_video,
-                certainty=certainty,
-                distance=distance,
-                filters=filters,
-                autocut=auto_limit,
-                return_metadata=return_metadata,
-                return_properties=ret_properties,
-            )
-        ]
+        return _QueryReturn(
+            objects=[
+                self.__result_to_object(obj, ret_type)
+                for obj in self._query().near_video(
+                    video=near_video,
+                    certainty=certainty,
+                    distance=distance,
+                    filters=filters,
+                    autocut=auto_limit,
+                    return_metadata=return_metadata,
+                    return_properties=ret_properties,
+                )
+            ]
+        )
 
     def generative(
         self,
-        prompt_per_object: Optional[str] = None,
-        prompt_combined_results: Optional[str] = None,
-        combined_results_properties: Optional[List[str]] = None,
+        generate: Generate,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
@@ -946,9 +953,9 @@ class _GrpcCollection(_Grpc):
     ) -> _GenerativeReturn[Properties]:
         ret_properties, ret_type = self.__determine_generic(return_properties)
         ret = self._query().generative(
-            single=prompt_per_object,
-            grouped=prompt_combined_results,
-            grouped_properties=combined_results_properties,
+            single=generate.single_prompt,
+            grouped=generate.grouped_task,
+            grouped_properties=generate.grouped_properties,
             filters=filters,
             auto_limit=auto_limit,
             return_metadata=return_metadata,
@@ -958,9 +965,7 @@ class _GrpcCollection(_Grpc):
         grouped_results = (
             ret.generative_grouped_result if ret.generative_grouped_result != "" else None
         )
-        return _GenerativeReturn[Properties](
-            objects=objects, generative_combined_result=grouped_results
-        )
+        return _GenerativeReturn[Properties](objects=objects, generated=grouped_results)
 
 
 class _GrpcCollectionModel(Generic[Model], _Grpc):


### PR DESCRIPTION
Introduces `QueryReturn` that wraps `objects: List[_Object[P]]` so that there is uniformity of the API surface between queries and the generative method, which itself returns `GenerativeReturn[P]`