### PR TITLE
Implement batch delete

### DIFF
--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -825,7 +825,6 @@ def test_delete_many_return(client: weaviate.Client):
     )
     ret = collection.data.delete_many(where=Filter(path="name").equal("delet me"))
     assert ret.failed == 0
-    assert ret.limit == 10000
     assert ret.matches == 1
     assert ret.objects is None
     assert ret.successful == 1

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -765,6 +765,7 @@ def test_delete_many_and(client: weaviate.Client):
     collection.data.delete_many(
         where=Filter(path="age").equal(10) & Filter(path="name").equal("Timmy")
     )
+
     objs = collection.data.get()
     assert len(objs) == 1
     assert objs[0].properties["age"] == 10
@@ -796,3 +797,25 @@ def test_delete_many_or(client: weaviate.Client):
     assert len(objs) == 1
     assert objs[0].properties["age"] == 20
     assert objs[0].properties["name"] == "Tim"
+
+
+def test_delete_many_return(client: weaviate.Client):
+    name = "TestDeleteManyReturn"
+    collection = client.collection.create(
+        name=name,
+        properties=[
+            Property(name="Name", data_type=DataType.TEXT),
+        ],
+        vectorizer_config=VectorizerFactory.none(),
+    )
+    collection.data.insert_many(
+        [
+            DataObject(properties={"name": "delet me"}, uuid=uuid.uuid4()),
+        ]
+    )
+    ret = collection.data.delete_many(where=Filter(path="name").equal("delet me"))
+    assert ret.failed == 0
+    assert ret.limit == 10000
+    assert ret.matches == 1
+    assert ret.objects is None
+    assert ret.successful == 1

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -444,6 +444,16 @@ def test_ref_filters_multi_target(client: weaviate.Client):
         ),
         (
             [
+                Property(name="text", data_type=DataType.TEXT),
+            ],
+            [
+                DataObject(properties={"text": "banana"}, uuid=uuid.uuid4()),
+            ],
+            Filter("text").like("ba*"),
+            0,
+        ),
+        (
+            [
                 Property(name="texts", data_type=DataType.TEXT_ARRAY),
             ],
             [

--- a/weaviate/collection/classes/batch.py
+++ b/weaviate/collection/classes/batch.py
@@ -3,9 +3,8 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
-class _DeleteBatchResult:
+class _BatchDeleteResult:
     failed: int
-    limit: int
     matches: int
     objects: Optional[List[Dict[str, Any]]]
     successful: int

--- a/weaviate/collection/classes/batch.py
+++ b/weaviate/collection/classes/batch.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class _DeleteBatchResult:
+    failed: int
+    limit: int
+    matches: int
+    objects: Optional[List[Dict[str, Any]]]
+    successful: int

--- a/weaviate/collection/classes/filters.py
+++ b/weaviate/collection/classes/filters.py
@@ -22,7 +22,32 @@ class _Operator(str, Enum):
     OR = "Or"
 
     def _to_grpc(self) -> weaviate_pb2.Filters.Operator:
-        return weaviate_pb2.Filters.Operator(self.value)
+        if self == _Operator.EQUAL:
+            return weaviate_pb2.Filters.OPERATOR_EQUAL
+        elif self == _Operator.NOT_EQUAL:
+            return weaviate_pb2.Filters.OPERATOR_NOT_EQUAL
+        elif self == _Operator.LESS_THAN:
+            return weaviate_pb2.Filters.OPERATOR_LESS_THAN
+        elif self == _Operator.LESS_THAN_EQUAL:
+            return weaviate_pb2.Filters.OPERATOR_LESS_THAN_EQUAL
+        elif self == _Operator.GREATER_THAN:
+            return weaviate_pb2.Filters.OPERATOR_GREATER_THAN
+        elif self == _Operator.GREATER_THAN_EQUAL:
+            return weaviate_pb2.Filters.OPERATOR_GREATER_THAN_EQUAL
+        elif self == _Operator.LIKE:
+            return weaviate_pb2.Filters.OPERATOR_LIKE
+        elif self == _Operator.IS_NULL:
+            return weaviate_pb2.Filters.OPERATOR_IS_NULL
+        elif self == _Operator.CONTAINS_ANY:
+            return weaviate_pb2.Filters.OPERATOR_CONTAINS_ANY
+        elif self == _Operator.CONTAINS_ALL:
+            return weaviate_pb2.Filters.OPERATOR_CONTAINS_ALL
+        elif self == _Operator.AND:
+            return weaviate_pb2.Filters.OPERATOR_AND
+        elif self == _Operator.OR:
+            return weaviate_pb2.Filters.OPERATOR_OR
+        else:
+            raise ValueError(f"Unknown operator {self}")
 
 
 class _Filters:

--- a/weaviate/collection/classes/filters.py
+++ b/weaviate/collection/classes/filters.py
@@ -1,9 +1,28 @@
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import List, Union
 
 from weaviate.weaviate_types import UUID
 from weaviate_grpc import weaviate_pb2
+
+
+class _Operator(str, Enum):
+    EQUAL = "Equal"
+    NOT_EQUAL = "NotEqual"
+    LESS_THAN = "LessThan"
+    LESS_THAN_EQUAL = "LessThanEqual"
+    GREATER_THAN = "GreaterThan"
+    GREATER_THAN_EQUAL = "GreaterThanEqual"
+    LIKE = "Like"
+    IS_NULL = "IsNull"
+    CONTAINS_ANY = "ContainsAny"
+    CONTAINS_ALL = "ContainsAll"
+    AND = "And"
+    OR = "Or"
+
+    def _to_grpc(self) -> weaviate_pb2.Filters.Operator:
+        return weaviate_pb2.Filters.Operator(self.value)
 
 
 class _Filters:
@@ -21,8 +40,8 @@ class _FilterAnd(_Filters):
     # replace with the following once 3.11 is the minimum version
     #     Operator: weaviate_pb2.Filters.OperatorType = weaviate_pb2.Filters.OperatorAnd
     @property
-    def operator(self) -> weaviate_pb2.Filters.Operator:
-        return weaviate_pb2.Filters.OPERATOR_AND
+    def operator(self) -> _Operator:
+        return _Operator.AND
 
 
 class _FilterOr(_Filters):
@@ -32,8 +51,8 @@ class _FilterOr(_Filters):
     # replace with the following once 3.11 is the minimum version
     #     Operator: weaviate_pb2.Filters.OperatorType = weaviate_pb2.Filters.OperatorOr
     @property
-    def operator(self) -> weaviate_pb2.Filters.Operator:
-        return weaviate_pb2.Filters.OPERATOR_OR
+    def operator(self) -> _Operator:
+        return _Operator.OR
 
 
 FilterValuesList = Union[List[str], List[bool], List[int], List[float], List[datetime], List[UUID]]
@@ -44,7 +63,7 @@ FilterValues = Union[int, float, str, bool, datetime, UUID, None, FilterValuesLi
 class _FilterValue(_Filters):
     path: Union[str, List[str]]
     value: FilterValues
-    operator: weaviate_pb2.Filters.Operator
+    operator: _Operator
 
 
 class Filter:
@@ -56,61 +75,51 @@ class Filter:
         self.__internal_path = path
 
     def is_none(self, val: bool) -> _FilterValue:
-        return _FilterValue(
-            path=self.__internal_path, value=val, operator=weaviate_pb2.Filters.OPERATOR_IS_NULL
-        )
+        return _FilterValue(path=self.__internal_path, value=val, operator=_Operator.IS_NULL)
 
     def contains_any(self, val: FilterValuesList) -> _FilterValue:
         return _FilterValue(
             path=self.__internal_path,
             value=val,
-            operator=weaviate_pb2.Filters.OPERATOR_CONTAINS_ANY,
+            operator=_Operator.CONTAINS_ANY,
         )
 
     def contains_all(self, val: FilterValuesList) -> _FilterValue:
         return _FilterValue(
             path=self.__internal_path,
             value=val,
-            operator=weaviate_pb2.Filters.OPERATOR_CONTAINS_ALL,
+            operator=_Operator.CONTAINS_ALL,
         )
 
     def equal(self, val: FilterValues) -> _FilterValue:
-        return _FilterValue(
-            path=self.__internal_path, value=val, operator=weaviate_pb2.Filters.OPERATOR_EQUAL
-        )
+        return _FilterValue(path=self.__internal_path, value=val, operator=_Operator.EQUAL)
 
     def not_equal(self, val: FilterValues) -> _FilterValue:
-        return _FilterValue(
-            path=self.__internal_path, value=val, operator=weaviate_pb2.Filters.OPERATOR_NOT_EQUAL
-        )
+        return _FilterValue(path=self.__internal_path, value=val, operator=_Operator.NOT_EQUAL)
 
     def less_than(self, val: FilterValues) -> _FilterValue:
-        return _FilterValue(
-            path=self.__internal_path, value=val, operator=weaviate_pb2.Filters.OPERATOR_LESS_THAN
-        )
+        return _FilterValue(path=self.__internal_path, value=val, operator=_Operator.LESS_THAN)
 
     def less_than_equal(self, val: FilterValues) -> _FilterValue:
         return _FilterValue(
             path=self.__internal_path,
             value=val,
-            operator=weaviate_pb2.Filters.OPERATOR_LESS_THAN_EQUAL,
+            operator=_Operator.LESS_THAN_EQUAL,
         )
 
     def greater_than(self, val: FilterValues) -> _FilterValue:
         return _FilterValue(
             path=self.__internal_path,
             value=val,
-            operator=weaviate_pb2.Filters.OPERATOR_GREATER_THAN,
+            operator=_Operator.GREATER_THAN,
         )
 
     def greater_than_equal(self, val: FilterValues) -> _FilterValue:
         return _FilterValue(
             path=self.__internal_path,
             value=val,
-            operator=weaviate_pb2.Filters.OPERATOR_GREATER_THAN_EQUAL,
+            operator=_Operator.GREATER_THAN_EQUAL,
         )
 
     def like(self, val: str) -> _FilterValue:
-        return _FilterValue(
-            path=self.__internal_path, value=val, operator=weaviate_pb2.Filters.OPERATOR_LIKE
-        )
+        return _FilterValue(path=self.__internal_path, value=val, operator=_Operator.LIKE)

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -29,6 +29,7 @@ from weaviate.collection.classes.orm import (
     Model,
 )
 from weaviate.collection.classes.types import Properties, TProperties, _check_data_model
+from weaviate.collection.classes.filters import _Filters
 from weaviate.collection.grpc_batch import _BatchGRPC
 from weaviate.collection.rest_batch import _BatchREST
 from weaviate.connect import Connection
@@ -54,7 +55,7 @@ class _Data:
         self._consistency_level = consistency_level
         self._tenant = tenant
         self._batch_grpc = _BatchGRPC(connection, consistency_level)
-        self._batch_rest = _BatchREST(connection, consistency_level)
+        self._batch_rest = _BatchREST(connection)
 
     def _insert(self, weaviate_obj: Dict[str, Any]) -> uuid_package.UUID:
         path = "/objects"
@@ -123,9 +124,12 @@ class _Data:
             return False  # did not exist
         raise UnexpectedStatusCodeException("Delete object", response)
 
-    def delete(self) -> None:
-        pass
-        # return self._batch_rest.delete(self.name)
+    def delete(
+        self, where: _Filters, verbose: bool = False, dry_run: bool = False
+    ) -> Dict[str, Any]:
+        return self._batch_rest.delete(
+            self.name, where, verbose, dry_run, self._consistency_level, self._tenant
+        )
 
     def _replace(self, weaviate_obj: Dict[str, Any], uuid: UUID) -> None:
         path = f"/objects/{self.name}/{uuid}"

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -17,6 +17,7 @@ from typing import (
 from google.protobuf.struct_pb2 import Struct
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
+from weaviate.collection.classes.batch import _DeleteBatchResult
 from weaviate.collection.classes.config import ConsistencyLevel
 from weaviate.collection.classes.data import (
     BatchReference,
@@ -126,7 +127,7 @@ class _Data:
 
     def delete_many(
         self, where: _Filters, verbose: bool = False, dry_run: bool = False
-    ) -> Dict[str, Any]:
+    ) -> _DeleteBatchResult:
         return self._batch_rest.delete(
             self.name, where, verbose, dry_run, self._consistency_level, self._tenant
         )

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -341,7 +341,7 @@ class _Data:
             elif isinstance(val, list) and isinstance(val[0], float):
                 float_arrays.append(weaviate_pb2.NumberArrayProperties(prop_name=key, values=val))
             else:
-                non_ref_properties.update({key: val})
+                non_ref_properties.update({key: self.__serialize_primitive(val)})
 
         return weaviate_pb2.BatchObject.Properties(
             non_ref_properties=non_ref_properties,

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -17,7 +17,7 @@ from typing import (
 from google.protobuf.struct_pb2 import Struct
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
-from weaviate.collection.classes.batch import _DeleteBatchResult
+from weaviate.collection.classes.batch import _BatchDeleteResult
 from weaviate.collection.classes.config import ConsistencyLevel
 from weaviate.collection.classes.data import (
     BatchReference,
@@ -127,7 +127,7 @@ class _Data:
 
     def delete_many(
         self, where: _Filters, verbose: bool = False, dry_run: bool = False
-    ) -> _DeleteBatchResult:
+    ) -> _BatchDeleteResult:
         return self._batch_rest.delete(
             self.name, where, verbose, dry_run, self._consistency_level, self._tenant
         )

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -111,7 +111,7 @@ class _Data:
             all_responses=all_responses,
         )
 
-    def delete_by_id(self, uuid: UUID) -> bool:
+    def delete(self, uuid: UUID) -> bool:
         path = f"/objects/{self.name}/{uuid}"
 
         try:
@@ -124,7 +124,7 @@ class _Data:
             return False  # did not exist
         raise UnexpectedStatusCodeException("Delete object", response)
 
-    def delete(
+    def delete_many(
         self, where: _Filters, verbose: bool = False, dry_run: bool = False
     ) -> Dict[str, Any]:
         return self._batch_rest.delete(

--- a/weaviate/collection/extract_filters.py
+++ b/weaviate/collection/extract_filters.py
@@ -1,5 +1,5 @@
 import uuid as uuid_lib
-from typing import Optional, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 from weaviate.collection.classes.filters import (
     _Filters,
@@ -28,7 +28,7 @@ class FilterToGRPC:
     def __value_filter(weav_filter: _FilterValue) -> weaviate_pb2.Filters:
 
         return weaviate_pb2.Filters(
-            operator=weav_filter.operator,
+            operator=weav_filter.operator._to_grpc(),
             value_text=FilterToGRPC.__filter_to_text(weav_filter.value),
             value_int=weav_filter.value if isinstance(weav_filter.value, int) else None,
             value_boolean=weav_filter.value if isinstance(weav_filter.value, bool) else None,  # type: ignore
@@ -99,10 +99,70 @@ class FilterToGRPC:
     def __and_or_filter(weav_filter: _Filters) -> Optional[weaviate_pb2.Filters]:
         assert isinstance(weav_filter, _FilterAnd) or isinstance(weav_filter, _FilterOr)
         return weaviate_pb2.Filters(
-            operator=weav_filter.operator,
+            operator=weav_filter.operator._to_grpc(),
             filters=[
                 filter_
                 for single_filter in weav_filter.filters
                 if (filter_ := FilterToGRPC.convert(single_filter)) is not None
             ],
         )
+
+
+class FilterToREST:
+    @staticmethod
+    def convert(weav_filter: Optional[_Filters]) -> Optional[Dict[str, Any]]:
+        if weav_filter is None:
+            return None
+        if isinstance(weav_filter, _FilterValue):
+            return FilterToREST.__value_filter(weav_filter)
+        else:
+            return FilterToREST.__and_or_filter(weav_filter)
+
+    @staticmethod
+    def __value_filter(weav_filter: _FilterValue) -> Dict[str, Any]:
+        return {
+            "operator": weav_filter.operator,
+            "path": weav_filter.path if isinstance(weav_filter.path, list) else [weav_filter.path],
+            **FilterToREST.__parse_filter(weav_filter.value),
+        }
+
+    @staticmethod
+    def __parse_filter(value: FilterValues) -> Dict[str, Any]:
+        if isinstance(value, str):
+            return {"valueText": value}
+        if isinstance(value, uuid_lib.UUID):
+            return {"valueText": str(value)}
+        if isinstance(value, TIME):
+            return {"valueDate": _datetime_to_string(value)}
+        if isinstance(value, bool):
+            return {"valueBoolean": value}
+        if isinstance(value, int):
+            return {"valueInt": value}
+        if isinstance(value, float):
+            return {"valueNumber": value}
+        if isinstance(value, list):
+            if isinstance(value[0], str):
+                return {"valueTextArray": value}
+            if isinstance(value[0], uuid_lib.UUID):
+                return {"valueTextArray": [str(val) for val in value]}
+            if isinstance(value[0], TIME):
+                return {"valueDateArray": [_datetime_to_string(cast(TIME, val)) for val in value]}
+            if isinstance(value[0], bool):
+                return {"valueBooleanArray": value}
+            if isinstance(value[0], int):
+                return {"valueIntArray": value}
+            if isinstance(value[0], float):
+                return {"valueNumberArray": value}
+        return {}
+
+    @staticmethod
+    def __and_or_filter(weav_filter: _Filters) -> Dict[str, Any]:
+        assert isinstance(weav_filter, _FilterAnd) or isinstance(weav_filter, _FilterOr)
+        return {
+            "operator": weav_filter.operator,
+            "operands": [
+                filter_
+                for single_filter in weav_filter.filters
+                if (filter_ := FilterToREST.convert(single_filter)) is not None
+            ],
+        }

--- a/weaviate/collection/extract_filters.py
+++ b/weaviate/collection/extract_filters.py
@@ -121,7 +121,7 @@ class FilterToREST:
     @staticmethod
     def __value_filter(weav_filter: _FilterValue) -> Dict[str, Any]:
         return {
-            "operator": weav_filter.operator,
+            "operator": weav_filter.operator.value,
             "path": weav_filter.path if isinstance(weav_filter.path, list) else [weav_filter.path],
             **FilterToREST.__parse_filter(weav_filter.value),
         }
@@ -159,7 +159,7 @@ class FilterToREST:
     def __and_or_filter(weav_filter: _Filters) -> Dict[str, Any]:
         assert isinstance(weav_filter, _FilterAnd) or isinstance(weav_filter, _FilterOr)
         return {
-            "operator": weav_filter.operator,
+            "operator": weav_filter.operator.value,
             "operands": [
                 filter_
                 for single_filter in weav_filter.filters

--- a/weaviate/collection/extract_filters.py
+++ b/weaviate/collection/extract_filters.py
@@ -153,7 +153,7 @@ class FilterToREST:
                 return {"valueIntArray": value}
             if isinstance(value[0], float):
                 return {"valueNumberArray": value}
-        return {}
+        raise ValueError(f"Unknown filter value type: {type(value)}")
 
     @staticmethod
     def __and_or_filter(weav_filter: _Filters) -> Dict[str, Any]:

--- a/weaviate/collection/rest_batch.py
+++ b/weaviate/collection/rest_batch.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
-from weaviate.collection.classes.batch import _DeleteBatchResult
+from weaviate.collection.classes.batch import _BatchDeleteResult
 from weaviate.collection.classes.config import ConsistencyLevel
 from weaviate.collection.extract_filters import FilterToREST
 from weaviate.collection.classes.filters import _Filters
@@ -22,7 +22,7 @@ class _BatchREST:
         dry_run: bool,
         consistency_level: Optional[ConsistencyLevel],
         tenant: Optional[str],
-    ) -> _DeleteBatchResult:
+    ) -> _BatchDeleteResult:
         payload: Dict[str, Any] = {
             "match": {
                 "class": class_name,
@@ -50,9 +50,8 @@ class _BatchREST:
             raise RequestsConnectionError("Batch delete was not successful.") from conn_err
         res = _decode_json_response_dict(response, "Delete in batch")
         assert res is not None
-        return _DeleteBatchResult(
+        return _BatchDeleteResult(
             failed=res["results"]["failed"],
-            limit=res["results"]["limit"],
             matches=res["results"]["matches"],
             objects=res["results"]["objects"],
             successful=res["results"]["successful"],

--- a/weaviate/collection/rest_batch.py
+++ b/weaviate/collection/rest_batch.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
+from weaviate.collection.classes.batch import _DeleteBatchResult
 from weaviate.collection.classes.config import ConsistencyLevel
 from weaviate.collection.extract_filters import FilterToREST
 from weaviate.collection.classes.filters import _Filters
@@ -21,7 +22,7 @@ class _BatchREST:
         dry_run: bool,
         consistency_level: Optional[ConsistencyLevel],
         tenant: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> _DeleteBatchResult:
         payload: Dict[str, Any] = {
             "match": {
                 "class": class_name,
@@ -49,4 +50,10 @@ class _BatchREST:
             raise RequestsConnectionError("Batch delete was not successful.") from conn_err
         res = _decode_json_response_dict(response, "Delete in batch")
         assert res is not None
-        return res
+        return _DeleteBatchResult(
+            failed=res["results"]["failed"],
+            limit=res["results"]["limit"],
+            matches=res["results"]["matches"],
+            objects=res["results"]["objects"],
+            successful=res["results"]["successful"],
+        )

--- a/weaviate/collection/rest_batch.py
+++ b/weaviate/collection/rest_batch.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+from weaviate.collection.classes.config import ConsistencyLevel
+from weaviate.collection.classes.filters import _Filters
+from weaviate.connect import Connection
+
+
+class _BatchREST:
+    def __init__(
+        self, connection: Connection, consistency_level: Optional[ConsistencyLevel]
+    ) -> None:
+        self.__connection = connection
+        self.__consistency_level = consistency_level
+
+    def delete(
+        self, class_name: str, where: _Filters, verbose: bool = False, dry_run: bool = False
+    ) -> None:
+        pass

--- a/weaviate/collection/rest_batch.py
+++ b/weaviate/collection/rest_batch.py
@@ -1,18 +1,52 @@
-from typing import Optional
+from typing import Any, Dict, Optional
+
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weaviate.collection.classes.config import ConsistencyLevel
+from weaviate.collection.extract_filters import FilterToREST
 from weaviate.collection.classes.filters import _Filters
 from weaviate.connect import Connection
+from weaviate.util import _decode_json_response_dict
 
 
 class _BatchREST:
-    def __init__(
-        self, connection: Connection, consistency_level: Optional[ConsistencyLevel]
-    ) -> None:
+    def __init__(self, connection: Connection) -> None:
         self.__connection = connection
-        self.__consistency_level = consistency_level
 
     def delete(
-        self, class_name: str, where: _Filters, verbose: bool = False, dry_run: bool = False
-    ) -> None:
-        pass
+        self,
+        class_name: str,
+        where: _Filters,
+        verbose: bool,
+        dry_run: bool,
+        consistency_level: Optional[ConsistencyLevel],
+        tenant: Optional[str],
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "match": {
+                "class": class_name,
+                "where": FilterToREST.convert(where),
+            }
+        }
+        if verbose:
+            payload["output"] = "verbose"
+        if dry_run:
+            payload["dryRun"] = True
+
+        params = {}
+        if consistency_level is not None:
+            params["consistency"] = consistency_level.value
+        if tenant is not None:
+            params["tenant"] = tenant
+
+        try:
+            response = self.__connection.delete(
+                path="/batch/objects",
+                weaviate_object=payload,
+                params=params,
+            )
+        except RequestsConnectionError as conn_err:
+            raise RequestsConnectionError("Batch delete was not successful.") from conn_err
+        res = _decode_json_response_dict(response, "Delete in batch")
+        assert res is not None
+        return res


### PR DESCRIPTION
This PR adds support for a `collection.data.delete_many` method that sends batch delete requests through the REST API

In the process, `Filters` are abstracted slightly so that they can be used as a SSoT between REST and gRPC use-cases