### PR TITLE
Move per object generated result around

### DIFF
--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -55,7 +55,7 @@ def test_generative_search_single(client: weaviate.Client, parameter: str, answe
         single_prompt=f"is it good or bad based on {{{parameter}}}? Just answer with yes or no without punctuation"
     )
     for obj in res.objects:
-        assert obj.metadata.generative == answer
+        assert obj.generated == answer
     assert res.generated is None
 
 
@@ -200,7 +200,7 @@ def test_fetch_objects_generate_with_everything(client: weaviate.Client):
     )
     assert res.generated == "Teddy cats"
     for obj in res.objects:
-        assert obj.metadata.generative == "Yes"
+        assert obj.generated == "Yes"
 
 
 def test_bm25_generate_with_everything(client: weaviate.Client):
@@ -241,7 +241,7 @@ def test_bm25_generate_with_everything(client: weaviate.Client):
     )
     assert res.generated == "Teddy apples"
     for obj in res.objects:
-        assert obj.metadata.generative == "Yes"
+        assert obj.generated == "Yes"
 
 
 def test_hybrid_generate_with_everything(client: weaviate.Client):
@@ -282,7 +282,7 @@ def test_hybrid_generate_with_everything(client: weaviate.Client):
     )
     assert res.generated == "cats bananas"
     for obj in res.objects:
-        assert obj.metadata.generative == "No"
+        assert obj.generated == "No"
 
 
 def test_near_text_generate_with_everything(client: weaviate.Client):
@@ -322,8 +322,8 @@ def test_near_text_generate_with_everything(client: weaviate.Client):
         grouped_task="Write out the fruit in the order in which they appear in the provided list. Only write the names separated by a space",
     )
     assert res.generated == "bananas apples"
-    assert res.objects[0].metadata.generative == "No"
-    assert res.objects[1].metadata.generative == "Yes"
+    assert res.objects[0].generated == "No"
+    assert res.objects[1].generated == "Yes"
 
 
 def test_near_vector_generate_with_everything(client: weaviate.Client):
@@ -364,8 +364,8 @@ def test_near_vector_generate_with_everything(client: weaviate.Client):
         grouped_task="Write out the fruit in the order in which they appear in the provided list. Only write the names separated by a space",
     )
     assert res.generated == "apples bananas"
-    assert res.objects[0].metadata.generative == "Yes"
-    assert res.objects[1].metadata.generative == "No"
+    assert res.objects[0].generated == "Yes"
+    assert res.objects[1].generated == "No"
 
 
 def test_openapi_invalid_key():

--- a/weaviate/collection/classes/internal.py
+++ b/weaviate/collection/classes/internal.py
@@ -26,17 +26,43 @@ from weaviate_grpc import weaviate_pb2
 
 
 @dataclass
+class _MetadataResult:
+    uuid: Optional[uuid_package.UUID]
+    vector: Optional[List[float]]
+    creation_time_unix: Optional[int]
+    last_update_time_unix: Optional[int]
+    distance: Optional[float]
+    certainty: Optional[float]
+    score: Optional[float]
+    explain_score: Optional[str]
+    is_consistent: Optional[bool]
+    generative: Optional[str]
+
+    def _to_return(self) -> "_MetadataReturn":
+        return _MetadataReturn(
+            uuid=self.uuid,
+            vector=self.vector,
+            creation_time_unix=self.creation_time_unix,
+            last_update_time_unix=self.last_update_time_unix,
+            distance=self.distance,
+            certainty=self.certainty,
+            score=self.score,
+            explain_score=self.explain_score,
+            is_consistent=self.is_consistent,
+        )
+
+
+@dataclass
 class _MetadataReturn:
-    uuid: Optional[uuid_package.UUID] = None
-    vector: Optional[List[float]] = None
-    creation_time_unix: Optional[int] = None
-    last_update_time_unix: Optional[int] = None
-    distance: Optional[float] = None
-    certainty: Optional[float] = None
-    score: Optional[float] = None
-    explain_score: Optional[str] = None
-    is_consistent: Optional[bool] = None
-    generative: Optional[str] = None
+    uuid: Optional[uuid_package.UUID]
+    vector: Optional[List[float]]
+    creation_time_unix: Optional[int]
+    last_update_time_unix: Optional[int]
+    distance: Optional[float]
+    certainty: Optional[float]
+    score: Optional[float]
+    explain_score: Optional[str]
+    is_consistent: Optional[bool]
 
 
 @dataclass
@@ -51,8 +77,13 @@ class _GroupByObject(Generic[P], _Object[P]):
 
 
 @dataclass
+class _GenerativeObject(Generic[P], _Object[P]):
+    generated: Optional[str]
+
+
+@dataclass
 class _GenerativeReturn(Generic[P]):
-    objects: List[_Object[P]]
+    objects: List[_GenerativeObject[P]]
     generated: Optional[str]
 
 

--- a/weaviate/collection/grpc.py
+++ b/weaviate/collection/grpc.py
@@ -156,7 +156,7 @@ class _GrpcCollectionModel(Generic[Model], _Grpc):
                         properties=self.__parse_result(
                             prop, cast(Type[Model], referenced_property_type)
                         ),
-                        metadata=self._extract_metadata_for_object(prop.metadata),
+                        metadata=self._extract_metadata_for_object(prop.metadata)._to_return(),
                     )
                     for prop in ref_prop.properties
                 ]
@@ -169,7 +169,7 @@ class _GrpcCollectionModel(Generic[Model], _Grpc):
 
     def __result_to_object(self, res: SearchResult) -> _Object[Model]:
         properties = self.__parse_result(res.properties, self.model)
-        metadata = self._extract_metadata_for_object(res.additional_properties)
+        metadata = self._extract_metadata_for_object(res.additional_properties)._to_return()
         return _Object[Model](properties=properties, metadata=metadata)
 
     def get(


### PR DESCRIPTION
This PR moves the per object generated result from `object.metadata.generative` to the `object.generated` by introducing the `_GenerativeObject` class in a similar way to the `_GroupByObject` class and `belongs_to_group`

In the process, it removes the `generative` field from `_MetadataReturn` by introducing the internal `_MetadataResult` class to be used by the gRPC classes query hierarchy. `_MetadataReturn` is then used only when propagating internal data to the external user