### PR TITLE
allow `List[Properties]` in `insert_many` and clean obj for `id` and `vector`

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -236,7 +236,7 @@ def test_delete_by_id(client: weaviate.Client):
 
 
 @pytest.mark.parametrize(
-    "objects,should_implicitly_clean,should_error",
+    "objects,should_error",
     [
         (
             [
@@ -244,14 +244,12 @@ def test_delete_by_id(client: weaviate.Client):
                 DataObject(properties={"name": "some other name"}, uuid=uuid.uuid4()),
             ],
             False,
-            False,
         ),
         (
             [
                 {"name": "some name"},
                 DataObject(properties={"name": "some other name"}),
             ],
-            False,
             False,
         ),
         (
@@ -260,13 +258,11 @@ def test_delete_by_id(client: weaviate.Client):
                 {"name": "some other name"},
             ],
             False,
-            False,
         ),
         (
             [
                 {"name": "some name", "vector": [1, 2, 3]},
             ],
-            False,
             True,
         ),
         (
@@ -274,7 +270,6 @@ def test_delete_by_id(client: weaviate.Client):
                 {"name": "some name", "vector": [1, 2, 3]},
                 DataObject(properties={"name": "some other name"}),
             ],
-            False,
             True,
         ),
         (
@@ -284,22 +279,12 @@ def test_delete_by_id(client: weaviate.Client):
                     properties={"name": "some other name"}, uuid=uuid.uuid4(), vector=[1, 2, 3]
                 ),
             ],
-            False,
             True,
-        ),
-        (
-            [
-                {"name": "some name", "vector": [1, 2, 3]},
-                {"name": "some other name", "uuid": uuid.uuid4()},
-            ],
-            True,
-            False,
         ),
         (
             [
                 {"name": "some name", "id": uuid.uuid4()},
             ],
-            False,
             True,
         ),
     ],
@@ -307,7 +292,6 @@ def test_delete_by_id(client: weaviate.Client):
 def test_insert_many(
     client: weaviate.Client,
     objects: List[Union[Properties, DataObject[Properties]]],
-    should_implicitly_clean: bool,
     should_error: bool,
 ):
     name = "TestInsertMany"
@@ -318,7 +302,7 @@ def test_insert_many(
         vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     if not should_error:
-        ret = collection.data.insert_many(objects, should_implicitly_clean)
+        ret = collection.data.insert_many(objects)
         for idx, uuid_ in ret.uuids.items():
             obj1 = collection.query.fetch_object_by_id(uuid_)
             assert (

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -349,7 +349,7 @@ def test_insert_many(
             collection.data.insert_many(objects)
         assert (
             e.value.message
-            == f"""It is forbidden to insert either of `uuid` or `vector` inside properties: {objects[0]}. Only properties defined in your collection's config can be insterted as properties of the object, `uuid` and `vector` are forbidden at this level. You should use the `DataObject` class if you wish to insert an object with `uuid` and `vector` alongside its properties."""
+            == f"""It is forbidden to insert `vector` inside properties: {objects[0]}. Only properties defined in your collection's config can be insterted as properties of the object, `vector` is forbidden at this level. You should use the `DataObject` class if you wish to insert an object with a custom `vector` whilst inserting its properties."""
         )
 
 

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -271,13 +271,6 @@ def test_delete_by_id(client: weaviate.Client):
         ),
         (
             [
-                {"name": "some name", "uuid": uuid.uuid4()},
-            ],
-            False,
-            True,
-        ),
-        (
-            [
                 {"name": "some name", "vector": [1, 2, 3]},
                 DataObject(properties={"name": "some other name"}),
             ],
@@ -286,25 +279,7 @@ def test_delete_by_id(client: weaviate.Client):
         ),
         (
             [
-                {"name": "some name", "uuid": uuid.uuid4()},
-                DataObject(properties={"name": "some other name"}),
-            ],
-            False,
-            True,
-        ),
-        (
-            [
                 {"name": "some name", "vector": [1, 2, 3]},
-                DataObject(
-                    properties={"name": "some other name"}, uuid=uuid.uuid4(), vector=[1, 2, 3]
-                ),
-            ],
-            False,
-            True,
-        ),
-        (
-            [
-                {"name": "some name", "uuid": uuid.uuid4()},
                 DataObject(
                     properties={"name": "some other name"}, uuid=uuid.uuid4(), vector=[1, 2, 3]
                 ),
@@ -319,6 +294,13 @@ def test_delete_by_id(client: weaviate.Client):
             ],
             True,
             False,
+        ),
+        (
+            [
+                {"name": "some name", "id": uuid.uuid4()},
+            ],
+            False,
+            True,
         ),
     ],
 )
@@ -349,7 +331,7 @@ def test_insert_many(
             collection.data.insert_many(objects)
         assert (
             e.value.message
-            == f"""It is forbidden to insert `vector` inside properties: {objects[0]}. Only properties defined in your collection's config can be insterted as properties of the object, `vector` is forbidden at this level. You should use the `DataObject` class if you wish to insert an object with a custom `vector` whilst inserting its properties."""
+            == f"""It is forbidden to insert `id` or `vector` inside properties: {objects[0]}. Only properties defined in your collection's config can be insterted as properties of the object, `id` is totally forbidden as it is reserved and `vector` is forbidden at this level. You should use the `DataObject` class if you wish to insert an object with a custom `vector` whilst inserting its properties."""
         )
 
 

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -1,5 +1,8 @@
 import pytest
 from typing import List
+
+from pydantic import ValidationError
+
 from weaviate.collection.classes.config import (
     _CollectionConfigCreate,
     DataType,
@@ -8,6 +11,7 @@ from weaviate.collection.classes.config import (
     _VectorizerConfig,
     ConfigFactory,
     Property,
+    ReferenceProperty,
 )
 
 
@@ -616,3 +620,21 @@ def test_config_with_properties():
             },
         ],
     }
+
+
+@pytest.mark.parametrize("name", ["id", "vector"])
+def test_config_with_invalid_property(name: str):
+    with pytest.raises(ValidationError):
+        _CollectionConfigCreate(
+            name="test",
+            description="test",
+            properties=[Property(name=name, data_type=DataType.TEXT)],
+        )
+
+
+@pytest.mark.parametrize("name", ["id", "vector"])
+def test_config_with_invalid_reference_property(name: str):
+    with pytest.raises(ValidationError):
+        _CollectionConfigCreate(
+            name="test", description="test", properties=[ReferenceProperty(name=name, to="Test")]
+        )

--- a/weaviate/collection/classes/config.py
+++ b/weaviate/collection/classes/config.py
@@ -2,12 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union, cast
 
-from pydantic import (
-    AnyHttpUrl,
-    BaseModel,
-    ConfigDict,
-    Field,
-)
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
 
 from weaviate.util import _capitalize_first_letter
 from weaviate.warnings import _Warnings
@@ -1159,6 +1154,12 @@ class Property(_ConfigCreateModel):
     tokenization: Optional[Tokenization] = Field(default=None)
     vectorize_property_name: bool = True
 
+    @field_validator("name")
+    def check_name(cls, v: str) -> str:
+        if v in ["id", "vector"]:
+            raise ValueError(f"Property name '{v}' is reserved and cannot be used")
+        return v
+
     def to_dict(self, vectorizer: Optional[Vectorizer] = None) -> Dict[str, Any]:
         ret_dict = super().to_dict()
         ret_dict["dataType"] = [ret_dict["dataType"]]
@@ -1176,6 +1177,12 @@ class Property(_ConfigCreateModel):
 
 class ReferencePropertyBase(_ConfigCreateModel):
     name: str
+
+    @field_validator("name")
+    def check_name(cls, v: str) -> str:
+        if v in ["id", "vector"]:
+            raise ValueError(f"Property name '{v}' is reserved and cannot be used")
+        return v
 
 
 class ReferenceProperty(ReferencePropertyBase):

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -66,6 +66,11 @@ class _Data:
 
     def __validate_props(self, props: Dict[str, Any], clean_props: bool) -> None:
         should_throw = False
+        if "id" in props:
+            if clean_props:
+                del props["id"]
+            else:
+                should_throw = True
         if "vector" in props:
             if clean_props:
                 del props["vector"]

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -38,6 +38,7 @@ from weaviate.connect import Connection
 from weaviate.exceptions import (
     UnexpectedStatusCodeException,
     ObjectAlreadyExistsException,
+    WeaviateInsertInvalidPropertyError,
 )
 from weaviate.util import (
     _datetime_to_string,
@@ -63,8 +64,25 @@ class _Data:
         self._batch_grpc = _BatchGRPC(connection, consistency_level)
         self._batch_rest = _BatchREST(connection)
 
-    def _insert(self, weaviate_obj: Dict[str, Any]) -> uuid_package.UUID:
+    def __validate_props(self, props: Dict[str, Any], clean_props: bool) -> None:
+        should_throw = False
+        if "uuid" in props:
+            if clean_props:
+                del props["uuid"]
+            else:
+                should_throw = True
+        if "vector" in props:
+            if clean_props:
+                del props["vector"]
+            else:
+                should_throw = True
+        if should_throw:
+            raise WeaviateInsertInvalidPropertyError(props)
+
+    def _insert(self, weaviate_obj: Dict[str, Any], clean_props: bool) -> uuid_package.UUID:
         path = "/objects"
+        self.__validate_props(weaviate_obj["properties"], clean_props=clean_props)
+
         params, weaviate_obj = self.__apply_context_to_params_and_object({}, weaviate_obj)
         try:
             response = self._connection.post(path=path, weaviate_object=weaviate_obj, params=params)
@@ -82,13 +100,13 @@ class _Data:
             pass
         raise UnexpectedStatusCodeException("Creating object", response)
 
-    def _insert_many(self, objects: List[Dict[str, Any]]) -> _BatchReturn:
+    def _insert_many(self, objects: List[Dict[str, Any]], clean_props: bool) -> _BatchReturn:
         weaviate_objs: List[weaviate_pb2.BatchObject] = [
             weaviate_pb2.BatchObject(
                 class_name=self.name,
                 vector=obj["vector"] if obj["vector"] is not None else None,
                 uuid=str(obj["uuid"]) if obj["uuid"] is not None else str(uuid_package.uuid4()),
-                properties=self.__parse_properties_grpc(obj["properties"]),
+                properties=self.__parse_properties_grpc(obj["properties"], clean_props),
                 tenant=self._tenant,
             )
             for obj in objects
@@ -323,7 +341,11 @@ class _Data:
             ]
         return value
 
-    def __parse_properties_grpc(self, data: Dict[str, Any]) -> weaviate_pb2.BatchObject.Properties:
+    def __parse_properties_grpc(
+        self, data: Dict[str, Any], clean_props: bool
+    ) -> weaviate_pb2.BatchObject.Properties:
+        self.__validate_props(data, clean_props)
+
         multi_target: List[weaviate_pb2.BatchObject.RefPropertiesMultiTarget] = []
         single_target: List[weaviate_pb2.BatchObject.RefPropertiesSingleTarget] = []
         non_ref_properties: Struct = Struct()
@@ -420,6 +442,7 @@ class _DataCollection(Generic[Properties], _Data):
         properties: Properties,
         uuid: Optional[UUID] = None,
         vector: Optional[List[float]] = None,
+        implicitly_clean_properties: bool = False,
     ) -> uuid_package.UUID:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
@@ -430,9 +453,13 @@ class _DataCollection(Generic[Properties], _Data):
         if vector is not None:
             weaviate_obj["vector"] = vector
 
-        return self._insert(weaviate_obj)
+        return self._insert(weaviate_obj, implicitly_clean_properties)
 
-    def insert_many(self, objects: List[DataObject[Properties]]) -> _BatchReturn:
+    def insert_many(
+        self,
+        objects: List[Union[Properties, DataObject[Properties]]],
+        implicitly_clean_properties: bool = False,
+    ) -> _BatchReturn:
         return self._insert_many(
             [
                 {
@@ -440,8 +467,15 @@ class _DataCollection(Generic[Properties], _Data):
                     "vector": obj.vector,
                     "uuid": obj.uuid,
                 }
+                if isinstance(obj, DataObject)
+                else {
+                    "properties": obj,
+                    "vector": None,
+                    "uuid": None,
+                }
                 for obj in objects
-            ]
+            ],
+            implicitly_clean_properties,
         )
 
     def replace(
@@ -538,7 +572,7 @@ class _DataCollectionModel(Generic[Model], _Data):
         )
         return model_object
 
-    def insert(self, obj: Model) -> uuid_package.UUID:
+    def insert(self, obj: Model, implicitly_clean_properties: bool = False) -> uuid_package.UUID:
         self.__model.model_validate(obj)
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
@@ -548,10 +582,12 @@ class _DataCollectionModel(Generic[Model], _Data):
         if obj.vector is not None:
             weaviate_obj["vector"] = obj.vector
 
-        self._insert(weaviate_obj)
+        self._insert(weaviate_obj, implicitly_clean_properties)
         return uuid_package.UUID(str(obj.uuid))
 
-    def insert_many(self, objects: List[Model]) -> _BatchReturn:
+    def insert_many(
+        self, objects: List[Model], implicitly_clean_properties: bool = False
+    ) -> _BatchReturn:
         for obj in objects:
             self.__model.model_validate(obj)
 
@@ -564,7 +600,7 @@ class _DataCollectionModel(Generic[Model], _Data):
             for obj in objects
         ]
 
-        return self._insert_many(data_objects)
+        return self._insert_many(data_objects, implicitly_clean_properties)
 
     def replace(self, obj: Model, uuid: UUID) -> None:
         self.__model.model_validate(obj)

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -66,11 +66,6 @@ class _Data:
 
     def __validate_props(self, props: Dict[str, Any], clean_props: bool) -> None:
         should_throw = False
-        if "uuid" in props:
-            if clean_props:
-                del props["uuid"]
-            else:
-                should_throw = True
         if "vector" in props:
             if clean_props:
                 del props["vector"]

--- a/weaviate/collection/data.py
+++ b/weaviate/collection/data.py
@@ -442,7 +442,6 @@ class _DataCollection(Generic[Properties], _Data):
         properties: Properties,
         uuid: Optional[UUID] = None,
         vector: Optional[List[float]] = None,
-        implicitly_clean_properties: bool = False,
     ) -> uuid_package.UUID:
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
@@ -453,12 +452,11 @@ class _DataCollection(Generic[Properties], _Data):
         if vector is not None:
             weaviate_obj["vector"] = vector
 
-        return self._insert(weaviate_obj, implicitly_clean_properties)
+        return self._insert(weaviate_obj, False)
 
     def insert_many(
         self,
         objects: List[Union[Properties, DataObject[Properties]]],
-        implicitly_clean_properties: bool = False,
     ) -> _BatchReturn:
         return self._insert_many(
             [
@@ -475,7 +473,7 @@ class _DataCollection(Generic[Properties], _Data):
                 }
                 for obj in objects
             ],
-            implicitly_clean_properties,
+            False,
         )
 
     def replace(
@@ -572,7 +570,7 @@ class _DataCollectionModel(Generic[Model], _Data):
         )
         return model_object
 
-    def insert(self, obj: Model, implicitly_clean_properties: bool = False) -> uuid_package.UUID:
+    def insert(self, obj: Model) -> uuid_package.UUID:
         self.__model.model_validate(obj)
         weaviate_obj: Dict[str, Any] = {
             "class": self.name,
@@ -582,12 +580,10 @@ class _DataCollectionModel(Generic[Model], _Data):
         if obj.vector is not None:
             weaviate_obj["vector"] = obj.vector
 
-        self._insert(weaviate_obj, implicitly_clean_properties)
+        self._insert(weaviate_obj, False)
         return uuid_package.UUID(str(obj.uuid))
 
-    def insert_many(
-        self, objects: List[Model], implicitly_clean_properties: bool = False
-    ) -> _BatchReturn:
+    def insert_many(self, objects: List[Model]) -> _BatchReturn:
         for obj in objects:
             self.__model.model_validate(obj)
 
@@ -600,7 +596,7 @@ class _DataCollectionModel(Generic[Model], _Data):
             for obj in objects
         ]
 
-        return self._insert_many(data_objects, implicitly_clean_properties)
+        return self._insert_many(data_objects, False)
 
     def replace(self, obj: Model, uuid: UUID) -> None:
         self.__model.model_validate(obj)

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -190,5 +190,5 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
     """Is raised when inserting an invalid property."""
 
     def __init__(self, data: dict):
-        msg = f"""It is forbidden to insert either of `uuid` or `vector` inside properties: {data}. Only properties defined in your collection's config can be insterted as properties of the object, `uuid` and `vector` are forbidden at this level. You should use the `DataObject` class if you wish to insert an object with `uuid` and `vector` alongside its properties."""
+        msg = f"""It is forbidden to insert `vector` inside properties: {data}. Only properties defined in your collection's config can be insterted as properties of the object, `vector` is forbidden at this level. You should use the `DataObject` class if you wish to insert an object with a custom `vector` whilst inserting its properties."""
         super().__init__(msg)

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -184,3 +184,11 @@ class WeaviateAddInvalidPropertyError(WeaviateBaseError):
         value are valid"""
         super().__init__(msg)
         self.message = message
+
+
+class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
+    """Is raised when inserting an invalid property."""
+
+    def __init__(self, data: dict):
+        msg = f"""It is forbidden to insert either of `uuid` or `vector` inside properties: {data}. Only properties defined in your collection's config can be insterted as properties of the object, `uuid` and `vector` are forbidden at this level. You should use the `DataObject` class if you wish to insert an object with `uuid` and `vector` alongside its properties."""
+        super().__init__(msg)

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -190,5 +190,5 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
     """Is raised when inserting an invalid property."""
 
     def __init__(self, data: dict):
-        msg = f"""It is forbidden to insert `vector` inside properties: {data}. Only properties defined in your collection's config can be insterted as properties of the object, `vector` is forbidden at this level. You should use the `DataObject` class if you wish to insert an object with a custom `vector` whilst inserting its properties."""
+        msg = f"""It is forbidden to insert `id` or `vector` inside properties: {data}. Only properties defined in your collection's config can be insterted as properties of the object, `id` is totally forbidden as it is reserved and `vector` is forbidden at this level. You should use the `DataObject` class if you wish to insert an object with a custom `vector` whilst inserting its properties."""
         super().__init__(msg)


### PR DESCRIPTION
This PR refactors the `.data.insert_many` method allowing the user to supply objects of `Properties` type alongside objects of `DataObject[Properties]` type. As such, use cases such as:
```python
.data.insert_many([{"name": "one"}, {"name": "two"}])
```
are now supported.

Thanks @iamleonie for this UAT feedback suggestion 😁 

Due to potential user errors associated with adding their custom `uuid` and `vector` fields in these `Properties` objects, custom client-side data validation is implemented that throws these as exceptions. The user can switch these error throws off in which case the extra `uuid` and `vector` fields in the objects will be silently removed by the client.