### PR TITLE
Refactor naming conventions for cross references

### DIFF
--- a/ci/stop_weaviate.sh
+++ b/ci/stop_weaviate.sh
@@ -7,5 +7,5 @@ docker-compose -f ci/docker-compose-azure.yml down --remove-orphans
 docker-compose -f ci/docker-compose-okta-cc.yml down --remove-orphans
 docker-compose -f ci/docker-compose-okta-users.yml down --remove-orphans
 docker-compose -f ci/docker-compose-wcs.yml down --remove-orphans
-docker-compose -f ci/docker-compose-openai.yml down --remove-orphans
+docker-compose -f ci/docker-compose-generative.yml down --remove-orphans
 docker-compose -f ci/docker-compose-cluster.yml down --remove-orphans

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -30,7 +30,7 @@ from weaviate.collection.classes.data import (
 from weaviate.collection.classes.grpc import (
     GroupBy,
     HybridFusion,
-    LinkTo,
+    FromReference,
     MetadataQuery,
     Move,
     Sort,
@@ -1426,7 +1426,9 @@ def test_optional_ref_returns(client: weaviate.Client):
     )
     collection.data.insert(properties={"ref": ReferenceFactory.to(uuid_to1)})
 
-    objects = collection.query.fetch_objects(return_properties=[LinkTo(link_on="ref")]).objects
+    objects = collection.query.fetch_objects(
+        return_properties=[FromReference(link_on="ref")]
+    ).objects
 
     assert objects[0].properties["ref"].objects[0].properties["text"] == "ref text"
     assert objects[0].properties["ref"].objects[0].metadata.uuid is not None

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -21,7 +21,7 @@ from weaviate.collection.classes.config import (
     ConfigFactory,
     PropertyConfig,
 )
-from weaviate.collection.classes.internal import CrossReference, ReferenceFactory
+from weaviate.collection.classes.internal import Reference, ReferenceFactory
 from weaviate.collection.classes.orm import BaseProperty, CollectionModelConfig
 from weaviate.collection.classes.tenants import Tenant, TenantActivityStatus
 from pydantic import Field
@@ -96,8 +96,8 @@ def test_types(client: weaviate.Client, member_type, value, optional: bool):
     "member_type, annotation ,value,expected",
     [
         (str, PropertyConfig(index_filterable=False), "value", "text"),
-        (UUIDS, CrossReference[Group], [str(REF_TO_UUID)], "Group"),
-        (Optional[UUIDS], CrossReference[Group], [str(REF_TO_UUID)], "Group"),
+        (UUIDS, Reference[Group], [str(REF_TO_UUID)], "Group"),
+        (Optional[UUIDS], Reference[Group], [str(REF_TO_UUID)], "Group"),
     ],
 )
 def test_types_annotates(client: weaviate.Client, member_type, annotation, value, expected: str):
@@ -261,7 +261,7 @@ def test_multi_searches(client: weaviate.Client):
 def test_multi_searches_with_references(client: weaviate.Client):
     class TestMultiSearchesWithReferences(BaseProperty):
         name: Optional[str] = None
-        group: Optional[CrossReference[Group]] = None
+        group: Optional[Reference[Group]] = None
 
     client.collection_model.delete(TestMultiSearchesWithReferences)
     collection = client.collection_model.create(
@@ -465,7 +465,7 @@ def test_update_reference_property(client: weaviate.Client):
 
     class TestRefPropUpdate(BaseProperty):
         name: str
-        group: CrossReference[Group]
+        group: Reference[Group]
 
     create_original_collection()
     client.collection_model.update(TestRefPropUpdate)

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -21,7 +21,7 @@ from weaviate.collection.classes.config import (
     ConfigFactory,
     PropertyConfig,
 )
-from weaviate.collection.classes.internal import ReferenceFactory
+from weaviate.collection.classes.internal import CrossReference, ReferenceFactory
 from weaviate.collection.classes.orm import BaseProperty, CollectionModelConfig
 from weaviate.collection.classes.tenants import Tenant, TenantActivityStatus
 from pydantic import Field
@@ -96,8 +96,8 @@ def test_types(client: weaviate.Client, member_type, value, optional: bool):
     "member_type, annotation ,value,expected",
     [
         (str, PropertyConfig(index_filterable=False), "value", "text"),
-        (UUIDS, ReferenceFactory[Group], [str(REF_TO_UUID)], "Group"),
-        (Optional[UUIDS], ReferenceFactory[Group], [str(REF_TO_UUID)], "Group"),
+        (UUIDS, CrossReference[Group], [str(REF_TO_UUID)], "Group"),
+        (Optional[UUIDS], CrossReference[Group], [str(REF_TO_UUID)], "Group"),
     ],
 )
 def test_types_annotates(client: weaviate.Client, member_type, annotation, value, expected: str):
@@ -261,7 +261,7 @@ def test_multi_searches(client: weaviate.Client):
 def test_multi_searches_with_references(client: weaviate.Client):
     class TestMultiSearchesWithReferences(BaseProperty):
         name: Optional[str] = None
-        group: Optional[ReferenceFactory[Group]] = None
+        group: Optional[CrossReference[Group]] = None
 
     client.collection_model.delete(TestMultiSearchesWithReferences)
     collection = client.collection_model.create(
@@ -272,11 +272,11 @@ def test_multi_searches_with_references(client: weaviate.Client):
 
     collection.data.insert(
         TestMultiSearchesWithReferences(
-            name="some word", group=ReferenceFactory[Group].to(REF_TO_UUID)
+            name="some word", group=ReferenceFactory.to(REF_TO_UUID, Group)
         )
     )
     collection.data.insert(
-        TestMultiSearchesWithReferences(name="other", group=ReferenceFactory[Group].to(REF_TO_UUID))
+        TestMultiSearchesWithReferences(name="other", group=ReferenceFactory.to(REF_TO_UUID, Group))
     )
 
     objects = collection.query.bm25(
@@ -465,7 +465,7 @@ def test_update_reference_property(client: weaviate.Client):
 
     class TestRefPropUpdate(BaseProperty):
         name: str
-        group: ReferenceFactory[Group]
+        group: CrossReference[Group]
 
     create_original_collection()
     client.collection_model.update(TestRefPropUpdate)

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -24,7 +24,7 @@ from weaviate.collection.classes.config import (
     ReferencePropertyMultiTarget,
 )
 
-from weaviate.collection.classes.internal import CrossReference, ReferenceFactory
+from weaviate.collection.classes.internal import Reference, ReferenceFactory
 from weaviate.collection.grpc import MetadataQuery
 
 
@@ -178,11 +178,11 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.Client):
 
     class BProps(TypedDict):
         name: str
-        ref: Annotated[CrossReference[AProps], MetadataQuery(uuid=True)]
+        ref: Annotated[Reference[AProps], MetadataQuery(uuid=True)]
 
     class CProps(TypedDict):
         name: str
-        ref: Annotated[CrossReference[BProps], MetadataQuery(uuid=True)]
+        ref: Annotated[Reference[BProps], MetadataQuery(uuid=True)]
 
     client.collection.create(
         name="ATypedDicts",

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -459,20 +459,16 @@ def test_references_with_string_syntax(client: weaviate.Client):
         {"Name": "B", "ref": ReferenceFactory.to(uuids=uuid_A)}
     )
 
-    objects = (
-        client.collection.get(name2)
-        .query.bm25(
-            query="B",
-            return_properties=[
-                "name",
-                "__ref__properties__Name",
-                "__ref__properties__Age",
-                "__ref__properties__Weird__Name",
-                "__ref__metadata__uuid",
-                "__ref__metadata__last_update_time_unix",
-            ],
-        )
-        .objects
+    objects = client.collection.get(name2).query.bm25(
+        query="B",
+        return_properties=[
+            "name",
+            "__ref__properties__Name",
+            "__ref__properties__Age",
+            "__ref__properties__Weird__Name",
+            "__ref__metadata__uuid",
+            "__ref__metadata__last_update_time_unix",
+        ],
     )
 
     assert objects[0].properties["name"] == "B"

--- a/test/collection/test_classes.py
+++ b/test/collection/test_classes.py
@@ -1,19 +1,19 @@
 import pytest
 from pydantic import ValidationError
 
-from weaviate.collection.classes.grpc import LinkTo, LinkToMultiTarget
+from weaviate.collection.classes.grpc import FromReference, FromReferenceMultiTarget
 
 
 def test_link_to_errors_on_extra_variable():
     with pytest.raises(ValidationError):
-        LinkTo(link_on="ref", return_property="name")
+        FromReference(link_on="ref", return_property="name")
 
 
 def test_link_to_multi_target_errors_on_extra_variable():
     with pytest.raises(ValidationError):
-        LinkToMultiTarget(link_on="ref", target_colection="Test")
+        FromReferenceMultiTarget(link_on="ref", target_colection="Test")
 
 
 def test_link_to_multi_target_is_link_to():
-    link_to = LinkToMultiTarget(link_on="ref", target_collection="Test")
-    assert isinstance(link_to, LinkTo)
+    link_to = FromReferenceMultiTarget(link_on="ref", target_collection="Test")
+    assert isinstance(link_to, FromReference)

--- a/test/collection/test_collection_model.py
+++ b/test/collection/test_collection_model.py
@@ -9,7 +9,7 @@ else:
 import pytest as pytest
 
 from weaviate.collection.classes.config import PropertyConfig
-from weaviate.collection.classes.orm import BaseProperty, CrossReference
+from weaviate.collection.classes.orm import BaseProperty, Reference
 from weaviate.types import UUIDS
 
 
@@ -44,8 +44,8 @@ def test_types(member_type, expected: str, optional: bool):
     "member_type, annotation ,expected",
     [
         (str, PropertyConfig(index_filterable=False), "text"),
-        (UUIDS, CrossReference(Group), "Group"),
-        (Optional[UUIDS], CrossReference(Group), "Group"),
+        (UUIDS, Reference(Group), "Group"),
+        (Optional[UUIDS], Reference(Group), "Group"),
     ],
 )
 def test_types_annotation(member_type, annotation, expected: str):

--- a/test/collection/test_queries.py
+++ b/test/collection/test_queries.py
@@ -1,0 +1,94 @@
+from typing import List, Optional, Union
+
+import pytest
+
+from weaviate.collection.classes.grpc import (
+    PROPERTIES,
+    FromReference,
+    FromReferenceMultiTarget,
+    MetadataQuery,
+)
+from weaviate.collection.queries.base import _PropertiesParser
+
+
+@pytest.mark.parametrize(
+    "properties,output",
+    [
+        (["name"], ["name"]),
+        ([FromReference(link_on="name")], [FromReference(link_on="name")]),
+        (["name", FromReference(link_on="name")], ["name", FromReference(link_on="name")]),
+        (
+            [FromReferenceMultiTarget(link_on="name", target_collection="Test"), "name"],
+            ["name", FromReferenceMultiTarget(link_on="name", target_collection="Test")],
+        ),
+        (
+            ["__article__properties__name"],
+            [FromReference(link_on="article", return_properties=["name"])],
+        ),
+        (
+            ["__article__properties__name", "name", "__article__properties__age"],
+            ["name", FromReference(link_on="article", return_properties=["name", "age"])],
+        ),
+        (
+            ["__article__metadata__uuid"],
+            [FromReference(link_on="article", return_metadata=MetadataQuery(uuid=True))],
+        ),
+        (
+            ["__article__metadata__uuid", "__article__metadata__vector"],
+            [
+                FromReference(
+                    link_on="article", return_metadata=MetadataQuery(uuid=True, vector=True)
+                )
+            ],
+        ),
+        (["__article"], [FromReference(link_on="article")]),
+        (
+            ["__article", "__article__metadata__uuid"],
+            [FromReference(link_on="article", return_metadata=MetadataQuery(uuid=True))],
+        ),
+        (
+            ["__article", "__article__properties__name"],
+            [FromReference(link_on="article", return_properties=["name"])],
+        ),
+        (
+            ["__article__metadata__uuid", "__article"],
+            [FromReference(link_on="article", return_metadata=MetadataQuery(uuid=True))],
+        ),
+        (
+            ["__article__properties__name", "__article"],
+            [FromReference(link_on="article", return_properties=["name"])],
+        ),
+        (None, None),
+        ([None, "name"], ["name"]),
+        (["__article", "name"], ["name", FromReference(link_on="article")]),
+        ("__article", [FromReference(link_on="article")]),
+        ("__article__", [FromReference(link_on="article")]),
+    ],
+)
+def test_properties_parser_success(properties: Optional[PROPERTIES], output: Optional[PROPERTIES]):
+    assert output == _PropertiesParser().parse(properties)
+
+
+ERROR_MESSAGE = (
+    lambda s: f"return reference property {s} must be in the format __{{prop_name}} or __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
+)
+
+
+@pytest.mark.parametrize(
+    "wrong",
+    [
+        ["__article__propertie__uuid"],
+        ["__article__propertiess__uuid"],
+        ["__article__metadat__uuid"],
+        ["__article__metadataa__uuid"],
+        "__article__propertie__uuid",
+        "__article__propertiess__uuid",
+        "__article__metadat__uuid",
+        "__article__metadataa__uuid",
+    ],
+)
+def test_properties_parser_error(wrong: Union[str, List[str]]):
+    with pytest.raises(ValueError) as e:
+        out = _PropertiesParser().parse(wrong)
+        print(out)
+    assert e.value.args[0] == ERROR_MESSAGE(wrong[0] if len(wrong) == 1 else wrong)

--- a/weaviate/classes.py
+++ b/weaviate/classes.py
@@ -14,8 +14,8 @@ from weaviate.collection.classes.data import (
 from weaviate.collection.classes.filters import Filter
 from weaviate.collection.classes.grpc import (
     HybridFusion,
-    LinkTo,
-    LinkToMultiTarget,
+    FromReference,
+    FromReferenceMultiTarget,
     MetadataQuery,
     Generate,
 )
@@ -29,8 +29,8 @@ __all__ = [
     "Filter",
     "Generate",
     "HybridFusion",
-    "LinkTo",
-    "LinkToMultiTarget",
+    "FromReference",
+    "FromReferenceMultiTarget",
     "MetadataQuery",
     "Multi2VecField",
     "Property",

--- a/weaviate/collection/classes/grpc.py
+++ b/weaviate/collection/classes/grpc.py
@@ -80,7 +80,7 @@ class GroupBy(WeaviateInput):
     objects_per_group: int
 
 
-class LinkTo(WeaviateInput):
+class FromReference(WeaviateInput):
     link_on: str
     return_properties: Optional["PROPERTIES"] = Field(default=None)
     return_metadata: Optional[MetadataQuery] = Field(default=None)
@@ -89,11 +89,11 @@ class LinkTo(WeaviateInput):
         return hash(str(self))
 
 
-class LinkToMultiTarget(LinkTo):
+class FromReferenceMultiTarget(FromReference):
     target_collection: str
 
 
-PROPERTY = Union[str, LinkTo]
+PROPERTY = Union[str, FromReference]
 PROPERTIES = Union[List[PROPERTY], PROPERTY]
 
 

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -11,8 +11,8 @@ else:
 
 from weaviate.collection.collection_base import CollectionObjectBase
 from weaviate.collection.classes.grpc import (
-    LinkTo,
-    LinkToMultiTarget,
+    FromReference,
+    FromReferenceMultiTarget,
     MetadataQuery,
     PROPERTIES,
     Generate,
@@ -141,7 +141,7 @@ class _GroupBy:
         )
 
 
-class ReferenceFactory(Generic[P]):
+class _Reference(Generic[P]):
     def __init__(
         self,
         objects: Optional[List[_Object[P]]],
@@ -152,29 +152,13 @@ class ReferenceFactory(Generic[P]):
         self.__target_collection = target_collection if target_collection else ""
         self.__uuids = uuids
 
-    @classmethod
-    def to(cls, uuids: UUIDS) -> "ReferenceFactory[P]":
-        return cls(None, None, uuids)
-
-    @classmethod
-    def to_multi_target(
-        cls, uuids: UUIDS, target_collection: Union[str, CollectionObjectBase]
-    ) -> "ReferenceFactory[P]":
-        return cls(
-            None,
-            target_collection.name
-            if isinstance(target_collection, CollectionObjectBase)
-            else target_collection,
-            uuids,
-        )
-
     def _to_beacons(self) -> List[Dict[str, str]]:
         if self.__uuids is None:
             return []
         return _to_beacons(self.__uuids, self.__target_collection)
 
     @classmethod
-    def _from(cls, objects: List[_Object[P]]) -> "ReferenceFactory[P]":
+    def _from(cls, objects: List[_Object[P]]) -> "_Reference[P]":
         return cls(objects, None, None)
 
     @property
@@ -197,6 +181,53 @@ class ReferenceFactory(Generic[P]):
         return self.__objects or []
 
 
+CrossReference = _Reference[P]
+
+
+class ReferenceFactory:
+    """Factory class for cross references to other objects.
+
+    Can be used with or without generics. If used with generics, the type of the cross reference can be defined from
+    which the nested relationship will be used when performing queries using the generics. If used without generics,
+    all returned objects will of the`Dict[str, Any]` type.
+    """
+
+    @classmethod
+    def to(cls, uuids: UUIDS, data_model: Optional[Type[P]] = None) -> CrossReference[P]:
+        """Defines cross references to other objects by their UUIDs.
+
+        Can be made to be generic by supplying a type to the `data_model` argument.
+
+        Arguments:
+            uuids
+                List of UUIDs of the objects to which the reference should point.
+        """
+        return _Reference[P](None, None, uuids)
+
+    @classmethod
+    def to_multi_target(
+        cls,
+        uuids: UUIDS,
+        target_collection: Union[str, CollectionObjectBase],
+        data_model: Optional[Type[P]] = None,
+    ) -> CrossReference[P]:
+        """Defines cross references to other objects by their UUIDs and the collection in which they are stored.
+
+        Can be made to be generic by supplying a type to the `data_model` argument.
+
+        Arguments:
+            - uuids: List of UUIDs of the objects to which the reference should point.
+            - target_collection: The collection in which the objects are stored. Can be either the name of the collection or the collection object itself.
+        """
+        return _Reference[P](
+            None,
+            target_collection.name
+            if isinstance(target_collection, CollectionObjectBase)
+            else target_collection,
+            uuids,
+        )
+
+
 def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
     return _MetadataReturn(
         uuid=uuid_package.UUID(metadata["id"]) if "id" in metadata else None,
@@ -211,9 +242,9 @@ def _metadata_from_dict(metadata: Dict[str, Any]) -> _MetadataReturn:
     )
 
 
-def _extract_property_type_from_reference(type_: ReferenceFactory[P]) -> Type[P]:
-    """Extract inner type from Reference[Properties]"""
-    if getattr(type_, "__origin__", None) == ReferenceFactory:
+def _extract_property_type_from_reference(type_: _Reference[P]) -> Type[P]:
+    """Extract inner type from Reference[Properties]."""
+    if getattr(type_, "__origin__", None) == _Reference:
         args = cast(List[Type[P]], getattr(type_, "__args__", None))
         return args[0]
     raise ValueError("Type is not Reference[Properties]")
@@ -221,15 +252,15 @@ def _extract_property_type_from_reference(type_: ReferenceFactory[P]) -> Type[P]
 
 def _extract_property_type_from_annotated_reference(
     type_: Union[
-        Annotated[ReferenceFactory[P], MetadataQuery],
-        Annotated[ReferenceFactory[P], MetadataQuery, str],
+        Annotated[_Reference[P], MetadataQuery],
+        Annotated[_Reference[P], MetadataQuery, str],
     ]
 ) -> Type[P]:
     """Extract inner type from Annotated[Reference[Properties]]"""
     if get_origin(type_) is Annotated:
-        args = cast(List[ReferenceFactory[Type[P]]], getattr(type_, "__args__", None))
+        args = cast(List[_Reference[Type[P]]], getattr(type_, "__args__", None))
         inner_type = args[0]
-        if get_origin(inner_type) is ReferenceFactory:
+        if get_origin(inner_type) is _Reference:
             inner_args = cast(List[Type[P]], getattr(inner_type, "__args__", None))
             return inner_args[0]
     raise ValueError("Type is not Annotated[Reference[Properties]]")
@@ -238,15 +269,15 @@ def _extract_property_type_from_annotated_reference(
 def __create_link_to_from_annotated_reference(
     link_on: str,
     value: Union[
-        Annotated[ReferenceFactory[Properties], MetadataQuery],
-        Annotated[ReferenceFactory[Properties], MetadataQuery, str],
+        Annotated[_Reference[Properties], MetadataQuery],
+        Annotated[_Reference[Properties], MetadataQuery, str],
     ],
-) -> Union[LinkTo, LinkToMultiTarget]:
-    """Create LinkTo or LinkToMultiTarget from Annotated[Reference[Properties]]"""
+) -> Union[FromReference, FromReferenceMultiTarget]:
+    """Create FromReference or FromReferenceMultiTarget from Annotated[Reference[Properties]]"""
     assert get_origin(value) is Annotated
-    args = cast(List[ReferenceFactory[Properties]], getattr(value, "__args__", None))
+    args = cast(List[_Reference[Properties]], getattr(value, "__args__", None))
     inner_type = args[0]
-    assert get_origin(inner_type) is ReferenceFactory
+    assert get_origin(inner_type) is _Reference
     inner_type_metadata = cast(
         Union[Tuple[MetadataQuery], Tuple[MetadataQuery, str]], getattr(value, "__metadata__", None)
     )
@@ -255,7 +286,7 @@ def __create_link_to_from_annotated_reference(
         target_collection = cast(Tuple[MetadataQuery, str], inner_type_metadata)[
             1
         ]  # https://github.com/python/mypy/issues/1178
-        return LinkToMultiTarget(
+        return FromReferenceMultiTarget(
             link_on=link_on,
             return_metadata=metadata,
             return_properties=_extract_properties_from_data_model(
@@ -264,7 +295,7 @@ def __create_link_to_from_annotated_reference(
             target_collection=target_collection,
         )
     else:
-        return LinkTo(
+        return FromReference(
             link_on=link_on,
             return_metadata=metadata,
             return_properties=_extract_properties_from_data_model(
@@ -275,10 +306,10 @@ def __create_link_to_from_annotated_reference(
 
 def __create_link_to_from_reference(
     link_on: str,
-    value: ReferenceFactory[Properties],
-) -> LinkTo:
-    """Create LinkTo from Reference[Properties]"""
-    return LinkTo(
+    value: _Reference[Properties],
+) -> FromReference:
+    """Create FromReference from Reference[Properties]"""
+    return FromReference(
         link_on=link_on,
         return_metadata=MetadataQuery(),
         return_properties=_extract_properties_from_data_model(
@@ -288,14 +319,16 @@ def __create_link_to_from_reference(
 
 
 def _extract_properties_from_data_model(type_: Type[Properties]) -> PROPERTIES:
-    """Extract properties of Properties recursively from Properties"""
+    """Extract properties of Properties recursively from Properties.
+
+    Checks to see if there is a _Reference[Properties] or Annotated[_Reference[Properties]] in the data model and
+    lists out the non-cross-reference properties.
+    """
     return [
         __create_link_to_from_annotated_reference(key, value)
         if get_origin(value) is Annotated
         else (
-            __create_link_to_from_reference(key, value)
-            if get_origin(value) is ReferenceFactory
-            else key
+            __create_link_to_from_reference(key, value) if get_origin(value) is _Reference else key
         )
         for key, value in get_type_hints(type_, include_extras=True).items()
     ]

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -199,7 +199,7 @@ class _Reference(Generic[P]):
         return self.__objects or []
 
 
-CrossReference = _Reference[P]
+Reference = _Reference[P]
 
 
 class ReferenceFactory:
@@ -211,7 +211,7 @@ class ReferenceFactory:
     """
 
     @classmethod
-    def to(cls, uuids: UUIDS, data_model: Optional[Type[P]] = None) -> CrossReference[P]:
+    def to(cls, uuids: UUIDS, data_model: Optional[Type[P]] = None) -> Reference[P]:
         """Defines cross references to other objects by their UUIDs.
 
         Can be made to be generic by supplying a type to the `data_model` argument.
@@ -228,7 +228,7 @@ class ReferenceFactory:
         uuids: UUIDS,
         target_collection: Union[str, CollectionObjectBase],
         data_model: Optional[Type[P]] = None,
-    ) -> CrossReference[P]:
+    ) -> Reference[P]:
         """Defines cross references to other objects by their UUIDs and the collection in which they are stored.
 
         Can be made to be generic by supplying a type to the `data_model` argument.

--- a/weaviate/collection/classes/orm.py
+++ b/weaviate/collection/classes/orm.py
@@ -34,7 +34,7 @@ from weaviate.types import PYTHON_TYPE_TO_DATATYPE, UUID
 
 
 @dataclass
-class CrossReference:
+class Reference:
     ref_type: Union[Type, str]
 
     @property
@@ -65,7 +65,7 @@ class BaseProperty(BaseModel):
             if (
                 field.metadata is not None
                 and len(field.metadata) > 0
-                and isinstance(field.metadata[0], CrossReference)
+                and isinstance(field.metadata[0], Reference)
             )
             and name not in BaseProperty.model_fields
         }

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -26,7 +26,12 @@ from weaviate.collection.classes.data import (
     _BatchReturn,
     RefError,
 )
-from weaviate.collection.classes.internal import _Object, _metadata_from_dict, ReferenceFactory
+from weaviate.collection.classes.internal import (
+    _Object,
+    _metadata_from_dict,
+    CrossReference,
+    _Reference,
+)
 from weaviate.collection.classes.orm import (
     Model,
 )
@@ -196,7 +201,7 @@ class _Data:
             return None
         raise UnexpectedStatusCodeException("Get object/s", response)
 
-    def _reference_add(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def _reference_add(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         params: Dict[str, str] = {}
 
         path = f"/objects/{self.name}/{from_uuid}/references/{from_property}"
@@ -244,7 +249,7 @@ class _Data:
             return None
         raise UnexpectedStatusCodeException("Send ref batch", response)
 
-    def _reference_delete(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def _reference_delete(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         params: Dict[str, str] = {}
 
         path = f"/objects/{self.name}/{from_uuid}/references/{from_property}"
@@ -260,9 +265,7 @@ class _Data:
             if response.status_code != 204:
                 raise UnexpectedStatusCodeException("Add property reference to object", response)
 
-    def _reference_replace(
-        self, from_uuid: UUID, from_property: str, ref: ReferenceFactory
-    ) -> None:
+    def _reference_replace(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         params: Dict[str, str] = {}
 
         path = f"/objects/{self.name}/{from_uuid}/references/{from_property}"
@@ -296,7 +299,7 @@ class _Data:
     def _serialize_properties(self, data: Properties) -> Dict[str, Any]:
         return {
             key: val._to_beacons()
-            if isinstance(val, ReferenceFactory)
+            if isinstance(val, _Reference)
             else self.__serialize_primitive(val)
             for key, val in data.items()
         }
@@ -332,7 +335,7 @@ class _Data:
         int_arrays: List[weaviate_pb2.IntArrayProperties] = []
         float_arrays: List[weaviate_pb2.NumberArrayProperties] = []
         for key, val in data.items():
-            if isinstance(val, ReferenceFactory):
+            if isinstance(val, _Reference):
                 if val.is_multi_target:
                     multi_target.append(
                         weaviate_pb2.BatchObject.RefPropertiesMultiTarget(
@@ -468,7 +471,7 @@ class _DataCollection(Generic[Properties], _Data):
 
         self._update(weaviate_obj, uuid=uuid)
 
-    def reference_add(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def reference_add(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         self._reference_add(
             from_uuid=from_uuid,
             from_property=from_property,
@@ -487,10 +490,10 @@ class _DataCollection(Generic[Properties], _Data):
         ]
         return self._reference_add_many(refs_dict)
 
-    def reference_delete(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def reference_delete(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         self._reference_delete(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
-    def reference_replace(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def reference_replace(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         self._reference_replace(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
 
@@ -605,13 +608,13 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         return [self._json_to_object(obj) for obj in ret["objects"]]
 
-    def reference_add(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def reference_add(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         self._reference_add(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
-    def reference_delete(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def reference_delete(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         self._reference_delete(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
-    def reference_replace(self, from_uuid: UUID, from_property: str, ref: ReferenceFactory) -> None:
+    def reference_replace(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
         self._reference_replace(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
     def reference_add_many(self, from_property: str, refs: List[BatchReference]) -> None:

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -29,7 +29,7 @@ from weaviate.collection.classes.data import (
 from weaviate.collection.classes.internal import (
     _Object,
     _metadata_from_dict,
-    CrossReference,
+    Reference,
     _Reference,
 )
 from weaviate.collection.classes.orm import (
@@ -219,7 +219,7 @@ class _Data:
             return None
         raise UnexpectedStatusCodeException("Get object/s", response)
 
-    def _reference_add(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def _reference_add(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         params: Dict[str, str] = {}
 
         path = f"/objects/{self.name}/{from_uuid}/references/{from_property}"
@@ -267,7 +267,7 @@ class _Data:
             return None
         raise UnexpectedStatusCodeException("Send ref batch", response)
 
-    def _reference_delete(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def _reference_delete(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         params: Dict[str, str] = {}
 
         path = f"/objects/{self.name}/{from_uuid}/references/{from_property}"
@@ -283,7 +283,7 @@ class _Data:
             if response.status_code != 204:
                 raise UnexpectedStatusCodeException("Add property reference to object", response)
 
-    def _reference_replace(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def _reference_replace(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         params: Dict[str, str] = {}
 
         path = f"/objects/{self.name}/{from_uuid}/references/{from_property}"
@@ -503,7 +503,7 @@ class _DataCollection(Generic[Properties], _Data):
 
         self._update(weaviate_obj, uuid=uuid)
 
-    def reference_add(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def reference_add(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         self._reference_add(
             from_uuid=from_uuid,
             from_property=from_property,
@@ -522,10 +522,10 @@ class _DataCollection(Generic[Properties], _Data):
         ]
         return self._reference_add_many(refs_dict)
 
-    def reference_delete(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def reference_delete(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         self._reference_delete(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
-    def reference_replace(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def reference_replace(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         self._reference_replace(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
 
@@ -640,13 +640,13 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         return [self._json_to_object(obj) for obj in ret["objects"]]
 
-    def reference_add(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def reference_add(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         self._reference_add(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
-    def reference_delete(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def reference_delete(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         self._reference_delete(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
-    def reference_replace(self, from_uuid: UUID, from_property: str, ref: CrossReference) -> None:
+    def reference_replace(self, from_uuid: UUID, from_property: str, ref: Reference) -> None:
         self._reference_replace(from_uuid=from_uuid, from_property=from_property, ref=ref)
 
     def reference_add_many(self, from_property: str, refs: List[BatchReference]) -> None:

--- a/weaviate/collection/grpc_query.py
+++ b/weaviate/collection/grpc_query.py
@@ -20,8 +20,8 @@ from weaviate.collection.classes.config import ConsistencyLevel
 from weaviate.collection.classes.filters import _Filters
 from weaviate.collection.classes.grpc import (
     HybridFusion,
-    LinkTo,
-    LinkToMultiTarget,
+    FromReference,
+    FromReferenceMultiTarget,
     MetadataQuery,
     Move,
     PROPERTIES,
@@ -558,11 +558,11 @@ class _QueryGRPC(_BaseGRPC):
                     if prop.return_metadata is not None
                     else None,
                     which_collection=prop.target_collection
-                    if isinstance(prop, LinkToMultiTarget)
+                    if isinstance(prop, FromReferenceMultiTarget)
                     else None,
                 )
                 for prop in properties
-                if isinstance(prop, LinkTo)
+                if isinstance(prop, FromReference)
             ],
         )
 

--- a/weaviate/collection/queries/base.py
+++ b/weaviate/collection/queries/base.py
@@ -22,14 +22,14 @@ import uuid as uuid_lib
 
 from weaviate.collection.classes.config import ConsistencyLevel
 from weaviate.collection.classes.grpc import (
-    LinkTo,
+    FromReference,
     PROPERTIES,
 )
 from weaviate.collection.classes.internal import (
     _GroupByObject,
     _MetadataReturn,
     _Object,
-    ReferenceFactory,
+    _Reference,
     _extract_property_type_from_annotated_reference,
     _extract_property_type_from_reference,
     _extract_properties_from_data_model,
@@ -126,9 +126,9 @@ class _Grpc:
                 if get_origin(hint) is Annotated:
                     referenced_property_type = _extract_property_type_from_annotated_reference(hint)
                 else:
-                    assert get_origin(hint) is ReferenceFactory
+                    assert get_origin(hint) is _Reference
                     referenced_property_type = _extract_property_type_from_reference(hint)
-                result[ref_prop.prop_name] = ReferenceFactory._from(
+                result[ref_prop.prop_name] = _Reference._from(
                     [
                         _Object(
                             properties=self.__parse_result(prop, referenced_property_type),
@@ -138,7 +138,7 @@ class _Grpc:
                     ]
                 )
             else:
-                result[ref_prop.prop_name] = ReferenceFactory[Dict[str, Any]]._from(
+                result[ref_prop.prop_name] = _Reference._from(
                     [
                         _Object(
                             properties=self.__parse_result(prop, Dict[str, Any]),
@@ -215,7 +215,7 @@ class _Grpc:
         if (
             isinstance(type_, list)
             or isinstance(type_, str)
-            or isinstance(type_, LinkTo)
+            or isinstance(type_, FromReference)
             or type_ is None
         ):
             ret_properties = cast(Optional[PROPERTIES], type_)

--- a/weaviate/collection/queries/base.py
+++ b/weaviate/collection/queries/base.py
@@ -1,10 +1,12 @@
 import datetime
 import io
 import pathlib
+import re
 import sys
 from typing import (
     Any,
     Dict,
+    List,
     Optional,
     Union,
     Tuple,
@@ -23,6 +25,7 @@ import uuid as uuid_lib
 from weaviate.collection.classes.config import ConsistencyLevel
 from weaviate.collection.classes.grpc import (
     FromReference,
+    MetadataQuery,
     PROPERTIES,
 )
 from weaviate.collection.classes.internal import (
@@ -209,25 +212,25 @@ class _Grpc:
             max_distance=res.max_distance,
         )
 
-    def _determine_generic(
-        self, type_: Union[PROPERTIES, Type[Properties], None]
+    def _parse_return_properties(
+        self, return_properties: Optional[Union[PROPERTIES, Type[Properties]]]
     ) -> Tuple[Optional[PROPERTIES], Type[Properties]]:
         if (
-            isinstance(type_, list)
-            or isinstance(type_, str)
-            or isinstance(type_, FromReference)
-            or type_ is None
+            isinstance(return_properties, list)
+            or isinstance(return_properties, str)
+            or isinstance(return_properties, FromReference)
+            or return_properties is None
         ):
-            ret_properties = cast(Optional[PROPERTIES], type_)
+            ret_properties = _PropertiesParser().parse(return_properties)
             ret_type = cast(Type[Properties], Dict[str, Any])
         else:
-            if not is_typeddict(type_):
+            if not is_typeddict(return_properties):
                 raise TypeError(
-                    f"return_properties must only be a TypedDict or PROPERTIES within this context but is {type(type_)}"
+                    f"return_properties must only be a TypedDict or PROPERTIES within this context but is {type(return_properties)}"
                 )
-            type_ = cast(Type[Properties], type_)
-            ret_properties = _extract_properties_from_data_model(type_)
-            ret_type = type_
+            return_properties = cast(Type[Properties], return_properties)
+            ret_properties = _extract_properties_from_data_model(return_properties)
+            ret_type = return_properties
         return ret_properties, ret_type
 
     @staticmethod
@@ -236,3 +239,72 @@ class _Grpc:
             return media
         else:
             return file_encoder_b64(media)
+
+
+class _PropertiesParser:
+    def __init__(self) -> None:
+        self.__from_references_by_prop_name: Dict[str, FromReference] = {}
+        self.__non_ref_properties: List[str] = []
+
+    def parse(self, properties: Optional[PROPERTIES]) -> Optional[PROPERTIES]:
+        if (
+            properties is None
+            or isinstance(properties, str)
+            or isinstance(properties, FromReference)
+        ):
+            return properties
+        elif isinstance(properties, list):
+            for prop in properties:
+                if isinstance(prop, str):
+                    if prop.startswith("__"):
+                        self.__parse_reference_property_string(prop)
+                    else:
+                        self.__non_ref_properties.append(prop)
+                else:
+                    self.__from_references_by_prop_name[prop.link_on] = prop
+            return [*self.__non_ref_properties, *self.__from_references_by_prop_name.values()]
+        else:
+            raise TypeError(
+                f"return_properties must be a list of strings and/or FromReferences, a string, or a FromReference but is {type(properties)}"
+            )
+
+    def __parse_reference_property_string(self, ref_prop: str) -> None:
+        match_ = re.search(r"__([^_]+)__([^_]+)__([\w_]+)", ref_prop)
+        if match_ is None:
+            raise ValueError(
+                f"return reference property {ref_prop} must be in the format __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
+            )
+        prop_name = match_.group(1)
+        existing_from_reference = self.__from_references_by_prop_name.get(prop_name)
+        properties_or_metadata = match_.group(2)
+        if properties_or_metadata not in ["properties", "metadata"]:
+            raise ValueError(
+                f"return reference property {ref_prop} must be in the format __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
+            )
+        nested_prop_name = match_.group(3)
+        if existing_from_reference is None:
+            self.__from_references_by_prop_name[prop_name] = FromReference(
+                link_on=prop_name,
+                return_properties=[nested_prop_name]
+                if properties_or_metadata == "properties"
+                else None,
+                return_metadata=MetadataQuery(**{nested_prop_name: True})
+                if properties_or_metadata == "metadata"
+                else None,
+            )
+        else:
+            if properties_or_metadata == "properties":
+                if existing_from_reference.return_properties is None:
+                    self.__from_references_by_prop_name[prop_name].return_properties = [
+                        nested_prop_name
+                    ]
+                else:
+                    assert isinstance(existing_from_reference.return_properties, list)
+                    existing_from_reference.return_properties.append(nested_prop_name)
+            else:
+                if existing_from_reference.return_metadata is None:
+                    metadata = MetadataQuery()
+                else:
+                    metadata = existing_from_reference.return_metadata
+                setattr(metadata, nested_prop_name, True)
+                self.__from_references_by_prop_name[prop_name].return_metadata = metadata

--- a/weaviate/collection/queries/bm25.py
+++ b/weaviate/collection/queries/bm25.py
@@ -63,7 +63,7 @@ class _BM25(_Grpc):
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> Union[_QueryReturn[Properties], _GenerativeReturn[Properties]]:
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().bm25(
             query=query,
             properties=query_properties,

--- a/weaviate/collection/queries/fetch_objects.py
+++ b/weaviate/collection/queries/fetch_objects.py
@@ -65,7 +65,7 @@ class _FetchObjects(_Grpc):
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> Union[_QueryReturn[Properties], _GenerativeReturn[Properties]]:
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().get(
             limit=limit,
             offset=offset,

--- a/weaviate/collection/queries/hybrid.py
+++ b/weaviate/collection/queries/hybrid.py
@@ -72,7 +72,7 @@ class _Hybrid(_Grpc):
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> Union[_QueryReturn[Properties], _GenerativeReturn[Properties]]:
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().hybrid(
             query=query,
             alpha=alpha,

--- a/weaviate/collection/queries/near_audio.py
+++ b/weaviate/collection/queries/near_audio.py
@@ -91,7 +91,7 @@ class _NearAudio(_Grpc):
         if generate is not None and group_by is not None:
             raise ValueError("Cannot have group_by and generate defined simultaneously")
 
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().near_audio(
             audio=self._parse_media(near_audio),
             certainty=certainty,

--- a/weaviate/collection/queries/near_image.py
+++ b/weaviate/collection/queries/near_image.py
@@ -86,7 +86,7 @@ class _NearImage(_Grpc):
         if generate is not None and group_by is not None:
             raise ValueError("Cannot have group_by and generate defined simultaneously")
 
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().near_image(
             image=self._parse_media(near_image),
             certainty=certainty,

--- a/weaviate/collection/queries/near_object.py
+++ b/weaviate/collection/queries/near_object.py
@@ -90,7 +90,7 @@ class _NearObject(_Grpc):
         if generate is not None and group_by is not None:
             raise ValueError("Cannot have group_by and generate defined simultaneously")
 
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().near_object(
             near_object=near_object,
             certainty=certainty,

--- a/weaviate/collection/queries/near_text.py
+++ b/weaviate/collection/queries/near_text.py
@@ -105,7 +105,7 @@ class _NearText(_Grpc):
         if generate is not None and group_by is not None:
             raise ValueError("Cannot have group_by and generate defined simultaneously")
 
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().near_text(
             near_text=query,
             certainty=certainty,

--- a/weaviate/collection/queries/near_vector.py
+++ b/weaviate/collection/queries/near_vector.py
@@ -96,7 +96,7 @@ class _NearVector(_Grpc):
         if generate is not None and group_by is not None:
             raise ValueError("Cannot have group_by and generate defined simultaneously")
 
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().near_vector(
             near_vector=near_vector,
             certainty=certainty,

--- a/weaviate/collection/queries/near_video.py
+++ b/weaviate/collection/queries/near_video.py
@@ -97,7 +97,7 @@ class _NearVideo(_Grpc):
         if generate is not None and group_by is not None:
             raise ValueError("Cannot have group_by and generate defined simultaneously")
 
-        ret_properties, ret_type = self._determine_generic(return_properties)
+        ret_properties, ret_type = self._parse_return_properties(return_properties)
         res = self._query().near_video(
             video=self._parse_media(near_video),
             certainty=certainty,


### PR DESCRIPTION
This PR attempts to align the naming conventions for references across the collections API

It:

- Refactors `ReferenceFactory` so that it is a true factory returning `_Reference[P]` objects from its `.to()` and `.to_multi_target()` classmethods
- Introduces the internal `_Reference[P]` class to contain the business logic of references previously in `ReferenceFactory`
- Introduces the `Reference` typeAlias for `_Reference[P]` that users use when defining generic cross-references
- Renames `LinkTo` and `LinkToMultiTarget` to `FromReference` and `FromReferenceMultiTarget`
- Introduce a specific string syntax instead of `FromReference` of the form `__{prop}__{properties|metadata}__{nested_prop}`, e.g. `__article__properties__title` and `__article__metadata__uuid`