### PR TITLE
split group_by queries into `query_group_by` namespace

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -524,7 +524,7 @@ def test_search_hybrid(client: weaviate.Client, fusion_type):
     )
     collection.data.insert({"Name": "some name"}, uuid.uuid4())
     collection.data.insert({"Name": "other word"}, uuid.uuid4())
-    res = collection.query.hybrid(alpha=0, query="name", fusion_type=fusion_type).objects
+    res = collection.query.hybrid(alpha=0, query="name", fusion_type=fusion_type)
     assert len(res) == 1
     client.collection.delete("Testing")
 
@@ -539,7 +539,7 @@ def test_search_limit(client: weaviate.Client, limit):
     for i in range(5):
         collection.data.insert({"Name": str(i)})
 
-    assert len(collection.query.fetch_objects(limit=limit).objects) == limit
+    assert len(collection.query.fetch_objects(limit=limit)) == limit
 
     client.collection.delete("TestLimit")
 
@@ -556,7 +556,7 @@ def test_search_offset(client: weaviate.Client, offset):
     for i in range(nr_objects):
         collection.data.insert({"Name": str(i)})
 
-    objects = collection.query.fetch_objects(offset=offset).objects
+    objects = collection.query.fetch_objects(offset=offset)
     assert len(objects) == nr_objects - offset
 
     client.collection.delete("TestOffset")
@@ -573,9 +573,9 @@ def test_search_after(client: weaviate.Client):
     for i in range(nr_objects):
         collection.data.insert({"Name": str(i)})
 
-    objects = collection.query.fetch_objects(return_metadata=MetadataQuery(uuid=True)).objects
+    objects = collection.query.fetch_objects(return_metadata=MetadataQuery(uuid=True))
     for i, obj in enumerate(objects):
-        objects_after = collection.query.fetch_objects(after=obj.metadata.uuid).objects
+        objects_after = collection.query.fetch_objects(after=obj.metadata.uuid)
         assert len(objects_after) == nr_objects - 1 - i
 
     client.collection.delete("TestOffset")
@@ -595,19 +595,19 @@ def test_auto_limit(client: weaviate.Client):
         collection.data.insert({"Name": ""})
 
     # match all objects with rain
-    objects = collection.query.bm25(query="rain", auto_limit=0).objects
+    objects = collection.query.bm25(query="rain", auto_limit=0)
     assert len(objects) == 2 * 4
     objects = collection.query.hybrid(
         query="rain", auto_limit=0, alpha=0, fusion_type=HybridFusion.RELATIVE_SCORE
-    ).objects
+    )
     assert len(objects) == 2 * 4
 
     # match only objects with two rains
-    objects = collection.query.bm25(query="rain", auto_limit=1).objects
+    objects = collection.query.bm25(query="rain", auto_limit=1)
     assert len(objects) == 1 * 4
     objects = collection.query.hybrid(
         query="rain", auto_limit=1, alpha=0, fusion_type=HybridFusion.RELATIVE_SCORE
-    ).objects
+    )
     assert len(objects) == 1 * 4
 
     client.collection.delete("TestAutoLimit")
@@ -628,18 +628,18 @@ def test_query_properties(client: weaviate.Client):
     collection.data.insert({"Name": "snow", "Age": 4})
     collection.data.insert({"Name": "hail", "Age": 5})
 
-    objects = collection.query.bm25(query="rain", query_properties=["name"]).objects
+    objects = collection.query.bm25(query="rain", query_properties=["name"])
     assert len(objects) == 1
     assert objects[0].properties["age"] == 1
 
-    objects = collection.query.bm25(query="sleet", query_properties=["name"]).objects
+    objects = collection.query.bm25(query="sleet", query_properties=["name"])
     assert len(objects) == 0
 
-    objects = collection.query.hybrid(query="cloud", query_properties=["name"], alpha=0).objects
+    objects = collection.query.hybrid(query="cloud", query_properties=["name"], alpha=0)
     assert len(objects) == 1
     assert objects[0].properties["age"] == 3
 
-    objects = collection.query.hybrid(query="sleet", query_properties=["name"], alpha=0).objects
+    objects = collection.query.hybrid(query="sleet", query_properties=["name"], alpha=0)
     assert len(objects) == 0
 
     client.collection.delete("TestQueryProperties")
@@ -660,17 +660,17 @@ def test_near_vector(client: weaviate.Client):
 
     full_objects = collection.query.near_vector(
         banana.metadata.vector, return_metadata=MetadataQuery(distance=True, certainty=True)
-    ).objects
+    )
     assert len(full_objects) == 4
 
     objects_distance = collection.query.near_vector(
         banana.metadata.vector, distance=full_objects[2].metadata.distance
-    ).objects
+    )
     assert len(objects_distance) == 3
 
     objects_distance = collection.query.near_vector(
         banana.metadata.vector, certainty=full_objects[2].metadata.certainty
-    ).objects
+    )
     assert len(objects_distance) == 3
 
     client.collection.delete("TestNearVector")
@@ -693,7 +693,7 @@ def test_near_vector_group_by(client: weaviate.Client):
     banana1 = collection.query.fetch_object_by_id(uuid_banana1, include_vector=True)
 
     assert banana1.metadata.vector is not None
-    ret = collection.query.near_vector(
+    ret = collection.query_group_by.near_vector(
         banana1.metadata.vector,
         group_by=GroupBy(prop="name", number_of_groups=4, objects_per_group=10),
         return_metadata=MetadataQuery(distance=True, certainty=True),
@@ -721,17 +721,17 @@ def test_near_object(client: weaviate.Client):
 
     full_objects = collection.query.near_object(
         uuid_banana, return_metadata=MetadataQuery(distance=True, certainty=True)
-    ).objects
+    )
     assert len(full_objects) == 4
 
     objects_distance = collection.query.near_object(
         uuid_banana, distance=full_objects[2].metadata.distance
-    ).objects
+    )
     assert len(objects_distance) == 3
 
     objects_certainty = collection.query.near_object(
         uuid_banana, certainty=full_objects[2].metadata.certainty
-    ).objects
+    )
     assert len(objects_certainty) == 3
 
     client.collection.delete("TestNearObject")
@@ -751,7 +751,7 @@ def test_near_object_group_by(client: weaviate.Client):
     collection.data.insert({"Name": "car", "Count": 12})
     collection.data.insert({"Name": "Mountain", "Count": 1})
 
-    ret = collection.query.near_object(
+    ret = collection.query_group_by.near_object(
         uuid_banana1,
         group_by=GroupBy(prop="name", number_of_groups=4, objects_per_group=10),
         return_metadata=MetadataQuery(distance=True, certainty=True),
@@ -804,11 +804,11 @@ def test_multi_searches(client: weaviate.Client):
         query="word",
         return_properties=["name"],
         return_metadata=MetadataQuery(last_update_time_unix=True),
-    ).objects
+    )
     assert "name" in objects[0].properties
     assert objects[0].metadata.last_update_time_unix is not None
 
-    objects = collection.query.bm25(query="other", return_metadata=MetadataQuery(uuid=True)).objects
+    objects = collection.query.bm25(query="other", return_metadata=MetadataQuery(uuid=True))
     assert "name" not in objects[0].properties
     assert objects[0].metadata.uuid is not None
     assert objects[0].metadata.last_update_time_unix is None
@@ -828,11 +828,11 @@ def test_search_with_tenant(client: weaviate.Client):
     tenant1 = collection.with_tenant("Tenant1")
     tenant2 = collection.with_tenant("Tenant2")
     uuid1 = tenant1.data.insert({"name": "some name"})
-    objects1 = tenant1.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True)).objects
+    objects1 = tenant1.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True))
     assert len(objects1) == 1
     assert objects1[0].metadata.uuid == uuid1
 
-    objects2 = tenant2.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True)).objects
+    objects2 = tenant2.query.bm25(query="some", return_metadata=MetadataQuery(uuid=True))
     assert len(objects2) == 0
 
     client.collection.delete("TestTenantSearch")
@@ -877,8 +877,8 @@ def test_fetch_objects_with_limit(client: weaviate.Client):
     for i in range(10):
         collection.data.insert({"name": str(i)})
 
-    ret = collection.query.fetch_objects(limit=5)
-    assert len(ret.objects) == 5
+    objects = collection.query.fetch_objects(limit=5)
+    assert len(objects) == 5
 
     client.collection.delete("TestLimit")
 
@@ -896,17 +896,17 @@ def test_fetch_objects_with_tenant(client: weaviate.Client):
     tenant2 = collection.with_tenant("Tenant2")
 
     tenant1.data.insert({"name": "some name"})
-    ret = tenant1.query.fetch_objects()
-    assert len(ret.objects) == 1
-    assert ret.objects[0].properties["name"] == "some name"
+    objects = tenant1.query.fetch_objects()
+    assert len(objects) == 1
+    assert objects[0].properties["name"] == "some name"
 
-    ret = tenant2.query.fetch_objects()
-    assert len(ret.objects) == 0
+    objects = tenant2.query.fetch_objects()
+    assert len(objects) == 0
 
     tenant2.data.insert({"name": "some other name"})
-    ret = tenant2.query.fetch_objects()
-    assert len(ret.objects) == 1
-    assert ret.objects[0].properties["name"] == "some other name"
+    objects = tenant2.query.fetch_objects()
+    assert len(objects) == 1
+    assert objects[0].properties["name"] == "some other name"
 
     client.collection.delete("TestTenantGetWithTenant")
 
@@ -959,7 +959,7 @@ def test_empty_search_returns_everything(client: weaviate.Client):
 
     collection.data.insert(properties={"name": "word"})
 
-    objects = collection.query.bm25(query="word").objects
+    objects = collection.query.bm25(query="word")
     assert "name" in objects[0].properties
     assert objects[0].properties["name"] == "word"
     assert objects[0].metadata.uuid is not None
@@ -1085,7 +1085,7 @@ def test_return_list_properties(client: weaviate.Client):
         "uuids": [uuid.uuid4(), uuid.uuid4()],
     }
     collection.data.insert(properties=data)
-    objects = collection.query.fetch_objects().objects
+    objects = collection.query.fetch_objects()
     assert len(objects) == 1
 
     # remove dates because of problems comparing dates
@@ -1135,7 +1135,7 @@ def test_near_text(
         move_away=Move(force=0.5, concepts=concepts),
         return_metadata=MetadataQuery(uuid=True),
         return_properties=["value"],
-    ).objects
+    )
 
     assert len(objs) == 4
 
@@ -1173,7 +1173,7 @@ def test_near_text_group_by(client: weaviate.Client):
         ]
     )
 
-    ret = collection.query.near_text(
+    ret = collection.query_group_by.near_text(
         query="cake",
         group_by=GroupBy(prop="value", number_of_groups=2, objects_per_group=100),
         return_metadata=MetadataQuery(uuid=True),
@@ -1205,18 +1205,18 @@ def test_near_text_limit(client: weaviate.Client):
         ]
     )
 
-    ret = collection.query.near_text(
+    objects = collection.query.near_text(
         query="cake",
         limit=2,
         return_metadata=MetadataQuery(uuid=True),
         return_properties=["value"],
     )
 
-    assert len(ret.objects) == 2
-    assert ret.objects[0].metadata.uuid == batch_return.uuids[2]
-    assert ret.objects[0].properties["value"] == "apple cake"
-    assert ret.objects[1].metadata.uuid == batch_return.uuids[3]
-    assert ret.objects[1].properties["value"] == "cake"
+    assert len(objects) == 2
+    assert objects[0].metadata.uuid == batch_return.uuids[2]
+    assert objects[0].properties["value"] == "apple cake"
+    assert objects[1].metadata.uuid == batch_return.uuids[3]
+    assert objects[1].properties["value"] == "cake"
 
 
 @pytest.mark.parametrize(
@@ -1252,7 +1252,7 @@ def test_near_image(
     collection.data.insert(properties={"imageProp": WEAVIATE_LOGO_NEW_ENCODED})
 
     image = image_maker()
-    objects = collection.query.near_image(image, distance=distance, certainty=certainty).objects
+    objects = collection.query.near_image(image, distance=distance, certainty=certainty)
 
     if isinstance(image, io.BufferedReader):
         image.close()
@@ -1283,7 +1283,7 @@ def test_return_properties_with_typed_dict(client: weaviate.Client, which_case: 
         class DataModel(TypedDict):
             int_: int
 
-        objects = collection.query.fetch_objects(return_properties=DataModel).objects
+        objects = collection.query.fetch_objects(return_properties=DataModel)
         assert len(objects) == 1
         assert objects[0].properties == {"int_": 1}
     elif which_case == 1:
@@ -1291,7 +1291,7 @@ def test_return_properties_with_typed_dict(client: weaviate.Client, which_case: 
         class DataModel(TypedDict):
             ints: List[int]
 
-        objects = collection.query.fetch_objects(return_properties=DataModel).objects
+        objects = collection.query.fetch_objects(return_properties=DataModel)
         assert len(objects) == 1
         assert objects[0].properties == {"ints": [1, 2, 3]}
     elif which_case == 2:
@@ -1300,7 +1300,7 @@ def test_return_properties_with_typed_dict(client: weaviate.Client, which_case: 
             int_: int
             ints: List[int]
 
-        objects = collection.query.fetch_objects(return_properties=DataModel).objects
+        objects = collection.query.fetch_objects(return_properties=DataModel)
         assert len(objects) == 1
         assert objects[0].properties == data
     elif which_case == 3:
@@ -1396,7 +1396,7 @@ def test_sort(client: weaviate.Client, sort: Union[Sort, List[Sort]], expected: 
         collection.data.insert(properties={"name": "C", "age": 22}),
     ]
 
-    objects = collection.query.fetch_objects(sort=sort).objects
+    objects = collection.query.fetch_objects(sort=sort)
     assert len(objects) == len(expected)
 
     expected_uuids = [uuids_from[result] for result in expected]
@@ -1426,7 +1426,7 @@ def test_optional_ref_returns(client: weaviate.Client):
     )
     collection.data.insert(properties={"ref": ReferenceFactory.to(uuid_to1)})
 
-    objects = collection.query.fetch_objects(return_properties=[LinkTo(link_on="ref")]).objects
+    objects = collection.query.fetch_objects(return_properties=[LinkTo(link_on="ref")])
 
     assert objects[0].properties["ref"].objects[0].properties["text"] == "ref text"
     assert objects[0].properties["ref"].objects[0].metadata.uuid is not None

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -64,7 +64,7 @@ def test_filters_text(client: weaviate.Client, weaviate_filter: _FilterValue, re
         collection.data.insert({"name": "Mountain"}),
     ]
 
-    objects = collection.query.fetch_objects(filters=weaviate_filter).objects
+    objects = collection.query.fetch_objects(filters=weaviate_filter)
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -113,7 +113,7 @@ def test_filters_nested(
 
     objects = collection.query.fetch_objects(
         filters=weaviate_filter, return_metadata=MetadataQuery(uuid=True)
-    ).objects
+    )
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -134,9 +134,7 @@ def test_length_filter(client: weaviate.Client):
         collection.data.insert({"field": "three"}),
         collection.data.insert({"field": "four"}),
     ]
-    objects = collection.query.fetch_objects(
-        filters=Filter(path="field", length=True).equal(3)
-    ).objects
+    objects = collection.query.fetch_objects(filters=Filter(path="field", length=True).equal(3))
 
     results = [0, 1]
     assert len(objects) == len(results)
@@ -169,7 +167,7 @@ def test_filters_comparison(
         collection.data.insert({"number": None}),
     ]
 
-    objects = collection.query.fetch_objects(filters=weaviate_filter).objects
+    objects = collection.query.fetch_objects(filters=weaviate_filter)
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -302,7 +300,7 @@ def test_filters_contains(
 
     objects = collection.query.fetch_objects(
         filters=weaviate_filter, return_metadata=MetadataQuery(uuid=True)
-    ).objects
+    )
     assert len(objects) == len(results)
 
     uuids = [uuids[result] for result in results]
@@ -348,7 +346,7 @@ def test_ref_filters(client: weaviate.Client, weaviate_filter: _FilterValue, res
 
     objects = from_collection.query.fetch_objects(
         filters=weaviate_filter, return_metadata=MetadataQuery(uuid=True)
-    ).objects
+    )
     assert len(objects) == len(results)
 
     uuids = [uuids_from[result] for result in results]
@@ -409,13 +407,13 @@ def test_ref_filters_multi_target(client: weaviate.Client):
 
     objects = from_collection.query.fetch_objects(
         filters=Filter(path=["ref", target, "int"]).greater_than(3)
-    ).objects
+    )
     assert len(objects) == 1
     assert objects[0].properties["name"] == "second"
 
     objects = from_collection.query.fetch_objects(
         filters=Filter(path=["ref", source, "name"]).equal("first")
-    ).objects
+    )
     assert len(objects) == 1
     assert objects[0].properties["name"] == "third"
 
@@ -747,11 +745,11 @@ def test_delete_many_simple(
         vectorizer_config=ConfigFactory.Vectorizer.none(),
     )
     collection.data.insert_many(objects)
-    assert len(collection.query.fetch_objects().objects) == len(objects)
+    assert len(collection.query.fetch_objects()) == len(objects)
 
     collection.data.delete_many(where=where)
-    ret = collection.query.fetch_objects()
-    assert len(ret.objects) == expected_len
+    objects = collection.query.fetch_objects()
+    assert len(objects) == expected_len
 
 
 def test_delete_many_and(client: weaviate.Client):
@@ -770,17 +768,17 @@ def test_delete_many_and(client: weaviate.Client):
             DataObject(properties={"age": 10, "name": "Tommy"}, uuid=uuid.uuid4()),
         ]
     )
-    ret = collection.query.fetch_objects()
-    assert len(ret.objects) == 2
+    objects = collection.query.fetch_objects()
+    assert len(objects) == 2
 
     collection.data.delete_many(
         where=Filter(path="age").equal(10) & Filter(path="name").equal("Timmy")
     )
 
-    ret = collection.query.fetch_objects()
-    assert len(ret.objects) == 1
-    assert ret.objects[0].properties["age"] == 10
-    assert ret.objects[0].properties["name"] == "Tommy"
+    objects = collection.query.fetch_objects()
+    assert len(objects) == 1
+    assert objects[0].properties["age"] == 10
+    assert objects[0].properties["name"] == "Tommy"
 
 
 def test_delete_many_or(client: weaviate.Client):
@@ -800,14 +798,14 @@ def test_delete_many_or(client: weaviate.Client):
             DataObject(properties={"age": 30, "name": "Timothy"}, uuid=uuid.uuid4()),
         ]
     )
-    ret = collection.query.fetch_objects()
-    assert len(ret.objects) == 3
+    objects = collection.query.fetch_objects()
+    assert len(objects) == 3
 
     collection.data.delete_many(where=Filter(path="age").equal(10) | Filter(path="age").equal(30))
-    ret = collection.query.fetch_objects()
-    assert len(ret.objects) == 1
-    assert ret.objects[0].properties["age"] == 20
-    assert ret.objects[0].properties["name"] == "Tim"
+    objects = collection.query.fetch_objects()
+    assert len(objects) == 1
+    assert objects[0].properties["age"] == 20
+    assert objects[0].properties["name"] == "Tim"
 
 
 def test_delete_many_return(client: weaviate.Client):

--- a/integration/test_collection_multi_node.py
+++ b/integration/test_collection_multi_node.py
@@ -43,8 +43,6 @@ def test_consistency_on_multinode(client: weaviate.Client, level: ConsistencyLev
     )
     assert not ret.has_errors
 
-    objects = collection.query.fetch_objects(
-        return_metadata=MetadataQuery(is_consistent=True)
-    ).objects
+    objects = collection.query.fetch_objects(return_metadata=MetadataQuery(is_consistent=True))
     for obj in objects:
         assert obj.metadata.is_consistent

--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -425,6 +425,6 @@ def test_openai_batch_upload(client: weaviate.Client):
     )
     assert not ret.has_errors
 
-    objects = collection.query.fetch_objects(return_metadata=MetadataQuery(vector=True)).objects
+    objects = collection.query.fetch_objects(return_metadata=MetadataQuery(vector=True))
     assert objects[0].metadata.vector is not None
     assert len(objects[0].metadata.vector) > 0

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -385,7 +385,7 @@ def test_references_batch(client: weaviate.Client):
             "num",
             LinkTo(link_on="ref"),
         ],
-    ).objects
+    )
 
     for obj in objects:
         assert obj.properties["num"] == obj.properties["ref"].objects[0].properties["num"]

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -87,7 +87,7 @@ def test_mono_references_grpc(client: weaviate.Client):
     uuid_A1 = A.data.insert(properties={"Name": "A1"})
     uuid_A2 = A.data.insert(properties={"Name": "A2"})
 
-    objects = A.query.bm25(query="A1", return_properties="name").objects
+    objects = A.query.bm25(query="A1", return_properties="name")
     assert objects[0].properties["name"] == "A1"
 
     B = client.collection.create(
@@ -109,7 +109,7 @@ def test_mono_references_grpc(client: weaviate.Client):
             link_on="ref",
             return_properties=["name"],
         ),
-    ).objects
+    )
     assert objects[0].properties["ref"].objects[0].properties["name"] == "A1"
     assert objects[0].properties["ref"].objects[1].properties["name"] == "A2"
 
@@ -122,7 +122,7 @@ def test_mono_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True),
             )
         ],
-    ).objects
+    )
     assert objects[0].properties["ref"].objects[0].properties["name"] == "A1"
     assert objects[0].properties["ref"].objects[0].metadata.uuid == uuid_A1
     assert objects[0].properties["ref"].objects[1].properties["name"] == "A2"
@@ -155,7 +155,7 @@ def test_mono_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True, last_update_time_unix=True),
             ),
         ],
-    ).objects
+    )
     assert objects[0].properties["name"] == "find me"
     assert objects[0].properties["ref"].objects[0].properties["name"] == "B"
     assert (
@@ -223,13 +223,9 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.Client):
     C = client.collection.get("CTypedDicts", CProps)
     C.data.insert(properties=CProps(name="find me", ref=ReferenceFactory[BProps].to(uuids=uuid_B)))
 
-    objects = (
-        client.collection.get("CTypedDicts")
-        .query.bm25(
-            query="find",
-            return_properties=CProps,
-        )
-        .objects
+    objects = client.collection.get("CTypedDicts").query.bm25(
+        query="find",
+        return_properties=CProps,
     )
     assert (
         objects[0].properties["name"] == "find me"
@@ -313,7 +309,7 @@ def test_multi_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True, last_update_time_unix=True),
             ),
         ],
-    ).objects
+    )
     assert objects[0].properties["name"] == "first"
     assert len(objects[0].properties["ref"].objects) == 1
     assert objects[0].properties["ref"].objects[0].properties["name"] == "A"
@@ -331,7 +327,7 @@ def test_multi_references_grpc(client: weaviate.Client):
                 return_metadata=MetadataQuery(uuid=True, last_update_time_unix=True),
             ),
         ],
-    ).objects
+    )
     assert objects[0].properties["name"] == "second"
     assert len(objects[0].properties["ref"].objects) == 1
     assert objects[0].properties["ref"].objects[0].properties["name"] == "B"

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -57,11 +57,6 @@ class _GenerativeReturn(Generic[P]):
 
 
 @dataclass
-class _QueryReturn(Generic[P]):
-    objects: List[_Object[P]]
-
-
-@dataclass
 class _GroupByResult(Generic[P]):
     name: str
     min_distance: float

--- a/weaviate/collection/collection.py
+++ b/weaviate/collection/collection.py
@@ -22,7 +22,7 @@ from weaviate.collection.classes.types import Properties, TProperties, _check_da
 from weaviate.collection.collection_base import CollectionBase, CollectionObjectBase
 from weaviate.collection.config import _ConfigCollection
 from weaviate.collection.data import _DataCollection
-from weaviate.collection.grpc import _GenerateCollection, _QueryCollection
+from weaviate.collection.grpc import _GenerateCollection, _GroupByCollection, _QueryCollection
 from weaviate.collection.object_iterator import _ObjectIterator
 from weaviate.collection.tenants import _Tenants
 from weaviate.connect import Connection
@@ -45,6 +45,7 @@ class CollectionObject(CollectionObjectBase, Generic[TProperties]):
         self.config = _ConfigCollection(self._connection, name)
         self.data = _DataCollection[TProperties](connection, name, consistency_level, tenant, type_)
         self.generate = _GenerateCollection(connection, name, consistency_level, tenant)
+        self.query_group_by = _GroupByCollection(connection, name, consistency_level, tenant)
         self.query = _QueryCollection[TProperties](
             connection, name, self.data, consistency_level, tenant
         )

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -29,12 +29,36 @@ from weaviate.collection.queries.base import _Grpc
 from weaviate.collection.queries.bm25 import _BM25Generate, _BM25Query
 from weaviate.collection.queries.fetch_objects import _FetchObjectsGenerate, _FetchObjectsQuery
 from weaviate.collection.queries.hybrid import _HybridGenerate, _HybridQuery
-from weaviate.collection.queries.near_audio import _NearAudioGenerate, _NearAudioQuery
-from weaviate.collection.queries.near_image import _NearImageGenerate, _NearImageQuery
-from weaviate.collection.queries.near_object import _NearObjectGenerate, _NearObjectQuery
-from weaviate.collection.queries.near_text import _NearTextGenerate, _NearTextQuery
-from weaviate.collection.queries.near_vector import _NearVectorGenerate, _NearVectorQuery
-from weaviate.collection.queries.near_video import _NearVideoGenerate, _NearVideoQuery
+from weaviate.collection.queries.near_audio import (
+    _NearAudioGenerate,
+    _NearAudioGroupBy,
+    _NearAudioQuery,
+)
+from weaviate.collection.queries.near_image import (
+    _NearImageGenerate,
+    _NearImageGroupBy,
+    _NearImageQuery,
+)
+from weaviate.collection.queries.near_object import (
+    _NearObjectGenerate,
+    _NearObjectGroupBy,
+    _NearObjectQuery,
+)
+from weaviate.collection.queries.near_text import (
+    _NearTextGenerate,
+    _NearTextGroupBy,
+    _NearTextQuery,
+)
+from weaviate.collection.queries.near_vector import (
+    _NearVectorGenerate,
+    _NearVectorGroupBy,
+    _NearVectorQuery,
+)
+from weaviate.collection.queries.near_video import (
+    _NearVideoGenerate,
+    _NearVideoGroupBy,
+    _NearVideoQuery,
+)
 
 from weaviate.connect import Connection
 from weaviate.types import UUID
@@ -84,6 +108,17 @@ class _GenerateCollection(
     _NearTextGenerate,
     _NearVectorGenerate,
     _NearVideoGenerate,
+):
+    pass
+
+
+class _GroupByCollection(
+    _NearAudioGroupBy,
+    _NearImageGroupBy,
+    _NearObjectGroupBy,
+    _NearTextGroupBy,
+    _NearVectorGroupBy,
+    _NearVideoGroupBy,
 ):
     pass
 

--- a/weaviate/collection/object_iterator.py
+++ b/weaviate/collection/object_iterator.py
@@ -2,7 +2,7 @@ from typing import Generic, Iterable, Iterator, List, Optional, Type, Union
 from uuid import UUID
 
 from weaviate.collection.classes.grpc import MetadataQuery, PROPERTIES
-from weaviate.collection.classes.internal import _Object, _QueryReturn
+from weaviate.collection.classes.internal import _Object
 from weaviate.collection.classes.types import Properties, TProperties
 from weaviate.collection.grpc import _QueryCollection
 
@@ -37,13 +37,13 @@ class _ObjectIterator(Generic[Properties, TProperties], Iterable[_Object[Propert
 
     def __next__(self) -> _Object[Properties]:
         if len(self.__iter_object_cache) == 0:
-            ret: _QueryReturn[Properties] = self.__query.fetch_objects(
+            objects: List[_Object[Properties]] = self.__query.fetch_objects(
                 limit=ITERATOR_CACHE_SIZE,
                 after=self.__iter_object_last_uuid,
                 return_metadata=self.__meta,
                 return_properties=self.__props,
             )
-            self.__iter_object_cache = ret.objects
+            self.__iter_object_cache = objects
             if len(self.__iter_object_cache) == 0:
                 raise StopIteration
 

--- a/weaviate/collection/queries/base.py
+++ b/weaviate/collection/queries/base.py
@@ -5,10 +5,11 @@ import sys
 from typing import (
     Any,
     Dict,
+    List,
     Optional,
-    Union,
     Tuple,
     Type,
+    Union,
     cast,
 )
 from typing_extensions import is_typeddict
@@ -34,7 +35,6 @@ from weaviate.collection.classes.internal import (
     _extract_property_type_from_reference,
     _extract_properties_from_data_model,
     _GenerativeReturn,
-    _QueryReturn,
     _GroupByResult,
     _GroupByReturn,
 )
@@ -161,9 +161,8 @@ class _Grpc:
         self,
         res: SearchResponse,
         type_: Optional[Type[Properties]],
-    ) -> _QueryReturn[Properties]:
-        objects = [self.__result_to_object(obj, type_=type_) for obj in res.results]
-        return _QueryReturn[Properties](objects=objects)
+    ) -> List[_Object[Properties]]:
+        return [self.__result_to_object(obj, type_=type_) for obj in res.results]
 
     def _result_to_generative_return(
         self,

--- a/weaviate/collection/queries/bm25.py
+++ b/weaviate/collection/queries/bm25.py
@@ -12,7 +12,7 @@ from weaviate.collection.classes.grpc import (
     MetadataQuery,
     PROPERTIES,
 )
-from weaviate.collection.classes.internal import _GenerativeReturn, _QueryReturn, _Generative
+from weaviate.collection.classes.internal import _GenerativeReturn, _Object, _Generative
 from weaviate.collection.classes.types import (
     Properties,
 )
@@ -29,7 +29,7 @@ class _BM25Query(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().bm25(
             query=query,

--- a/weaviate/collection/queries/fetch_objects.py
+++ b/weaviate/collection/queries/fetch_objects.py
@@ -13,7 +13,7 @@ from weaviate.collection.classes.grpc import (
     PROPERTIES,
     Sort,
 )
-from weaviate.collection.classes.internal import _GenerativeReturn, _QueryReturn, _Generative
+from weaviate.collection.classes.internal import _GenerativeReturn, _Object, _Generative
 from weaviate.collection.classes.types import (
     Properties,
 )
@@ -31,7 +31,7 @@ class _FetchObjectsQuery(_Grpc):
         sort: Optional[Union[Sort, List[Sort]]] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().get(
             limit=limit,

--- a/weaviate/collection/queries/hybrid.py
+++ b/weaviate/collection/queries/hybrid.py
@@ -11,7 +11,7 @@ from weaviate.collection.classes.filters import (
 from weaviate.collection.classes.grpc import MetadataQuery, PROPERTIES, HybridFusion
 from weaviate.collection.classes.internal import (
     _GenerativeReturn,
-    _QueryReturn,
+    _Object,
     _Generative,
 )
 from weaviate.collection.classes.types import (
@@ -33,7 +33,7 @@ class _HybridQuery(_Grpc):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().hybrid(
             query=query,

--- a/weaviate/collection/queries/near_audio.py
+++ b/weaviate/collection/queries/near_audio.py
@@ -1,6 +1,6 @@
 from io import BufferedReader
 from pathlib import Path
-from typing import List, Literal, Optional, Type, Union, overload
+from typing import List, Optional, Type, Union
 
 from weaviate.collection.classes.filters import (
     _Filters,
@@ -11,11 +11,11 @@ from weaviate.collection.classes.grpc import (
     GroupBy,
 )
 from weaviate.collection.classes.internal import (
-    _QueryReturn,
     _Generative,
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
+    _Object,
 )
 from weaviate.collection.classes.types import (
     Properties,
@@ -24,7 +24,6 @@ from weaviate.collection.queries.base import _Grpc
 
 
 class _NearAudioQuery(_Grpc):
-    @overload
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
@@ -33,56 +32,21 @@ class _NearAudioQuery(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def near_audio(
-        self,
-        near_audio: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        group_by: GroupBy,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GroupByReturn[Properties]:
-        ...
-
-    def near_audio(
-        self,
-        near_audio: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        group_by: Optional[GroupBy] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_audio(
             audio=self._parse_media(near_audio),
             certainty=certainty,
             distance=distance,
             filters=filters,
-            group_by=_GroupBy.from_input(group_by),
             limit=limit,
             autocut=auto_limit,
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if group_by is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_groupby_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
 
 
 class _NearAudioGenerate(_Grpc):
@@ -117,3 +81,31 @@ class _NearAudioGenerate(_Grpc):
             return_properties=ret_properties,
         )
         return self._result_to_generative_return(res, ret_type)
+
+
+class _NearAudioGroupBy(_Grpc):
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        group_by: GroupBy,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GroupByReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_audio(
+            audio=self._parse_media(near_audio),
+            certainty=certainty,
+            distance=distance,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
+            limit=limit,
+            autocut=auto_limit,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_groupby_return(res, ret_type)

--- a/weaviate/collection/queries/near_image.py
+++ b/weaviate/collection/queries/near_image.py
@@ -1,6 +1,6 @@
 from io import BufferedReader
 from pathlib import Path
-from typing import List, Literal, Optional, Type, Union, overload
+from typing import List, Optional, Type, Union
 
 from weaviate.collection.classes.filters import (
     _Filters,
@@ -11,7 +11,7 @@ from weaviate.collection.classes.internal import (
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
-    _QueryReturn,
+    _Object,
 )
 from weaviate.collection.classes.types import (
     Properties,
@@ -20,7 +20,6 @@ from weaviate.collection.queries.base import _Grpc
 
 
 class _NearImageQuery(_Grpc):
-    @overload
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
@@ -29,56 +28,21 @@ class _NearImageQuery(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def near_image(
-        self,
-        near_image: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        group_by: GroupBy,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GroupByReturn[Properties]:
-        ...
-
-    def near_image(
-        self,
-        near_image: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        group_by: Optional[GroupBy] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_image(
             image=self._parse_media(near_image),
             certainty=certainty,
             distance=distance,
             filters=filters,
-            group_by=_GroupBy.from_input(group_by),
             limit=limit,
             autocut=auto_limit,
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if group_by is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_groupby_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
 
 
 class _NearImageGenerate(_Grpc):
@@ -113,3 +77,31 @@ class _NearImageGenerate(_Grpc):
             return_properties=ret_properties,
         )
         return self._result_to_generative_return(res, ret_type)
+
+
+class _NearImageGroupBy(_Grpc):
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        group_by: GroupBy,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GroupByReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_image(
+            image=self._parse_media(near_image),
+            certainty=certainty,
+            distance=distance,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
+            limit=limit,
+            autocut=auto_limit,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_groupby_return(res, ret_type)

--- a/weaviate/collection/queries/near_object.py
+++ b/weaviate/collection/queries/near_object.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional, Type, Union, overload
+from typing import List, Optional, Type, Union
 
 from weaviate.collection.classes.filters import (
     _Filters,
@@ -13,7 +13,7 @@ from weaviate.collection.classes.internal import (
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
-    _QueryReturn,
+    _Object,
 )
 from weaviate.collection.classes.types import (
     Properties,
@@ -23,7 +23,6 @@ from weaviate.types import UUID
 
 
 class _NearObjectQuery(_Grpc):
-    @overload
     def near_object(
         self,
         near_object: UUID,
@@ -32,40 +31,9 @@ class _NearObjectQuery(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def near_object(
-        self,
-        near_object: UUID,
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        group_by: GroupBy,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GroupByReturn[Properties]:
-        ...
-
-    def near_object(
-        self,
-        near_object: UUID,
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        group_by: Optional[GroupBy] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_object(
             near_object=near_object,
@@ -74,14 +42,10 @@ class _NearObjectQuery(_Grpc):
             limit=limit,
             autocut=auto_limit,
             filters=filters,
-            group_by=_GroupBy.from_input(group_by),
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if group_by is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_groupby_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
 
 
 class _NearObjectGenerate(_Grpc):
@@ -116,3 +80,31 @@ class _NearObjectGenerate(_Grpc):
             return_properties=ret_properties,
         )
         return self._result_to_generative_return(res, ret_type)
+
+
+class _NearObjectGroupBy(_Grpc):
+    def near_object(
+        self,
+        near_object: UUID,
+        group_by: GroupBy,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GroupByReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_object(
+            near_object=near_object,
+            certainty=certainty,
+            distance=distance,
+            limit=limit,
+            autocut=auto_limit,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_groupby_return(res, ret_type)

--- a/weaviate/collection/queries/near_text.py
+++ b/weaviate/collection/queries/near_text.py
@@ -1,10 +1,8 @@
 from typing import (
     List,
-    Literal,
     Optional,
     Union,
     Type,
-    overload,
 )
 
 from weaviate.collection.classes.filters import (
@@ -21,7 +19,7 @@ from weaviate.collection.classes.internal import (
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
-    _QueryReturn,
+    _Object,
 )
 from weaviate.collection.classes.types import (
     Properties,
@@ -30,7 +28,6 @@ from weaviate.collection.queries.base import _Grpc
 
 
 class _NearTextQuery(_Grpc):
-    @overload
     def near_text(
         self,
         query: Union[List[str], str],
@@ -41,44 +38,9 @@ class _NearTextQuery(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def near_text(
-        self,
-        query: Union[List[str], str],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        move_to: Optional[Move] = None,
-        move_away: Optional[Move] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        group_by: GroupBy,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GroupByReturn[Properties]:
-        ...
-
-    def near_text(
-        self,
-        query: Union[List[str], str],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        move_to: Optional[Move] = None,
-        move_away: Optional[Move] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        group_by: Optional[GroupBy] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_text(
             near_text=query,
@@ -89,14 +51,10 @@ class _NearTextQuery(_Grpc):
             limit=limit,
             autocut=auto_limit,
             filters=filters,
-            group_by=_GroupBy.from_input(group_by),
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if group_by is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_groupby_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
 
 
 class _NearTextGenerate(_Grpc):
@@ -135,3 +93,35 @@ class _NearTextGenerate(_Grpc):
             return_properties=ret_properties,
         )
         return self._result_to_generative_return(res, ret_type)
+
+
+class _NearTextGroupBy(_Grpc):
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        group_by: GroupBy,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GroupByReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_text(
+            near_text=query,
+            certainty=certainty,
+            distance=distance,
+            move_to=move_to,
+            move_away=move_away,
+            limit=limit,
+            autocut=auto_limit,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_groupby_return(res, ret_type)

--- a/weaviate/collection/queries/near_vector.py
+++ b/weaviate/collection/queries/near_vector.py
@@ -1,10 +1,8 @@
 from typing import (
     List,
-    Literal,
     Optional,
     Type,
     Union,
-    overload,
 )
 
 from weaviate.collection.classes.filters import (
@@ -20,7 +18,7 @@ from weaviate.collection.classes.internal import (
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
-    _QueryReturn,
+    _Object,
 )
 from weaviate.collection.classes.types import (
     Properties,
@@ -29,7 +27,6 @@ from weaviate.collection.queries.base import _Grpc
 
 
 class _NearVectorQuery(_Grpc):
-    @overload
     def near_vector(
         self,
         near_vector: List[float],
@@ -38,40 +35,9 @@ class _NearVectorQuery(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def near_vector(
-        self,
-        near_vector: List[float],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        group_by: GroupBy,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GroupByReturn[Properties]:
-        ...
-
-    def near_vector(
-        self,
-        near_vector: List[float],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        group_by: Optional[GroupBy] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_vector(
             near_vector=near_vector,
@@ -80,14 +46,10 @@ class _NearVectorQuery(_Grpc):
             limit=limit,
             autocut=auto_limit,
             filters=filters,
-            group_by=_GroupBy.from_input(group_by),
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if group_by is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_groupby_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
 
 
 class _NearVectorGenerate(_Grpc):
@@ -122,3 +84,31 @@ class _NearVectorGenerate(_Grpc):
             return_properties=ret_properties,
         )
         return self._result_to_generative_return(res, ret_type)
+
+
+class _NearVectorGroupBy(_Grpc):
+    def near_vector(
+        self,
+        near_vector: List[float],
+        group_by: GroupBy,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GroupByReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_vector(
+            near_vector=near_vector,
+            certainty=certainty,
+            distance=distance,
+            limit=limit,
+            autocut=auto_limit,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_groupby_return(res, ret_type)

--- a/weaviate/collection/queries/near_video.py
+++ b/weaviate/collection/queries/near_video.py
@@ -2,11 +2,9 @@ from io import BufferedReader
 from pathlib import Path
 from typing import (
     List,
-    Literal,
     Optional,
     Type,
     Union,
-    overload,
 )
 
 from weaviate.collection.classes.filters import (
@@ -22,7 +20,7 @@ from weaviate.collection.classes.internal import (
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
-    _QueryReturn,
+    _Object,
 )
 from weaviate.collection.classes.types import (
     Properties,
@@ -31,7 +29,6 @@ from weaviate.collection.queries.base import _Grpc
 
 
 class _NearVideoQuery(_Grpc):
-    @overload
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
@@ -40,56 +37,21 @@ class _NearVideoQuery(_Grpc):
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Literal[None] = None,
         return_metadata: Optional[MetadataQuery] = None,
         return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _QueryReturn[Properties]:
-        ...
-
-    @overload
-    def near_video(
-        self,
-        near_video: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        *,
-        group_by: GroupBy,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> _GroupByReturn[Properties]:
-        ...
-
-    def near_video(
-        self,
-        near_video: Union[str, Path, BufferedReader],
-        certainty: Optional[float] = None,
-        distance: Optional[float] = None,
-        limit: Optional[int] = None,
-        auto_limit: Optional[int] = None,
-        filters: Optional[_Filters] = None,
-        group_by: Optional[GroupBy] = None,
-        return_metadata: Optional[MetadataQuery] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
-    ) -> Union[_GroupByReturn[Properties], _QueryReturn[Properties]]:
+    ) -> List[_Object[Properties]]:
         ret_properties, ret_type = self._determine_generic(return_properties)
         res = self._query().near_video(
             video=self._parse_media(near_video),
             certainty=certainty,
             distance=distance,
             filters=filters,
-            group_by=_GroupBy.from_input(group_by),
             limit=limit,
             autocut=auto_limit,
             return_metadata=return_metadata,
             return_properties=ret_properties,
         )
-        if group_by is None:
-            return self._result_to_query_return(res, ret_type)
-        else:
-            return self._result_to_groupby_return(res, ret_type)
+        return self._result_to_query_return(res, ret_type)
 
 
 class _NearVideoGenerate(_Grpc):
@@ -124,3 +86,31 @@ class _NearVideoGenerate(_Grpc):
             return_properties=ret_properties,
         )
         return self._result_to_generative_return(res, ret_type)
+
+
+class _NearVideoGroupBy(_Grpc):
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        group_by: GroupBy,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        return_metadata: Optional[MetadataQuery] = None,
+        return_properties: Optional[Union[PROPERTIES, Type[Properties]]] = None,
+    ) -> _GroupByReturn[Properties]:
+        ret_properties, ret_type = self._determine_generic(return_properties)
+        res = self._query().near_video(
+            video=self._parse_media(near_video),
+            certainty=certainty,
+            distance=distance,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
+            limit=limit,
+            autocut=auto_limit,
+            return_metadata=return_metadata,
+            return_properties=ret_properties,
+        )
+        return self._result_to_groupby_return(res, ret_type)


### PR DESCRIPTION
This PR splits query and groupBy queries into separate namespaces for utmost user clarity and code simplicity