### PR TITLE
move VectorizerConfig and GenerativeConfig into ConfigFactory

### DIFF
--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -15,7 +15,6 @@ from weaviate.collection.classes.config import (
     VectorDistance,
     VectorIndexType,
     Vectorizer,
-    VectorizerFactory,
 )
 
 
@@ -32,7 +31,7 @@ def client():
 def test_collection_list(client: weaviate.Client):
     client.collection.create(
         name="TestCollectionList",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="name", data_type=DataType.TEXT),
             Property(name="age", data_type=DataType.INT),
@@ -53,7 +52,7 @@ def test_collection_list(client: weaviate.Client):
 def test_collection_get_simple(client: weaviate.Client):
     client.collection.create(
         name="TestCollectionGetSimple",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="name", data_type=DataType.TEXT),
             Property(name="age", data_type=DataType.INT),
@@ -124,7 +123,7 @@ def test_collection_config_defaults(client: weaviate.Client):
         multi_tenancy_config=ConfigFactory.multi_tenancy(),
         replication_config=ConfigFactory.replication(),
         vector_index_config=ConfigFactory.vector_index(),
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     config = collection.config.get()
 
@@ -174,7 +173,7 @@ def test_collection_config_full(client: weaviate.Client):
     collection = client.collection.create(
         name="TestCollectionConfigFull",
         description="Test",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="text", data_type=DataType.TEXT),
             Property(name="texts", data_type=DataType.TEXT_ARRAY),
@@ -295,7 +294,7 @@ def test_collection_config_full(client: weaviate.Client):
 def test_collection_config_update(client: weaviate.Client):
     collection = client.collection.create(
         name="TestCollectionConfigUpdate",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="name", data_type=DataType.TEXT),
             Property(name="age", data_type=DataType.INT),

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -13,7 +13,6 @@ from weaviate.collection.classes.config import (
     ReferenceProperty,
     ReferencePropertyMultiTarget,
     Tokenization,
-    VectorizerFactory,
 )
 from weaviate.collection.classes.data import DataObject
 from weaviate.collection.classes.filters import (
@@ -55,7 +54,7 @@ def test_filters_text(client: weaviate.Client, weaviate_filter: _FilterValue, re
     client.collection.delete("TestFilterText")
     collection = client.collection.create(
         name="TestFilterText",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[Property(name="name", data_type=DataType.TEXT)],
     )
 
@@ -100,7 +99,7 @@ def test_filters_nested(
     client.collection.delete("TestFilterNested")
     collection = client.collection.create(
         name="TestFilterNested",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[Property(name="num", data_type=DataType.NUMBER)],
         inverted_index_config=ConfigFactory.inverted_index(index_null_state=True),
     )
@@ -125,7 +124,7 @@ def test_length_filter(client: weaviate.Client):
     client.collection.delete("TestFilterNested")
     collection = client.collection.create(
         name="TestFilterNested",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[Property(name="field", data_type=DataType.TEXT)],
         inverted_index_config=ConfigFactory.inverted_index(index_property_length=True),
     )
@@ -158,7 +157,7 @@ def test_filters_comparison(
     client.collection.delete("TestFilterNumber")
     collection = client.collection.create(
         name="TestFilterNumber",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[Property(name="number", data_type=DataType.INT)],
         inverted_index_config=ConfigFactory.inverted_index(index_null_state=True),
     )
@@ -220,7 +219,7 @@ def test_filters_contains(
     client.collection.delete("TestFilterContains")
     collection = client.collection.create(
         name="TestFilterContains",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="text", data_type=DataType.TEXT),
             Property(name="texts", data_type=DataType.TEXT_ARRAY),
@@ -322,7 +321,7 @@ def test_ref_filters(client: weaviate.Client, weaviate_filter: _FilterValue, res
     client.collection.delete("TestFilterRef2")
     to_collection = client.collection.create(
         name="TestFilterRef2",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="int", data_type=DataType.INT),
             Property(name="text", data_type=DataType.TEXT),
@@ -339,7 +338,7 @@ def test_ref_filters(client: weaviate.Client, weaviate_filter: _FilterValue, res
             ReferenceProperty(name="ref", target_collection="TestFilterRef2"),
             Property(name="name", data_type=DataType.TEXT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
 
     uuids_from = [
@@ -363,7 +362,7 @@ def test_ref_filters_multi_target(client: weaviate.Client):
     client.collection.delete(target)
     to_collection = client.collection.create(
         name=target,
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[Property(name="int", data_type=DataType.INT)],
     )
     uuid_to = to_collection.data.insert(properties={"int": 0})
@@ -376,7 +375,7 @@ def test_ref_filters_multi_target(client: weaviate.Client):
             ),
             Property(name="name", data_type=DataType.TEXT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
 
     uuid_from_to_target1 = from_collection.data.insert(
@@ -745,7 +744,7 @@ def test_delete_many_simple(
         name=name,
         properties=properties,
         inverted_index_config=ConfigFactory.inverted_index(index_null_state=True),
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     collection.data.insert_many(objects)
     assert len(collection.query.fetch_objects().objects) == len(objects)
@@ -763,7 +762,7 @@ def test_delete_many_and(client: weaviate.Client):
             Property(name="Name", data_type=DataType.TEXT),
             Property(name="Age", data_type=DataType.INT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     collection.data.insert_many(
         [
@@ -792,7 +791,7 @@ def test_delete_many_or(client: weaviate.Client):
             Property(name="Name", data_type=DataType.TEXT),
             Property(name="Age", data_type=DataType.INT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     collection.data.insert_many(
         [
@@ -818,7 +817,7 @@ def test_delete_many_return(client: weaviate.Client):
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     collection.data.insert_many(
         [

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -20,7 +20,6 @@ import weaviate
 from weaviate.collection.classes.config import (
     ConfigFactory,
     PropertyConfig,
-    VectorizerFactory,
 )
 from weaviate.collection.classes.internal import ReferenceFactory
 from weaviate.collection.classes.orm import BaseProperty, CollectionModelConfig
@@ -41,7 +40,7 @@ def client():
     )
     client.collection_model.delete(Group)
     collection = client.collection_model.create(
-        CollectionModelConfig[Group](model=Group, vectorizer_config=VectorizerFactory.none())
+        CollectionModelConfig[Group](model=Group, vectorizer_config=ConfigFactory.Vectorizer.none())
     )
     collection.data.insert(obj=Group(name="Name", uuid=REF_TO_UUID))
 
@@ -75,7 +74,7 @@ def test_types(client: weaviate.Client, member_type, value, optional: bool):
     client.collection_model.delete(ModelTypes)
     collection = client.collection_model.create(
         CollectionModelConfig[ModelTypes](
-            model=ModelTypes, vectorizer_config=VectorizerFactory.none()
+            model=ModelTypes, vectorizer_config=ConfigFactory.Vectorizer.none()
         )
     )
     assert collection.model == ModelTypes
@@ -108,7 +107,7 @@ def test_types_annotates(client: weaviate.Client, member_type, annotation, value
     client.collection_model.delete(ModelTypes)
     collection = client.collection_model.create(
         CollectionModelConfig[ModelTypes](
-            model=ModelTypes, vectorizer_config=VectorizerFactory.none()
+            model=ModelTypes, vectorizer_config=ConfigFactory.Vectorizer.none()
         )
     )
     assert collection.model == ModelTypes
@@ -128,7 +127,7 @@ def test_create_and_delete(client: weaviate.Client):
     client.collection_model.delete(DeleteModel)
     client.collection_model.create(
         CollectionModelConfig[DeleteModel](
-            model=DeleteModel, vectorizer_config=VectorizerFactory.none()
+            model=DeleteModel, vectorizer_config=ConfigFactory.Vectorizer.none()
         )
     )
 
@@ -144,7 +143,7 @@ def test_search(client: weaviate.Client):
     client.collection_model.delete(SearchTest)
     collection = client.collection_model.create(
         CollectionModelConfig[SearchTest](
-            model=SearchTest, vectorizer_config=VectorizerFactory.none()
+            model=SearchTest, vectorizer_config=ConfigFactory.Vectorizer.none()
         )
     )
 
@@ -163,7 +162,7 @@ def test_tenants(client: weaviate.Client):
     client.collection_model.delete(TenantsTest)
     collection = client.collection_model.create(
         CollectionModelConfig[TenantsTest](
-            vectorizer_config=VectorizerFactory.none(),
+            vectorizer_config=ConfigFactory.Vectorizer.none(),
             multi_tenancy_config=ConfigFactory.multi_tenancy(enabled=True),
             model=TenantsTest,
         )
@@ -189,7 +188,7 @@ def test_tenants_activity(client: weaviate.Client):
     client.collection_model.delete(TenantsUpdateTest)
     collection = client.collection_model.create(
         CollectionModelConfig[TenantsUpdateTest](
-            vectorizer_config=VectorizerFactory.none(),
+            vectorizer_config=ConfigFactory.Vectorizer.none(),
             multi_tenancy_config=ConfigFactory.multi_tenancy(enabled=True),
             model=TenantsUpdateTest,
         )
@@ -214,7 +213,7 @@ def test_tenants_update(client: weaviate.Client):
     client.collection_model.delete(TenantsUpdateTest)
     collection = client.collection_model.create(
         CollectionModelConfig[TenantsUpdateTest](
-            vectorizer_config=VectorizerFactory.none(),
+            vectorizer_config=ConfigFactory.Vectorizer.none(),
             multi_tenancy_config=ConfigFactory.multi_tenancy(enabled=True),
             model=TenantsUpdateTest,
         )
@@ -235,7 +234,7 @@ def test_multi_searches(client: weaviate.Client):
     client.collection_model.delete(TestMultiSearches)
     collection = client.collection_model.create(
         CollectionModelConfig[TestMultiSearches](
-            model=TestMultiSearches, vectorizer_config=VectorizerFactory.none()
+            model=TestMultiSearches, vectorizer_config=ConfigFactory.Vectorizer.none()
         )
     )
 
@@ -267,7 +266,7 @@ def test_multi_searches_with_references(client: weaviate.Client):
     client.collection_model.delete(TestMultiSearchesWithReferences)
     collection = client.collection_model.create(
         CollectionModelConfig[TestMultiSearchesWithReferences](
-            model=TestMultiSearchesWithReferences, vectorizer_config=VectorizerFactory.none()
+            model=TestMultiSearchesWithReferences, vectorizer_config=ConfigFactory.Vectorizer.none()
         )
     )
 
@@ -307,7 +306,7 @@ def test_search_with_tenant(client: weaviate.Client):
     collection = client.collection_model.create(
         CollectionModelConfig[TestTenantSearch](
             model=TestTenantSearch,
-            vectorizer_config=VectorizerFactory.none(),
+            vectorizer_config=ConfigFactory.Vectorizer.none(),
             multi_tenancy_config=ConfigFactory.multi_tenancy(enabled=True),
         )
     )
@@ -363,7 +362,7 @@ def test_update_properties(
         client.collection_model.delete(TestPropUpdate)
         collection_first = client.collection_model.create(
             CollectionModelConfig[TestPropUpdate](
-                model=TestPropUpdate, vectorizer_config=VectorizerFactory.none()
+                model=TestPropUpdate, vectorizer_config=ConfigFactory.Vectorizer.none()
             )
         )
         uuid_first = collection_first.data.insert(TestPropUpdate(name="first"))
@@ -413,7 +412,7 @@ def test_empty_search_returns_everything(client: weaviate.Client):
     collection = client.collection_model.create(
         CollectionModelConfig[TestReturnEverythingORM](
             model=TestReturnEverythingORM,
-            vectorizer_config=VectorizerFactory.none(),
+            vectorizer_config=ConfigFactory.Vectorizer.none(),
         )
     )
     collection.data.insert(TestReturnEverythingORM(name="word"))
@@ -436,7 +435,7 @@ def test_empty_return_properties(client: weaviate.Client):
     collection = client.collection_model.create(
         CollectionModelConfig[TestEmptyProperties](
             model=TestEmptyProperties,
-            vectorizer_config=VectorizerFactory.none(),
+            vectorizer_config=ConfigFactory.Vectorizer.none(),
         )
     )
     collection.data.insert(TestEmptyProperties(name="word"))
@@ -459,7 +458,7 @@ def test_update_reference_property(client: weaviate.Client):
         client.collection_model.delete(TestRefPropUpdate)
         collection_first = client.collection_model.create(
             CollectionModelConfig[TestRefPropUpdate](
-                model=TestRefPropUpdate, vectorizer_config=VectorizerFactory.none()
+                model=TestRefPropUpdate, vectorizer_config=ConfigFactory.Vectorizer.none()
             )
         )
         uuid_first = collection_first.data.insert(TestRefPropUpdate(name="first"))
@@ -480,7 +479,7 @@ def test_model_with_datetime_property(client: weaviate.Client):
     client.collection_model.delete(TestDatetime)
     collection = client.collection_model.create(
         CollectionModelConfig[TestDatetime](
-            model=TestDatetime, vectorizer_config=VectorizerFactory.none()
+            model=TestDatetime, vectorizer_config=ConfigFactory.Vectorizer.none()
         )
     )
     now = datetime.now(timezone.utc)

--- a/integration/test_collection_multi_node.py
+++ b/integration/test_collection_multi_node.py
@@ -4,7 +4,6 @@ import weaviate
 from weaviate import Config
 from weaviate.collection.classes.config import (
     ConfigFactory,
-    VectorizerFactory,
     Property,
     ConsistencyLevel,
     DataType,
@@ -31,7 +30,7 @@ def test_consistency_on_multinode(client: weaviate.Client, level: ConsistencyLev
     client.collection.delete(name)
     collection = client.collection.create(
         name=name,
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="name", data_type=DataType.TEXT),
         ],

--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -6,10 +6,9 @@ import pytest
 import weaviate
 from weaviate import Config
 from weaviate.collection.classes.config import (
+    ConfigFactory,
     DataType,
     Property,
-    GenerativeFactory,
-    VectorizerFactory,
 )
 from weaviate.collection.classes.data import DataObject
 from weaviate.collection.classes.grpc import Generate, MetadataQuery
@@ -42,7 +41,7 @@ def test_generative_search_single(client: weaviate.Client, parameter: str, answe
             Property(name="text", data_type=DataType.TEXT),
             Property(name="content", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -77,7 +76,7 @@ def test_fetch_objects_generate_search_grouped(
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -106,7 +105,7 @@ def test_fetch_objects_generate_search_grouped_all_props(client: weaviate.Client
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -144,7 +143,7 @@ def test_fetch_objects_generate_search_grouped_specified_prop(client: weaviate.C
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -183,7 +182,7 @@ def test_fetch_objects_generate_with_everything(client: weaviate.Client):
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -224,7 +223,7 @@ def test_bm25_generate_with_everything(client: weaviate.Client):
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -267,7 +266,7 @@ def test_hybrid_generate_with_everything(client: weaviate.Client):
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -310,8 +309,8 @@ def test_near_text_generate_with_everything(client: weaviate.Client):
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
-        vectorizer_config=VectorizerFactory.text2vec_openai(vectorize_class_name=False),
+        generative_config=ConfigFactory.Generative.openai(),
+        vectorizer_config=ConfigFactory.Vectorizer.text2vec_openai(vectorize_class_name=False),
     )
 
     collection.data.insert_many(
@@ -353,7 +352,7 @@ def test_near_vector_generate_with_everything(client: weaviate.Client):
             Property(name="content", data_type=DataType.TEXT),
             Property(name="extra", data_type=DataType.TEXT),
         ],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
 
     collection.data.insert_many(
@@ -399,7 +398,7 @@ def test_openapi_invalid_key():
     collection = local_client.collection.create(
         name=name,
         properties=[Property(name="text", data_type=DataType.TEXT)],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
     collection.data.insert(properties={"text": "test"})
     with pytest.raises(WeaviateGRPCException):
@@ -420,7 +419,7 @@ def test_openapi_no_module():
     collection = local_client.collection.create(
         name=name,
         properties=[Property(name="text", data_type=DataType.TEXT)],
-        generative_config=GenerativeFactory.openai(),
+        generative_config=ConfigFactory.Generative.openai(),
     )
     collection.data.insert(properties={"text": "test"})
     with pytest.raises(WeaviateGRPCException):
@@ -437,7 +436,7 @@ def test_openai_batch_upload(client: weaviate.Client):
         properties=[
             Property(name="text", data_type=DataType.TEXT),
         ],
-        vectorizer_config=VectorizerFactory.text2vec_openai(),
+        vectorizer_config=ConfigFactory.Vectorizer.text2vec_openai(),
     )
 
     ret = collection.data.insert_many(

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -17,11 +17,11 @@ else:
 import weaviate
 from weaviate import Config
 from weaviate.collection.classes.config import (
+    ConfigFactory,
     Property,
     DataType,
     ReferenceProperty,
     ReferencePropertyMultiTarget,
-    VectorizerFactory,
 )
 
 from weaviate.collection.classes.internal import ReferenceFactory
@@ -40,13 +40,13 @@ def client():
 
 def test_reference_add_delete_replace(client: weaviate.Client):
     ref_collection = client.collection.create(
-        name="RefClass2", vectorizer_config=VectorizerFactory.none()
+        name="RefClass2", vectorizer_config=ConfigFactory.Vectorizer.none()
     )
     uuid_to = ref_collection.data.insert(properties={})
     collection = client.collection.create(
         name="SomethingElse",
         properties=[ReferenceProperty(name="ref", target_collection="RefClass2")],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
 
     uuid_from1 = collection.data.insert({}, uuid.uuid4())
@@ -79,7 +79,7 @@ def test_reference_add_delete_replace(client: weaviate.Client):
 def test_mono_references_grpc(client: weaviate.Client):
     A = client.collection.create(
         name="A",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
         ],
@@ -96,7 +96,7 @@ def test_mono_references_grpc(client: weaviate.Client):
             Property(name="Name", data_type=DataType.TEXT),
             ReferenceProperty(name="ref", target_collection="A"),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     uuid_B = B.data.insert({"Name": "B", "ref": ReferenceFactory.to(uuids=uuid_A1)})
     B.data.reference_add(
@@ -134,7 +134,7 @@ def test_mono_references_grpc(client: weaviate.Client):
             Property(name="Name", data_type=DataType.TEXT),
             ReferenceProperty(name="ref", target_collection="B"),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     C.data.insert({"Name": "find me", "ref": ReferenceFactory.to(uuids=uuid_B)})
 
@@ -186,7 +186,7 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.Client):
 
     client.collection.create(
         name="ATypedDicts",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
         ],
@@ -201,7 +201,7 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.Client):
             Property(name="Name", data_type=DataType.TEXT),
             ReferenceProperty(name="ref", target_collection="ATypedDicts"),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     B = client.collection.get("BTypedDicts", BProps)
     uuid_B = B.data.insert(
@@ -218,7 +218,7 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.Client):
             Property(name="Age", data_type=DataType.INT),
             ReferenceProperty(name="ref", target_collection="BTypedDicts"),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     C = client.collection.get("CTypedDicts", CProps)
     C.data.insert(properties=CProps(name="find me", ref=ReferenceFactory[BProps].to(uuids=uuid_B)))
@@ -265,7 +265,7 @@ def test_multi_references_grpc(client: weaviate.Client):
 
     A = client.collection.create(
         name="A",
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
         ],
@@ -277,7 +277,7 @@ def test_multi_references_grpc(client: weaviate.Client):
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     uuid_B = B.data.insert({"Name": "B"})
 
@@ -287,7 +287,7 @@ def test_multi_references_grpc(client: weaviate.Client):
             Property(name="Name", data_type=DataType.TEXT),
             ReferencePropertyMultiTarget(name="ref", target_collections=["A", "B"]),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     C.data.insert(
         {
@@ -350,7 +350,7 @@ def test_references_batch(client: weaviate.Client):
 
     ref_collection = client.collection.create(
         name=name_ref_to,
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
         properties=[Property(name="num", data_type=DataType.INT)],
     )
     num_objects = 10
@@ -364,7 +364,7 @@ def test_references_batch(client: weaviate.Client):
             ReferenceProperty(name="ref", target_collection=name_ref_to),
             Property(name="num", data_type=DataType.INT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     uuids_from = collection.data.insert_many(
         [DataObject(properties={"num": i}) for i in range(num_objects)]
@@ -400,7 +400,7 @@ def test_references_batch_with_errors(client: weaviate.Client):
 
     _ = client.collection.create(
         name=name_ref_to,
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
 
     collection = client.collection.create(
@@ -409,7 +409,7 @@ def test_references_batch_with_errors(client: weaviate.Client):
             ReferenceProperty(name="ref", target_collection=name_ref_to),
             Property(name="num", data_type=DataType.INT),
         ],
-        vectorizer_config=VectorizerFactory.none(),
+        vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
 
     batch_return = collection.data.reference_add_many(

--- a/weaviate/classes.py
+++ b/weaviate/classes.py
@@ -1,15 +1,12 @@
 from weaviate.collection.classes.config import (
     ConfigFactory,
     DataType,
-    GenerativeFactory,
     Multi2VecField,
     Property,
     ReferenceProperty,
     ReferencePropertyMultiTarget,
     Tokenization,
-    VectorizerFactory,
     VectorDistance,
-    VectorIndexType,
 )
 from weaviate.collection.classes.data import (
     DataObject,
@@ -30,7 +27,6 @@ __all__ = [
     "DataObject",
     "DataType",
     "Filter",
-    "GenerativeFactory",
     "Generate",
     "HybridFusion",
     "LinkTo",
@@ -43,7 +39,5 @@ __all__ = [
     "ReferencePropertyMultiTarget",
     "Tenant",
     "Tokenization",
-    "VectorizerFactory",
     "VectorDistance",
-    "VectorIndexType",
 ]

--- a/weaviate/collection/classes/config.py
+++ b/weaviate/collection/classes/config.py
@@ -311,7 +311,7 @@ class _VectorizerConfig(_ConfigCreateModel):
     vectorizer: Vectorizer
 
 
-class GenerativeFactory:
+class _GenerativeFactory:
     @classmethod
     def openai(
         cls,
@@ -572,7 +572,7 @@ class _Ref2VecCentroidConfig(_VectorizerConfig):
     method: Literal["mean"]
 
 
-class VectorizerFactory:
+class _VectorizerFactory:
     """Use this factory class to generate the correct `VectorizerConfig` object for use in the `CollectionConfig` object.
 
     Each classmethod provides options specific to the named vectorizer in the function's name. Under-the-hood data validation steps
@@ -935,7 +935,7 @@ class _CollectionConfigCreateBase(_ConfigCreateModel):
         default=VectorIndexType.HNSW, alias="vector_index_type"
     )
     moduleConfig: _VectorizerConfig = Field(
-        default=VectorizerFactory.none(), alias="vectorizer_config"
+        default=_VectorizerFactory.none(), alias="vectorizer_config"
     )
     generativeSearch: Optional[_GenerativeConfig] = Field(default=None, alias="generative_config")
 
@@ -1235,6 +1235,9 @@ class ConfigFactory:
     will ensure that any mis-specifications are caught before the request is sent to Weaviate.
     """
 
+    Generative = _GenerativeFactory
+    Vectorizer = _VectorizerFactory
+
     @classmethod
     def inverted_index(
         cls,
@@ -1373,6 +1376,10 @@ class ConfigFactory:
             skip=skip,
             vectorCacheMaxObjects=vector_cache_max_objects,
         )
+
+    @classmethod
+    def vector_index_type(cls) -> VectorIndexType:
+        return VectorIndexType.HNSW
 
 
 class ConfigUpdateFactory:

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -13,7 +13,7 @@ from weaviate.collection.classes.config import (
     ReferencePropertyBase,
     _ReplicationConfigCreate,
     _VectorizerConfig,
-    VectorizerFactory,
+    _VectorizerFactory,
     _VectorIndexConfigCreate,
     VectorIndexType,
 )
@@ -84,7 +84,7 @@ class Collection(CollectionBase):
             properties=properties,
             replication_config=replication_config,
             sharding_config=sharding_config,
-            vectorizer_config=vectorizer_config or VectorizerFactory.none(),
+            vectorizer_config=vectorizer_config or _VectorizerFactory.none(),
             vector_index_config=vector_index_config,
             vector_index_type=vector_index_type,
         )


### PR DESCRIPTION
This PR moves `VectorizerConfig` and `GenerativeConfig` into `ConfigFactory` as class variables to be used like `ConfigFactory.Vectorizer.none()`. In doing so, it renames them to `_VectorizerConfig` and `_GenerativeConfig` to highlight their internal use to users.