### PR TITLE
refactor queries under .query and .generate submodules

### DIFF
--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -11,7 +11,7 @@ from weaviate.collection.classes.config import (
     Property,
 )
 from weaviate.collection.classes.data import DataObject
-from weaviate.collection.classes.grpc import Generate, MetadataQuery
+from weaviate.collection.classes.grpc import MetadataQuery
 from weaviate.exceptions import WeaviateGRPCException
 
 
@@ -51,10 +51,8 @@ def test_generative_search_single(client: weaviate.Client, parameter: str, answe
         ]
     )
 
-    res = collection.query.fetch_objects(
-        generate=Generate(
-            single_prompt=f"is it good or bad based on {{{parameter}}}? Just answer with yes or no without punctuation"
-        )
+    res = collection.generate.fetch_objects(
+        single_prompt=f"is it good or bad based on {{{parameter}}}? Just answer with yes or no without punctuation"
     )
     for obj in res.objects:
         assert obj.metadata.generative == answer
@@ -86,11 +84,9 @@ def test_fetch_objects_generate_search_grouped(
         ]
     )
 
-    res = collection.query.fetch_objects(
-        generate=Generate(
-            grouped_task="What is big and what is small? write the name of the big thing first and then the name of the small thing after a space.",
-            grouped_properties=prop,
-        )
+    res = collection.generate.fetch_objects(
+        grouped_task="What is big and what is small? write the name of the big thing first and then the name of the small thing after a space.",
+        grouped_properties=prop,
     )
     assert res.generated == answer
 
@@ -125,10 +121,8 @@ def test_fetch_objects_generate_search_grouped_all_props(client: weaviate.Client
         ]
     )
 
-    res = collection.query.fetch_objects(
-        generate=Generate(
-            grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space"
-        )
+    res = collection.generate.fetch_objects(
+        grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space"
     )
     assert res.generated == "Teddy cats"
 
@@ -163,11 +157,9 @@ def test_fetch_objects_generate_search_grouped_specified_prop(client: weaviate.C
         ]
     )
 
-    res = collection.query.fetch_objects(
-        generate=Generate(
-            grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space",
-            grouped_properties=["text"],
-        )
+    res = collection.generate.fetch_objects(
+        grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space",
+        grouped_properties=["text"],
     )
     assert res.generated == "apples bananas"
 
@@ -202,11 +194,9 @@ def test_fetch_objects_generate_with_everything(client: weaviate.Client):
         ]
     )
 
-    res = collection.query.fetch_objects(
-        generate=Generate(
-            single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
-            grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space",
-        )
+    res = collection.generate.fetch_objects(
+        single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
+        grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space",
     )
     assert res.generated == "Teddy cats"
     for obj in res.objects:
@@ -243,13 +233,11 @@ def test_bm25_generate_with_everything(client: weaviate.Client):
         ]
     )
 
-    res = collection.query.bm25(
+    res = collection.generate.bm25(
         query="Teddy",
         query_properties=["content"],
-        generate=Generate(
-            single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
-            grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space",
-        ),
+        single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
+        grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space",
     )
     assert res.generated == "Teddy apples"
     for obj in res.objects:
@@ -286,13 +274,11 @@ def test_hybrid_generate_with_everything(client: weaviate.Client):
         ]
     )
 
-    res = collection.query.hybrid(
+    res = collection.generate.hybrid(
         query="cats",
         query_properties=["text"],
-        generate=Generate(
-            single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
-            grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space from biggest to smallest",
-        ),
+        single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
+        grouped_task="What is the biggest and what is the smallest? Only write the names separated by a space from biggest to smallest",
     )
     assert res.generated == "cats bananas"
     for obj in res.objects:
@@ -330,12 +316,10 @@ def test_near_text_generate_with_everything(client: weaviate.Client):
         ]
     )
 
-    res = collection.query.near_text(
+    res = collection.generate.near_text(
         query="small fruit",
-        generate=Generate(
-            single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
-            grouped_task="Write out the fruit in the order in which they appear in the provided list. Only write the names separated by a space",
-        ),
+        single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
+        grouped_task="Write out the fruit in the order in which they appear in the provided list. Only write the names separated by a space",
     )
     assert res.generated == "bananas apples"
     assert res.objects[0].metadata.generative == "No"
@@ -374,12 +358,10 @@ def test_near_vector_generate_with_everything(client: weaviate.Client):
         ]
     )
 
-    res = collection.query.near_vector(
+    res = collection.generate.near_vector(
         near_vector=[1, 2, 3, 4, 6],
-        generate=Generate(
-            single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
-            grouped_task="Write out the fruit in the order in which they appear in the provided list. Only write the names separated by a space",
-        ),
+        single_prompt="Is there something to eat in {text}? Only answer yes if there is something to eat or no if not without punctuation",
+        grouped_task="Write out the fruit in the order in which they appear in the provided list. Only write the names separated by a space",
     )
     assert res.generated == "apples bananas"
     assert res.objects[0].metadata.generative == "Yes"
@@ -402,9 +384,7 @@ def test_openapi_invalid_key():
     )
     collection.data.insert(properties={"text": "test"})
     with pytest.raises(WeaviateGRPCException):
-        collection.query.fetch_objects(
-            generate=Generate(single_prompt="tell a joke based on {text}")
-        )
+        collection.generate.fetch_objects(single_prompt="tell a joke based on {text}")
 
 
 def test_openapi_no_module():
@@ -423,9 +403,7 @@ def test_openapi_no_module():
     )
     collection.data.insert(properties={"text": "test"})
     with pytest.raises(WeaviateGRPCException):
-        collection.query.fetch_objects(
-            generate=Generate(single_prompt="tell a joke based on {text}")
-        )
+        collection.generate.fetch_objects(single_prompt="tell a joke based on {text}")
 
 
 def test_openai_batch_upload(client: weaviate.Client):

--- a/weaviate/classes.py
+++ b/weaviate/classes.py
@@ -17,7 +17,6 @@ from weaviate.collection.classes.grpc import (
     LinkTo,
     LinkToMultiTarget,
     MetadataQuery,
-    Generate,
 )
 from weaviate.collection.classes.internal import ReferenceFactory
 from weaviate.collection.classes.tenants import Tenant
@@ -27,7 +26,6 @@ __all__ = [
     "DataObject",
     "DataType",
     "Filter",
-    "Generate",
     "HybridFusion",
     "LinkTo",
     "LinkToMultiTarget",

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -22,7 +22,7 @@ from weaviate.collection.classes.types import Properties, TProperties, _check_da
 from weaviate.collection.collection_base import CollectionBase, CollectionObjectBase
 from weaviate.collection.config import _ConfigCollection
 from weaviate.collection.data import _DataCollection
-from weaviate.collection.grpc import _GrpcCollection
+from weaviate.collection.grpc import _GenerateCollection, _QueryCollection
 from weaviate.collection.object_iterator import _ObjectIterator
 from weaviate.collection.tenants import _Tenants
 from weaviate.connect import Connection
@@ -44,7 +44,8 @@ class CollectionObject(CollectionObjectBase, Generic[TProperties]):
 
         self.config = _ConfigCollection(self._connection, name)
         self.data = _DataCollection[TProperties](connection, name, consistency_level, tenant, type_)
-        self.query = _GrpcCollection[TProperties](
+        self.generate = _GenerateCollection(connection, name, consistency_level, tenant)
+        self.query = _QueryCollection[TProperties](
             connection, name, self.data, consistency_level, tenant
         )
         self.tenants = _Tenants(connection, name)

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -26,15 +26,15 @@ from weaviate.collection.data import _DataCollection
 from weaviate.collection.grpc_query import SearchResult
 
 from weaviate.collection.queries.base import _Grpc
-from weaviate.collection.queries.bm25 import _BM25
-from weaviate.collection.queries.fetch_objects import _FetchObjects
-from weaviate.collection.queries.hybrid import _Hybrid
-from weaviate.collection.queries.near_audio import _NearAudio
-from weaviate.collection.queries.near_image import _NearImage
-from weaviate.collection.queries.near_object import _NearObject
-from weaviate.collection.queries.near_text import _NearText
-from weaviate.collection.queries.near_vector import _NearVector
-from weaviate.collection.queries.near_video import _NearVideo
+from weaviate.collection.queries.bm25 import _BM25Generate, _BM25Query
+from weaviate.collection.queries.fetch_objects import _FetchObjectsGenerate, _FetchObjectsQuery
+from weaviate.collection.queries.hybrid import _HybridGenerate, _HybridQuery
+from weaviate.collection.queries.near_audio import _NearAudioGenerate, _NearAudioQuery
+from weaviate.collection.queries.near_image import _NearImageGenerate, _NearImageQuery
+from weaviate.collection.queries.near_object import _NearObjectGenerate, _NearObjectQuery
+from weaviate.collection.queries.near_text import _NearTextGenerate, _NearTextQuery
+from weaviate.collection.queries.near_vector import _NearVectorGenerate, _NearVectorQuery
+from weaviate.collection.queries.near_video import _NearVideoGenerate, _NearVideoQuery
 
 from weaviate.connect import Connection
 from weaviate.types import UUID
@@ -42,17 +42,17 @@ from weaviate.types import UUID
 from weaviate_grpc import weaviate_pb2
 
 
-class _GrpcCollection(
+class _QueryCollection(
     Generic[TProperties],
-    _BM25,
-    _FetchObjects,
-    _Hybrid,
-    _NearAudio,
-    _NearImage,
-    _NearObject,
-    _NearText,
-    _NearVector,
-    _NearVideo,
+    _BM25Query,
+    _FetchObjectsQuery,
+    _HybridQuery,
+    _NearAudioQuery,
+    _NearImageQuery,
+    _NearObjectQuery,
+    _NearTextQuery,
+    _NearVectorQuery,
+    _NearVideoQuery,
 ):
     def __init__(
         self,
@@ -72,6 +72,20 @@ class _GrpcCollection(
         if ret is None:
             return ret
         return self.__data._json_to_object(ret)
+
+
+class _GenerateCollection(
+    _BM25Generate,
+    _FetchObjectsGenerate,
+    _HybridGenerate,
+    _NearAudioGenerate,
+    _NearImageGenerate,
+    _NearObjectGenerate,
+    _NearTextGenerate,
+    _NearVectorGenerate,
+    _NearVideoGenerate,
+):
+    pass
 
 
 class _GrpcCollectionModel(Generic[Model], _Grpc):

--- a/weaviate/collection/object_iterator.py
+++ b/weaviate/collection/object_iterator.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from weaviate.collection.classes.grpc import MetadataQuery, PROPERTIES
 from weaviate.collection.classes.internal import _Object, _QueryReturn
 from weaviate.collection.classes.types import Properties, TProperties
-from weaviate.collection.grpc import _GrpcCollection
+from weaviate.collection.grpc import _QueryCollection
 
 
 ITERATOR_CACHE_SIZE = 100
@@ -13,7 +13,7 @@ ITERATOR_CACHE_SIZE = 100
 class _ObjectIterator(Generic[Properties, TProperties], Iterable[_Object[Properties]]):
     def __init__(
         self,
-        query: _GrpcCollection[TProperties],
+        query: _QueryCollection[TProperties],
         return_metadata: Optional[MetadataQuery],
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]],
     ) -> None:

--- a/weaviate/collection/queries/bm25.py
+++ b/weaviate/collection/queries/bm25.py
@@ -1,17 +1,14 @@
 from typing import (
     List,
-    Literal,
     Optional,
     Union,
     Type,
-    overload,
 )
 
 from weaviate.collection.classes.filters import (
     _Filters,
 )
 from weaviate.collection.classes.grpc import (
-    Generate,
     MetadataQuery,
     PROPERTIES,
 )
@@ -22,8 +19,7 @@ from weaviate.collection.classes.types import (
 from weaviate.collection.queries.base import _Grpc
 
 
-class _BM25(_Grpc):
-    @overload
+class _BM25Query(_Grpc):
     def bm25(
         self,
         query: str,
@@ -31,38 +27,9 @@ class _BM25(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def bm25(
-        self,
-        query: str,
-        query_properties: Optional[List[str]] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        generate: Generate,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GenerativeReturn[Properties]:
-        ...
-
-    def bm25(
-        self,
-        query: str,
-        query_properties: Optional[List[str]] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        generate: Optional[Generate] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_QueryReturn[Properties], _GenerativeReturn[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().bm25(
             query=query,
@@ -72,9 +39,37 @@ class _BM25(_Grpc):
             filters=filters,
             return_metadata=return_metadata,
             return_properties=ret_properties,
-            generative=_Generative.from_input(generate),
         )
-        if generate is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_generative_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
+
+
+class _BM25Generate(_Grpc):
+    def bm25(
+        self,
+        query: str,
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        query_properties: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GenerativeReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().bm25(
+            query=query,
+            properties=query_properties,
+            limit=limit,
+            autocut=auto_limit,
+            filters=filters,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+            generative=_Generative(
+                single=single_prompt,
+                grouped=grouped_task,
+                grouped_properties=grouped_properties,
+            ),
+        )
+        return self._result_to_generative_return(res, ret_type)

--- a/weaviate/collection/queries/fetch_objects.py
+++ b/weaviate/collection/queries/fetch_objects.py
@@ -1,17 +1,14 @@
 from typing import (
     List,
-    Literal,
     Optional,
     Union,
     Type,
-    overload,
 )
 
 from weaviate.collection.classes.filters import (
     _Filters,
 )
 from weaviate.collection.classes.grpc import (
-    Generate,
     MetadataQuery,
     PROPERTIES,
     Sort,
@@ -24,8 +21,7 @@ from weaviate.collection.queries.base import _Grpc
 from weaviate.types import UUID
 
 
-class _FetchObjects(_Grpc):
-    @overload
+class _FetchObjectsQuery(_Grpc):
     def fetch_objects(
         self,
         limit: Optional[int] = None,
@@ -33,38 +29,9 @@ class _FetchObjects(_Grpc):
         after: Optional[UUID] = None,
         filters: Optional[_Filters] = None,
         sort: Optional[Union[Sort, List[Sort]]] = None,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def fetch_objects(
-        self,
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
-        after: Optional[UUID] = None,
-        filters: Optional[_Filters] = None,
-        sort: Optional[Union[Sort, List[Sort]]] = None,
-        *,
-        generate: Generate,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GenerativeReturn[Properties]:
-        ...
-
-    def fetch_objects(
-        self,
-        limit: Optional[int] = None,
-        offset: Optional[int] = None,
-        after: Optional[UUID] = None,
-        filters: Optional[_Filters] = None,
-        sort: Optional[Union[Sort, List[Sort]]] = None,
-        generate: Optional[Generate] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_QueryReturn[Properties], _GenerativeReturn[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().get(
             limit=limit,
@@ -74,9 +41,37 @@ class _FetchObjects(_Grpc):
             sort=sort,
             return_metadata=return_metadata,
             return_properties=ret_properties,
-            generative=_Generative.from_input(generate),
         )
-        if generate is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_generative_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
+
+
+class _FetchObjectsGenerate(_Grpc):
+    def fetch_objects(
+        self,
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        after: Optional[UUID] = None,
+        filters: Optional[_Filters] = None,
+        sort: Optional[Union[Sort, List[Sort]]] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GenerativeReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().get(
+            limit=limit,
+            offset=offset,
+            after=after,
+            filters=filters,
+            sort=sort,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+            generative=_Generative(
+                single=single_prompt,
+                grouped=grouped_task,
+                grouped_properties=grouped_properties,
+            ),
+        )
+        return self._result_to_generative_return(res, ret_type)

--- a/weaviate/collection/queries/hybrid.py
+++ b/weaviate/collection/queries/hybrid.py
@@ -1,16 +1,14 @@
 from typing import (
     List,
-    Literal,
     Optional,
     Union,
     Type,
-    overload,
 )
 
 from weaviate.collection.classes.filters import (
     _Filters,
 )
-from weaviate.collection.classes.grpc import Generate, MetadataQuery, PROPERTIES, HybridFusion
+from weaviate.collection.classes.grpc import MetadataQuery, PROPERTIES, HybridFusion
 from weaviate.collection.classes.internal import (
     _GenerativeReturn,
     _QueryReturn,
@@ -22,8 +20,7 @@ from weaviate.collection.classes.types import (
 from weaviate.collection.queries.base import _Grpc
 
 
-class _Hybrid(_Grpc):
-    @overload
+class _HybridQuery(_Grpc):
     def hybrid(
         self,
         query: str,
@@ -34,44 +31,9 @@ class _Hybrid(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def hybrid(
-        self,
-        query: str,
-        alpha: Optional[float] = None,
-        vector: Optional[List[float]] = None,
-        query_properties: Optional[List[str]] = None,
-        fusion_type: Optional[HybridFusion] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        generate: Generate,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GenerativeReturn[Properties]:
-        ...
-
-    def hybrid(
-        self,
-        query: str,
-        alpha: Optional[float] = None,
-        vector: Optional[List[float]] = None,
-        query_properties: Optional[List[str]] = None,
-        fusion_type: Optional[HybridFusion] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        generate: Optional[Generate] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_QueryReturn[Properties], _GenerativeReturn[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().hybrid(
             query=query,
@@ -84,9 +46,43 @@ class _Hybrid(_Grpc):
             filters=filters,
             return_metadata=return_metadata,
             return_properties=ret_properties,
-            generative=_Generative.from_input(generate),
         )
-        if generate is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_generative_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
+
+
+class _HybridGenerate(_Grpc):
+    def hybrid(
+        self,
+        query: str,
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        alpha: Optional[float] = None,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GenerativeReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().hybrid(
+            query=query,
+            alpha=alpha,
+            vector=vector,
+            properties=query_properties,
+            fusion_type=fusion_type,
+            limit=limit,
+            autocut=auto_limit,
+            filters=filters,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+            generative=_Generative(
+                single=single_prompt,
+                grouped=grouped_task,
+                grouped_properties=grouped_properties,
+            ),
+        )
+        return self._result_to_generative_return(res, ret_type)

--- a/weaviate/collection/queries/near_audio.py
+++ b/weaviate/collection/queries/near_audio.py
@@ -1,6 +1,6 @@
 from io import BufferedReader
 from pathlib import Path
-from typing import Literal, Optional, Type, Union, overload
+from typing import List, Literal, Optional, Type, Union, overload
 
 from weaviate.collection.classes.filters import (
     _Filters,
@@ -8,7 +8,6 @@ from weaviate.collection.classes.filters import (
 from weaviate.collection.classes.grpc import (
     MetadataQuery,
     PROPERTIES,
-    Generate,
     GroupBy,
 )
 from weaviate.collection.classes.internal import (
@@ -24,7 +23,7 @@ from weaviate.collection.classes.types import (
 from weaviate.collection.queries.base import _Grpc
 
 
-class _NearAudio(_Grpc):
+class _NearAudioQuery(_Grpc):
     @overload
     def near_audio(
         self,
@@ -35,7 +34,6 @@ class _NearAudio(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Literal[None] = None,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _QueryReturn[Properties]:
@@ -50,26 +48,8 @@ class _NearAudio(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
-        *,
-        generate: Generate,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GenerativeReturn[Properties]:
-        ...
-
-    @overload
-    def near_audio(
-        self,
-        near_audio: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
         *,
         group_by: GroupBy,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _GroupByReturn[Properties]:
@@ -84,13 +64,9 @@ class _NearAudio(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Optional[GroupBy] = None,
-        generate: Optional[Generate] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GenerativeReturn[Properties], _GroupByReturn[Properties], _QueryReturn[Properties]]:
-        if generate is not None and group_by is not None:
-            raise ValueError("Cannot have group_by and generate defined simultaneously")
-
+    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_audio(
             audio=self._parse_media(near_audio),
@@ -98,15 +74,46 @@ class _NearAudio(_Grpc):
             distance=distance,
             filters=filters,
             group_by=_GroupBy.from_input(group_by),
-            generative=_Generative.from_input(generate),
             limit=limit,
             autocut=auto_limit,
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if generate is None and group_by is None:
+        if group_by is None:
             return self._result_to_query_return(res, ret_type)
-        elif generate is not None:
-            return self._result_to_generative_return(res, ret_type)
         else:
             return self._result_to_groupby_return(res, ret_type)
+
+
+class _NearAudioGenerate(_Grpc):
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GenerativeReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_audio(
+            audio=self._parse_media(near_audio),
+            certainty=certainty,
+            distance=distance,
+            filters=filters,
+            generative=_Generative(
+                single=single_prompt,
+                grouped=grouped_task,
+                grouped_properties=grouped_properties,
+            ),
+            limit=limit,
+            autocut=auto_limit,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_generative_return(res, ret_type)

--- a/weaviate/collection/queries/near_image.py
+++ b/weaviate/collection/queries/near_image.py
@@ -1,11 +1,11 @@
 from io import BufferedReader
 from pathlib import Path
-from typing import Literal, Optional, Type, Union, overload
+from typing import List, Literal, Optional, Type, Union, overload
 
 from weaviate.collection.classes.filters import (
     _Filters,
 )
-from weaviate.collection.classes.grpc import MetadataQuery, PROPERTIES, Generate, GroupBy
+from weaviate.collection.classes.grpc import GroupBy, MetadataQuery, PROPERTIES
 from weaviate.collection.classes.internal import (
     _Generative,
     _GenerativeReturn,
@@ -19,7 +19,7 @@ from weaviate.collection.classes.types import (
 from weaviate.collection.queries.base import _Grpc
 
 
-class _NearImage(_Grpc):
+class _NearImageQuery(_Grpc):
     @overload
     def near_image(
         self,
@@ -30,7 +30,6 @@ class _NearImage(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Literal[None] = None,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _QueryReturn[Properties]:
@@ -45,26 +44,8 @@ class _NearImage(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
-        *,
-        generate: Generate,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GenerativeReturn[Properties]:
-        ...
-
-    @overload
-    def near_image(
-        self,
-        near_image: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
         *,
         group_by: GroupBy,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _GroupByReturn[Properties]:
@@ -79,29 +60,56 @@ class _NearImage(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Optional[GroupBy] = None,
-        generate: Optional[Generate] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GenerativeReturn[Properties], _GroupByReturn[Properties], _QueryReturn[Properties]]:
-        if generate is not None and group_by is not None:
-            raise ValueError("Cannot have group_by and generate defined simultaneously")
-
+    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_image(
             image=self._parse_media(near_image),
             certainty=certainty,
             distance=distance,
-            limit=limit,
-            autocut=auto_limit,
             filters=filters,
             group_by=_GroupBy.from_input(group_by),
-            generative=_Generative.from_input(generate),
+            limit=limit,
+            autocut=auto_limit,
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if generate is None and group_by is None:
+        if group_by is None:
             return self._result_to_query_return(res, ret_type)
-        elif generate is not None:
-            return self._result_to_generative_return(res, ret_type)
         else:
             return self._result_to_groupby_return(res, ret_type)
+
+
+class _NearImageGenerate(_Grpc):
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GenerativeReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_image(
+            image=self._parse_media(near_image),
+            certainty=certainty,
+            distance=distance,
+            filters=filters,
+            generative=_Generative(
+                single=single_prompt,
+                grouped=grouped_task,
+                grouped_properties=grouped_properties,
+            ),
+            limit=limit,
+            autocut=auto_limit,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_generative_return(res, ret_type)

--- a/weaviate/collection/queries/near_text.py
+++ b/weaviate/collection/queries/near_text.py
@@ -11,7 +11,6 @@ from weaviate.collection.classes.filters import (
     _Filters,
 )
 from weaviate.collection.classes.grpc import (
-    Generate,
     GroupBy,
     MetadataQuery,
     PROPERTIES,
@@ -30,7 +29,7 @@ from weaviate.collection.classes.types import (
 from weaviate.collection.queries.base import _Grpc
 
 
-class _NearText(_Grpc):
+class _NearTextQuery(_Grpc):
     @overload
     def near_text(
         self,
@@ -43,7 +42,6 @@ class _NearText(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Literal[None] = None,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _QueryReturn[Properties]:
@@ -61,27 +59,7 @@ class _NearText(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         *,
-        group_by: Literal[None] = None,
-        generate: Generate,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GenerativeReturn[Properties]:
-        ...
-
-    @overload
-    def near_text(
-        self,
-        query: Union[List[str], str],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        move_to: Optional[Move] = None,
-        move_away: Optional[Move] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
         group_by: GroupBy,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _GroupByReturn[Properties]:
@@ -98,13 +76,9 @@ class _NearText(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Optional[GroupBy] = None,
-        generate: Optional[Generate] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_QueryReturn[Properties], _GenerativeReturn[Properties], _GroupByReturn[Properties]]:
-        if generate is not None and group_by is not None:
-            raise ValueError("Cannot have group_by and generate defined simultaneously")
-
+    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_text(
             near_text=query,
@@ -116,13 +90,48 @@ class _NearText(_Grpc):
             autocut=auto_limit,
             filters=filters,
             group_by=_GroupBy.from_input(group_by),
-            generative=_Generative.from_input(generate),
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if generate is None and group_by is None:
+        if group_by is None:
             return self._result_to_query_return(res, ret_type)
-        elif generate is not None:
-            return self._result_to_generative_return(res, ret_type)
         else:
             return self._result_to_groupby_return(res, ret_type)
+
+
+class _NearTextGenerate(_Grpc):
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GenerativeReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_text(
+            near_text=query,
+            certainty=certainty,
+            distance=distance,
+            move_to=move_to,
+            move_away=move_away,
+            limit=limit,
+            autocut=auto_limit,
+            filters=filters,
+            generative=_Generative(
+                single=single_prompt,
+                grouped=grouped_task,
+                grouped_properties=grouped_properties,
+            ),
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_generative_return(res, ret_type)

--- a/weaviate/collection/queries/near_video.py
+++ b/weaviate/collection/queries/near_video.py
@@ -1,6 +1,7 @@
 from io import BufferedReader
 from pathlib import Path
 from typing import (
+    List,
     Literal,
     Optional,
     Type,
@@ -12,7 +13,6 @@ from weaviate.collection.classes.filters import (
     _Filters,
 )
 from weaviate.collection.classes.grpc import (
-    Generate,
     GroupBy,
     MetadataQuery,
     PROPERTIES,
@@ -30,7 +30,7 @@ from weaviate.collection.classes.types import (
 from weaviate.collection.queries.base import _Grpc
 
 
-class _NearVideo(_Grpc):
+class _NearVideoQuery(_Grpc):
     @overload
     def near_video(
         self,
@@ -41,7 +41,6 @@ class _NearVideo(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Literal[None] = None,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _QueryReturn[Properties]:
@@ -56,26 +55,8 @@ class _NearVideo(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
-        *,
-        generate: Generate,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GenerativeReturn[Properties]:
-        ...
-
-    @overload
-    def near_video(
-        self,
-        near_video: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
         *,
         group_by: GroupBy,
-        generate: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
     ) -> _GroupByReturn[Properties]:
@@ -90,29 +71,56 @@ class _NearVideo(_Grpc):
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
         group_by: Optional[GroupBy] = None,
-        generate: Optional[Generate] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GenerativeReturn[Properties], _GroupByReturn[Properties], _QueryReturn[Properties]]:
-        if generate is not None and group_by is not None:
-            raise ValueError("Cannot have group_by and generate defined simultaneously")
-
+    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_video(
             video=self._parse_media(near_video),
             certainty=certainty,
             distance=distance,
-            limit=limit,
-            autocut=auto_limit,
             filters=filters,
             group_by=_GroupBy.from_input(group_by),
-            generative=_Generative.from_input(generate),
+            limit=limit,
+            autocut=auto_limit,
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if generate is None and group_by is None:
+        if group_by is None:
             return self._result_to_query_return(res, ret_type)
-        elif generate is not None:
-            return self._result_to_generative_return(res, ret_type)
         else:
             return self._result_to_groupby_return(res, ret_type)
+
+
+class _NearVideoGenerate(_Grpc):
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GenerativeReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_video(
+            video=self._parse_media(near_video),
+            certainty=certainty,
+            distance=distance,
+            filters=filters,
+            generative=_Generative(
+                single=single_prompt,
+                grouped=grouped_task,
+                grouped_properties=grouped_properties,
+            ),
+            limit=limit,
+            autocut=auto_limit,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_generative_return(res, ret_type)


### PR DESCRIPTION
This PR splits up the queries from `.query` only into `.query` and `.generate`. The queries under `.query` now only accept an additional `group_by` argument that is used during the `typing.overload` logic to define the correct return from the method. All queries that used the `generate` argument are now housed under the `.generate` submodule of `collection`

In the process, `_GrpcCollection` is renamed to `_QueryCollection` to differentiate it from the new `_GenerateCollection`