### PR TITLE
Change default GRPC port for embedded

### DIFF
--- a/test/test_client.py
+++ b/test/test_client.py
@@ -130,10 +130,10 @@ class TestWeaviateClient(unittest.TestCase):
                 with patch("weaviate.embedded.EmbeddedDB.start") as mocked_start:
                     Client(embedded_options=EmbeddedOptions())
                     args, kwargs = mock_obj.call_args_list[0]
-                    self.assertEqual(kwargs["url"], "http://localhost:6666")
+                    self.assertEqual(kwargs["url"], "http://localhost:8079")
                     self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))
                     self.assertTrue(kwargs["embedded_db"] is not None)
-                    self.assertEqual(kwargs["embedded_db"].options.port, 6666)
+                    self.assertEqual(kwargs["embedded_db"].options.port, 8079)
                     mocked_start.assert_called_once()
 
     @patch("weaviate.client.Client.get_meta", return_value={"version": "1.13.2"})

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -15,11 +15,14 @@ from werkzeug import Request, Response
 
 import weaviate
 from weaviate import embedded, EmbeddedOptions
+from weaviate.config import Config
 from weaviate.embedded import EmbeddedDB
 from weaviate.exceptions import WeaviateEmbeddedInvalidVersion, WeaviateStartUpError
 
 if platform != "linux" and platform != "darwin":
     pytest.skip("Currently only supported on linux", allow_module_level=True)
+
+GRPC_EMBEDDED_DEFAULT_PORT = 50060
 
 
 def test_embedded__init__(tmp_path):
@@ -205,6 +208,7 @@ def test_weaviate_state(tmp_path_factory: pytest.TempPathFactory):
     )
     client.data_object.create({"name": "Name"}, "Person", uuid.uuid4())
     assert sock.connect_ex(("127.0.0.1", port)) == 0  # running
+
     client._connection.embedded_db.stop()
     del client
     time.sleep(5)  # give weaviate time to shut down
@@ -270,3 +274,38 @@ def test_invalid_version(tmp_path_factory: pytest.TempPathFactory, version):
                 version=version,
             )
         )
+
+
+def test_embedded_with_grpc_port(tmp_path_factory: pytest.TempPathFactory):
+    client = weaviate.Client(
+        embedded_options=EmbeddedOptions(
+            persistence_data_path=tmp_path_factory.mktemp("data"),
+            binary_path=tmp_path_factory.mktemp("bin"),
+            version="latest",
+            port=30668,
+        ),
+        additional_config=Config(grpc_port_experimental=GRPC_EMBEDDED_DEFAULT_PORT + 1),
+    )
+
+    assert client.is_ready()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1.0)  # we're only pinging the port, 1s is plenty
+
+    assert sock.connect_ex(("127.0.0.1", GRPC_EMBEDDED_DEFAULT_PORT + 1)) == 0  # running
+
+
+def test_embedded_with_grpc_port_default(tmp_path_factory: pytest.TempPathFactory):
+    client = weaviate.Client(
+        embedded_options=EmbeddedOptions(
+            persistence_data_path=tmp_path_factory.mktemp("data"),
+            binary_path=tmp_path_factory.mktemp("bin"),
+            version="latest",
+            port=30669,
+        )
+    )
+
+    assert client.is_ready()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1.0)  # we're only pinging the port, 1s is plenty
+
+    assert sock.connect_ex(("127.0.0.1", GRPC_EMBEDDED_DEFAULT_PORT)) == 0  # running

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -15,7 +15,6 @@ from werkzeug import Request, Response
 
 import weaviate
 from weaviate import embedded, EmbeddedOptions
-from weaviate.config import Config
 from weaviate.embedded import EmbeddedDB
 from weaviate.exceptions import WeaviateEmbeddedInvalidVersion, WeaviateStartUpError
 
@@ -27,7 +26,7 @@ GRPC_EMBEDDED_DEFAULT_PORT = 50060
 
 def test_embedded__init__(tmp_path):
     assert (
-        EmbeddedDB(EmbeddedOptions(port=6666, persistence_data_path=tmp_path)).options.port == 6666
+        EmbeddedDB(EmbeddedOptions(port=8079, persistence_data_path=tmp_path)).options.port == 8079
     )
 
 
@@ -283,8 +282,8 @@ def test_embedded_with_grpc_port(tmp_path_factory: pytest.TempPathFactory):
             binary_path=tmp_path_factory.mktemp("bin"),
             version="latest",
             port=30668,
+            grpc_port=GRPC_EMBEDDED_DEFAULT_PORT + 1,
         ),
-        additional_config=Config(grpc_port_experimental=GRPC_EMBEDDED_DEFAULT_PORT + 1),
     )
 
     assert client.is_ready()

--- a/test/test_embedded.py
+++ b/test/test_embedded.py
@@ -21,8 +21,6 @@ from weaviate.exceptions import WeaviateEmbeddedInvalidVersion, WeaviateStartUpE
 if platform != "linux" and platform != "darwin":
     pytest.skip("Currently only supported on linux", allow_module_level=True)
 
-GRPC_EMBEDDED_DEFAULT_PORT = 50060
-
 
 def test_embedded__init__(tmp_path):
     assert (
@@ -282,7 +280,7 @@ def test_embedded_with_grpc_port(tmp_path_factory: pytest.TempPathFactory):
             binary_path=tmp_path_factory.mktemp("bin"),
             version="latest",
             port=30668,
-            grpc_port=GRPC_EMBEDDED_DEFAULT_PORT + 1,
+            grpc_port=50061,
         ),
     )
 
@@ -290,7 +288,7 @@ def test_embedded_with_grpc_port(tmp_path_factory: pytest.TempPathFactory):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(1.0)  # we're only pinging the port, 1s is plenty
 
-    assert sock.connect_ex(("127.0.0.1", GRPC_EMBEDDED_DEFAULT_PORT + 1)) == 0  # running
+    assert sock.connect_ex(("127.0.0.1", 50061)) == 0  # running
 
 
 def test_embedded_with_grpc_port_default(tmp_path_factory: pytest.TempPathFactory):
@@ -307,4 +305,4 @@ def test_embedded_with_grpc_port_default(tmp_path_factory: pytest.TempPathFactor
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(1.0)  # we're only pinging the port, 1s is plenty
 
-    assert sock.connect_ex(("127.0.0.1", GRPC_EMBEDDED_DEFAULT_PORT)) == 0  # running
+    assert sock.connect_ex(("127.0.0.1", 50060)) == 0  # running

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -145,9 +145,7 @@ class Client:
             If arguments are of a wrong data type.
         """
         config = Config() if additional_config is None else additional_config
-        url, embedded_db = self.__parse_url_and_embedded_db(
-            url, embedded_options, grpc_port=config.grpc_port_experimental
-        )
+        url, embedded_db = self.__parse_url_and_embedded_db(url, embedded_options)
 
         self._connection = Connection(
             url=url,
@@ -276,7 +274,7 @@ class Client:
 
     @staticmethod
     def __parse_url_and_embedded_db(
-        url: Optional[str], embedded_options: Optional[EmbeddedOptions], grpc_port: Optional[int]
+        url: Optional[str], embedded_options: Optional[EmbeddedOptions]
     ) -> Tuple[str, Optional[EmbeddedDB]]:
         if embedded_options is None and url is None:
             raise TypeError("Either url or embedded options must be present.")
@@ -286,7 +284,7 @@ class Client:
             )
 
         if embedded_options is not None:
-            embedded_db = EmbeddedDB(options=embedded_options, grpc_port=grpc_port)
+            embedded_db = EmbeddedDB(options=embedded_options)
             embedded_db.start()
             return f"http://localhost:{embedded_db.options.port}", embedded_db
 

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -144,8 +144,10 @@ class Client:
         TypeError
             If arguments are of a wrong data type.
         """
-        url, embedded_db = self.__parse_url_and_embedded_db(url, embedded_options)
         config = Config() if additional_config is None else additional_config
+        url, embedded_db = self.__parse_url_and_embedded_db(
+            url, embedded_options, grpc_port=config.grpc_port_experimental
+        )
 
         self._connection = Connection(
             url=url,
@@ -274,7 +276,7 @@ class Client:
 
     @staticmethod
     def __parse_url_and_embedded_db(
-        url: Optional[str], embedded_options: Optional[EmbeddedOptions]
+        url: Optional[str], embedded_options: Optional[EmbeddedOptions], grpc_port: Optional[int]
     ) -> Tuple[str, Optional[EmbeddedDB]]:
         if embedded_options is None and url is None:
             raise TypeError("Either url or embedded options must be present.")
@@ -284,7 +286,7 @@ class Client:
             )
 
         if embedded_options is not None:
-            embedded_db = EmbeddedDB(options=embedded_options)
+            embedded_db = EmbeddedDB(options=embedded_options, grpc_port=grpc_port)
             embedded_db.start()
             return f"http://localhost:{embedded_db.options.port}", embedded_db
 

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -31,7 +31,7 @@ class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", DEFAULT_PERSISTENCE_DATA_PATH)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", DEFAULT_BINARY_PATH)
     version: str = "1.21.1"
-    port: int = 6666
+    port: int = 8079
     hostname: str = "127.0.0.1"
     additional_env_vars: Optional[Dict[str, str]] = None
 
@@ -45,9 +45,10 @@ def get_random_port() -> int:
 
 
 class EmbeddedDB:
-    def __init__(self, options: EmbeddedOptions) -> None:
+    def __init__(self, options: EmbeddedOptions, grpc_port: Optional[int] = None) -> None:
         self.data_bind_port = get_random_port()
         self.options = options
+        self.grpc_port: int = grpc_port if grpc_port else 50600
         self.process: Optional[subprocess.Popen[bytes]] = None
         self.ensure_paths_exist()
         self.check_supported_platform()
@@ -196,6 +197,8 @@ class EmbeddedDB:
         my_env.setdefault("PERSISTENCE_DATA_PATH", self.options.persistence_data_path)
         # Bug with weaviate requires setting gossip and data bind port
         my_env.setdefault("CLUSTER_GOSSIP_BIND_PORT", str(get_random_port()))
+        my_env.setdefault("GRPC_PORT", str(object=self.grpc_port))
+
         my_env.setdefault(
             "ENABLE_MODULES",
             "text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,generative-openai,qna-openai,"

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -25,16 +25,19 @@ DEFAULT_BINARY_PATH = str(Path.home() / ".cache/weaviate-embedded/")
 DEFAULT_PERSISTENCE_DATA_PATH = str(Path.home() / ".local/share/weaviate")
 GITHUB_RELEASE_DOWNLOAD_URL = "https://github.com/weaviate/weaviate/releases/download/"
 
+DEFAULT_PORT = 8079
+DEFAULT_GRPC_PORT = 50060
+
 
 @dataclass
 class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", DEFAULT_PERSISTENCE_DATA_PATH)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", DEFAULT_BINARY_PATH)
     version: str = "1.21.1"
-    port: int = 8079
+    port: int = DEFAULT_PORT
     hostname: str = "127.0.0.1"
     additional_env_vars: Optional[Dict[str, str]] = None
-    grpc_port: int = 50060
+    grpc_port: int = DEFAULT_GRPC_PORT
 
 
 def get_random_port() -> int:

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -33,7 +33,7 @@ DEFAULT_GRPC_PORT = 50060
 class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", DEFAULT_PERSISTENCE_DATA_PATH)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", DEFAULT_BINARY_PATH)
-    version: str = "1.21.1"
+    version: str = "1.21.4"
     port: int = DEFAULT_PORT
     hostname: str = "127.0.0.1"
     additional_env_vars: Optional[Dict[str, str]] = None

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -34,6 +34,7 @@ class EmbeddedOptions:
     port: int = 8079
     hostname: str = "127.0.0.1"
     additional_env_vars: Optional[Dict[str, str]] = None
+    grpc_port: int = 50060
 
 
 def get_random_port() -> int:
@@ -45,10 +46,10 @@ def get_random_port() -> int:
 
 
 class EmbeddedDB:
-    def __init__(self, options: EmbeddedOptions, grpc_port: Optional[int] = None) -> None:
+    def __init__(self, options: EmbeddedOptions) -> None:
         self.data_bind_port = get_random_port()
         self.options = options
-        self.grpc_port: int = grpc_port if grpc_port else 50600
+        self.grpc_port: int = options.grpc_port
         self.process: Optional[subprocess.Popen[bytes]] = None
         self.ensure_paths_exist()
         self.check_supported_platform()
@@ -197,7 +198,7 @@ class EmbeddedDB:
         my_env.setdefault("PERSISTENCE_DATA_PATH", self.options.persistence_data_path)
         # Bug with weaviate requires setting gossip and data bind port
         my_env.setdefault("CLUSTER_GOSSIP_BIND_PORT", str(get_random_port()))
-        my_env.setdefault("GRPC_PORT", str(object=self.grpc_port))
+        my_env.setdefault("GRPC_PORT", str(self.grpc_port))
 
         my_env.setdefault(
             "ENABLE_MODULES",


### PR DESCRIPTION
This PR provides the ability to set the gRPC port for `EmbeddedDB` by extending `EmbeddedOptions` to have `grpc_port` variable whose default is set as 50060, which should not collide with standard `50051` gRPC port

In the process, it also changes the default `port` of `EmbeddedDB` from `6666`, which is a bad port as mentioned here https://github.com/weaviate/weaviate-python-client/pull/416, to `8079` so that any collisions with `8080` are avoided