### PR TITLE
API updates in response to UAT request

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -79,6 +79,27 @@ def test_create_get_and_delete(client: weaviate.Client):
     assert not client.collection.exists(name)
 
 
+def test_delete_multiple(client: weaviate.Client):
+    name1 = "TestDeleteMultiple1"
+    name2 = "TestDeleteMultiple2"
+    client.collection.create(
+        name=name1,
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=VectorizerFactory.none(),
+    )
+    client.collection.create(
+        name=name2,
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=VectorizerFactory.none(),
+    )
+    assert client.collection.exists(name1)
+    assert client.collection.exists(name2)
+
+    client.collection.delete([name1, name2])
+    assert not client.collection.exists(name1)
+    assert not client.collection.exists(name2)
+
+
 @pytest.mark.parametrize("use_typed_dict", [True, False])
 def test_get_with_dict_generic(client: weaviate.Client, use_typed_dict: bool):
     name = "TestGetWithDictGeneric"
@@ -189,6 +210,22 @@ def test_insert(client: weaviate.Client, which_generic: str):
         uuid = collection.data.insert(properties=insert_data)
     name = collection.data.get_by_id(uuid).properties["name"]
     assert name == insert_data["name"]
+
+
+def test_delete_by_id(client: weaviate.Client):
+    name = "TestDeleteById"
+    collection = client.collection.create(
+        name=name,
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=VectorizerFactory.none(),
+    )
+
+    uuid = collection.data.insert(properties={"name": "some name"})
+    assert collection.data.get_by_id(uuid) is not None
+    collection.data.delete_by_id(uuid)
+    assert collection.data.get_by_id(uuid) is None
+
+    client.collection.delete(name)
 
 
 def test_insert_many(client: weaviate.Client):

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -100,21 +100,8 @@ class Collection(CollectionBase):
         name = _capitalize_first_letter(name)
         return CollectionObject[Properties](self._connection, name, type_=data_model)
 
-    @overload
-    def delete(self, name: str) -> None:
-        """Use this method to delete a collection from the Weaviate instance by its name.
-
-        WARNING: If you have instances of client.collection.get() or client.collection.create()
-        for this collection within your code, they will cease to function correctly after this operation.
-
-        Parameters:
-        - name: The name of the collection to delete.
-        """
-        ...
-
-    @overload
-    def delete(self, name: List[str]) -> None:
-        """Use this method to delete collections from the Weaviate instance by their names.
+    def delete(self, name: Union[str, List[str]]) -> None:
+        """Use this method to delete collection(s) from the Weaviate instance by its/their name(s).
 
         WARNING: If you have instances of client.collection.get() or client.collection.create()
         for these collections within your code, they will cease to function correctly after this operation.
@@ -122,9 +109,6 @@ class Collection(CollectionBase):
         Parameters:
         - name: The names of the collections to delete.
         """
-        ...
-
-    def delete(self, name: Union[str, List[str]]) -> None:
         if isinstance(name, str):
             self._delete(_capitalize_first_letter(name))
         else:

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -100,6 +100,7 @@ class Collection(CollectionBase):
         name = _capitalize_first_letter(name)
         return CollectionObject[Properties](self._connection, name, type_=data_model)
 
+    @overload
     def delete(self, name: str) -> None:
         """Use this method to delete a collection from the Weaviate instance by its name.
 
@@ -109,7 +110,26 @@ class Collection(CollectionBase):
         Parameters:
         - name: The name of the collection to delete.
         """
-        self._delete(_capitalize_first_letter(name))
+        ...
+
+    @overload
+    def delete(self, name: List[str]) -> None:
+        """Use this method to delete collections from the Weaviate instance by their names.
+
+        WARNING: If you have instances of client.collection.get() or client.collection.create()
+        for these collections within your code, they will cease to function correctly after this operation.
+
+        Parameters:
+        - name: The names of the collections to delete.
+        """
+        ...
+
+    def delete(self, name: Union[str, List[str]]) -> None:
+        if isinstance(name, str):
+            self._delete(_capitalize_first_letter(name))
+        else:
+            for n in name:
+                self._delete(_capitalize_first_letter(n))
 
     def exists(self, name: str) -> bool:
         return self._exists(_capitalize_first_letter(name))

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -108,7 +108,7 @@ class _Data:
             all_responses=all_responses,
         )
 
-    def delete(self, uuid: UUID) -> bool:
+    def delete_by_id(self, uuid: UUID) -> bool:
         path = f"/objects/{self.name}/{uuid}"
 
         try:


### PR DESCRIPTION
Renames `data.delete` to `data.delete_by_id` and allows `collection.delete(["One", "Two"])` through `typing.overload`

The `typing.overload` use here is so that each overload has a different docstring, since the language used must be different when deleting single vs multiple collections