### PR TITLE
Introduce `ConnectionParams` instead of `url` in `Client.__init__()`

### DIFF
--- a/integration/test_authentication.py
+++ b/integration/test_authentication.py
@@ -54,7 +54,7 @@ def is_auth_enabled(url: str):
 def test_no_auth_provided():
     """Test exception when trying to access a weaviate that requires authentication."""
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=AZURE_PORT)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert is_auth_enabled(url)
     with pytest.raises(AuthenticationFailedException):
         weaviate.Client(connection_params)
@@ -82,7 +82,7 @@ def test_authentication_client_credentials(
         pytest.skip(f"No {name} login data found.")
 
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=port)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert is_auth_enabled(url)
     client = weaviate.Client(
         connection_params,
@@ -128,7 +128,7 @@ def test_authentication_user_pw(
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=port)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert is_auth_enabled(url)
 
     pw = os.environ.get(env_variable_name)
@@ -193,7 +193,7 @@ def _get_access_token(url: str, user: str, pw: str) -> Dict[str, str]:
 def test_authentication_with_bearer_token(name: str, user: str, env_variable_name: str, port: str):
     """Test authentication using existing bearer token."""
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=port)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert is_auth_enabled(url)
     pw = os.environ.get(env_variable_name)
     if pw is None:
@@ -219,7 +219,7 @@ def test_client_with_authentication_with_anon_weaviate(recwarn):
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=ANON_PORT)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert not is_auth_enabled(url)
 
     client = weaviate.Client(
@@ -243,7 +243,7 @@ def test_bearer_token_without_refresh(recwarn):
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=WCS_PORT)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert is_auth_enabled(url)
     pw = os.environ.get("WCS_DUMMY_CI_PW")
     if pw is None:
@@ -266,7 +266,7 @@ def test_bearer_token_without_refresh(recwarn):
 
 def test_api_key():
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=WCS_PORT)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert is_auth_enabled(url)
 
     client = weaviate.Client(
@@ -277,7 +277,7 @@ def test_api_key():
 
 def test_api_key_wrong_key():
     connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=WCS_PORT)
-    url = connection_params._to_rest_url()
+    url = connection_params._rest_url
     assert is_auth_enabled(url)
 
     with pytest.raises(UnexpectedStatusCodeException) as e:

--- a/integration/test_authentication.py
+++ b/integration/test_authentication.py
@@ -14,15 +14,16 @@ from weaviate import (
     AuthClientCredentials,
     AuthClientPassword,
     AuthBearerToken,
+    ConnectionParams,
 )
 from weaviate.auth import AuthApiKey
 from weaviate.exceptions import WeaviateStartUpError, UnexpectedStatusCodeException
 
-ANON_PORT = "8080"
-AZURE_PORT = "8081"
-OKTA_PORT_CC = "8082"
-OKTA_PORT_USERS = "8083"
-WCS_PORT = "8085"
+ANON_PORT = 8080
+AZURE_PORT = 8081
+OKTA_PORT_CC = 8082
+OKTA_PORT_USERS = 8083
+WCS_PORT = 8085
 
 
 def wait_for_weaviate(url: str):
@@ -52,10 +53,11 @@ def is_auth_enabled(url: str):
 
 def test_no_auth_provided():
     """Test exception when trying to access a weaviate that requires authentication."""
-    url = "http://127.0.0.1:" + AZURE_PORT
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=AZURE_PORT)
+    url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     with pytest.raises(AuthenticationFailedException):
-        weaviate.Client(url)
+        weaviate.Client(connection_params)
 
 
 @pytest.mark.parametrize(
@@ -79,10 +81,12 @@ def test_authentication_client_credentials(
     if client_secret is None:
         pytest.skip(f"No {name} login data found.")
 
-    url = "http://127.0.0.1:" + port
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=port)
+    url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     client = weaviate.Client(
-        url, auth_client_secret=AuthClientCredentials(client_secret=client_secret, scope=scope)
+        connection_params,
+        auth_client_secret=AuthClientCredentials(client_secret=client_secret, scope=scope),
     )
     client.schema.delete_all()  # no exception
 
@@ -123,7 +127,8 @@ def test_authentication_user_pw(
     # testing for warnings can be flaky without this as there are open SSL conections
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
-    url = "http://127.0.0.1:" + port
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=port)
+    url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
 
     pw = os.environ.get(env_variable_name)
@@ -135,7 +140,7 @@ def test_authentication_user_pw(
     else:
         auth = AuthClientPassword(username=user, password=pw)
 
-    client = weaviate.Client(url, auth_client_secret=auth)
+    client = weaviate.Client(connection_params, auth_client_secret=auth)
     client.schema.delete_all()  # no exception
     if warning:
         assert len(recwarn) == 1
@@ -187,7 +192,8 @@ def _get_access_token(url: str, user: str, pw: str) -> Dict[str, str]:
 )
 def test_authentication_with_bearer_token(name: str, user: str, env_variable_name: str, port: str):
     """Test authentication using existing bearer token."""
-    url = "http://127.0.0.1:" + port
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=port)
+    url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     pw = os.environ.get(env_variable_name)
     if pw is None:
@@ -197,7 +203,7 @@ def test_authentication_with_bearer_token(name: str, user: str, env_variable_nam
     token = _get_access_token(url, user, pw)
 
     client = weaviate.Client(
-        url,
+        connection_params,
         auth_client_secret=AuthBearerToken(
             access_token=token["access_token"],
             expires_in=int(token["expires_in"]),
@@ -212,11 +218,12 @@ def test_client_with_authentication_with_anon_weaviate(recwarn):
     # testing for warnings can be flaky without this as there are open SSL conections
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
-    url = "http://127.0.0.1:" + ANON_PORT
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=ANON_PORT)
+    url = connection_params._to_rest_url()
     assert not is_auth_enabled(url)
 
     client = weaviate.Client(
-        url,
+        connection_params,
         auth_client_secret=AuthClientPassword(username="someUser", password="SomePw"),
     )
 
@@ -235,7 +242,8 @@ def test_bearer_token_without_refresh(recwarn):
     # testing for warnings can be flaky without this as there are open SSL conections
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
-    url = "http://127.0.0.1:" + WCS_PORT
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=WCS_PORT)
+    url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     pw = os.environ.get("WCS_DUMMY_CI_PW")
     if pw is None:
@@ -243,7 +251,7 @@ def test_bearer_token_without_refresh(recwarn):
 
     token = _get_access_token(url, "ms_2d0e007e7136de11d5f29fce7a53dae219a51458@existiert.net", pw)
     client = weaviate.Client(
-        url,
+        connection_params,
         auth_client_secret=AuthBearerToken(
             access_token=token["access_token"],
         ),
@@ -257,17 +265,21 @@ def test_bearer_token_without_refresh(recwarn):
 
 
 def test_api_key():
-    url = "http://127.0.0.1:" + WCS_PORT
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=WCS_PORT)
+    url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
 
-    client = weaviate.Client(url, auth_client_secret=AuthApiKey(api_key="my-secret-key"))
+    client = weaviate.Client(
+        connection_params, auth_client_secret=AuthApiKey(api_key="my-secret-key")
+    )
     client.schema.delete_all()  # no exception, client works
 
 
 def test_api_key_wrong_key():
-    url = "http://127.0.0.1:" + WCS_PORT
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=WCS_PORT)
+    url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
 
     with pytest.raises(UnexpectedStatusCodeException) as e:
-        weaviate.Client(url, auth_client_secret=AuthApiKey(api_key="wrong_key"))
+        weaviate.Client(connection_params, auth_client_secret=AuthApiKey(api_key="wrong_key"))
         assert e.value.status_code == 401

--- a/integration/test_authentication.py
+++ b/integration/test_authentication.py
@@ -53,7 +53,7 @@ def is_auth_enabled(url: str):
 
 def test_no_auth_provided():
     """Test exception when trying to access a weaviate that requires authentication."""
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=AZURE_PORT)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=AZURE_PORT)
     url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     with pytest.raises(AuthenticationFailedException):
@@ -81,7 +81,7 @@ def test_authentication_client_credentials(
     if client_secret is None:
         pytest.skip(f"No {name} login data found.")
 
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=port)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=port)
     url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     client = weaviate.Client(
@@ -127,7 +127,7 @@ def test_authentication_user_pw(
     # testing for warnings can be flaky without this as there are open SSL conections
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=port)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=port)
     url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
 
@@ -192,7 +192,7 @@ def _get_access_token(url: str, user: str, pw: str) -> Dict[str, str]:
 )
 def test_authentication_with_bearer_token(name: str, user: str, env_variable_name: str, port: str):
     """Test authentication using existing bearer token."""
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=port)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=port)
     url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     pw = os.environ.get(env_variable_name)
@@ -218,7 +218,7 @@ def test_client_with_authentication_with_anon_weaviate(recwarn):
     # testing for warnings can be flaky without this as there are open SSL conections
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=ANON_PORT)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=ANON_PORT)
     url = connection_params._to_rest_url()
     assert not is_auth_enabled(url)
 
@@ -242,7 +242,7 @@ def test_bearer_token_without_refresh(recwarn):
     # testing for warnings can be flaky without this as there are open SSL conections
     warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=WCS_PORT)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=WCS_PORT)
     url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
     pw = os.environ.get("WCS_DUMMY_CI_PW")
@@ -265,7 +265,7 @@ def test_bearer_token_without_refresh(recwarn):
 
 
 def test_api_key():
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=WCS_PORT)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=WCS_PORT)
     url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
 
@@ -276,7 +276,7 @@ def test_api_key():
 
 
 def test_api_key_wrong_key():
-    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", rest_port=WCS_PORT)
+    connection_params = ConnectionParams(scheme="http", host="127.0.0.1", port=WCS_PORT)
     url = connection_params._to_rest_url()
     assert is_auth_enabled(url)
 

--- a/integration/test_backup.py
+++ b/integration/test_backup.py
@@ -79,7 +79,7 @@ articles = [
 
 @pytest.fixture(scope="module")
 def client():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.create(schema)
     for para in paragraphs:

--- a/integration/test_backup.py
+++ b/integration/test_backup.py
@@ -79,7 +79,8 @@ articles = [
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.create(schema)
     for para in paragraphs:
         client.data_object.create(para["properties"], "Paragraph", para["id"])

--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -50,7 +50,8 @@ class MockTensorFlow:
 
 @pytest.fixture(scope="function")
 def client():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create_class(
         {
@@ -273,7 +274,8 @@ def test_add_reference(
 
 
 def test_add_object_batch_with_tenant():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
 
     # create two classes and add 5 tenants each
@@ -347,7 +349,8 @@ def test_add_object_batch_with_tenant():
 
 
 def test_add_ref_batch_with_tenant():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
 
     # create two classes and add 5 tenants each

--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -50,7 +50,7 @@ class MockTensorFlow:
 
 @pytest.fixture(scope="function")
 def client():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create_class(
@@ -274,7 +274,7 @@ def test_add_reference(
 
 
 def test_add_object_batch_with_tenant():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
 
@@ -349,7 +349,7 @@ def test_add_object_batch_with_tenant():
 
 
 def test_add_ref_batch_with_tenant():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
 

--- a/integration/test_classification.py
+++ b/integration/test_classification.py
@@ -42,7 +42,7 @@ schema = {
 
 @pytest.fixture(scope="module")
 def client():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.create(schema)
     yield client

--- a/integration/test_classification.py
+++ b/integration/test_classification.py
@@ -42,7 +42,8 @@ schema = {
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.create(schema)
     yield client
     client.schema.delete_all()

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -26,7 +26,8 @@ def schema(class_name: str) -> Dict[str, Any]:
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     yield client
     client.schema.delete_all()

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -26,7 +26,7 @@ def schema(class_name: str) -> Dict[str, Any]:
 
 @pytest.fixture(scope="module")
 def client():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     yield client

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -60,7 +60,7 @@ DATE3 = datetime.datetime.strptime("2019-06-10", "%Y-%m-%d").replace(tzinfo=date
 @pytest.fixture(scope="module")
 def client():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+        scheme="http", host="localhost", port=8080, grpc_port=50051
     )
     client = weaviate.Client(connection_params)
     client.schema.delete_all()

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -13,7 +13,6 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from integration.constants import WEAVIATE_LOGO_OLD_ENCODED, WEAVIATE_LOGO_NEW_ENCODED
 
-from weaviate.config import Config
 from weaviate.collection.collection import CollectionObject
 from weaviate.collection.classes.config import (
     ConfigFactory,
@@ -60,9 +59,10 @@ DATE3 = datetime.datetime.strptime("2019-06-10", "%Y-%m-%d").replace(tzinfo=date
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client(
-        "http://localhost:8080", additional_config=Config(grpc_port_experimental=50051)
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
     )
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     yield client
     client.schema.delete_all()

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -20,7 +20,7 @@ from weaviate.collection.classes.config import (
 @pytest.fixture(scope="module")
 def client():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8087, grpc_port=50051
+        scheme="http", host="localhost", port=8087, grpc_port=50051
     )
     client = weaviate.Client(connection_params)
     client.schema.delete_all()

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -1,7 +1,6 @@
 import pytest as pytest
 
 import weaviate
-from weaviate import Config
 from weaviate.collection.classes.config import (
     _CollectionConfig,
     _CollectionConfigSimple,
@@ -20,9 +19,10 @@ from weaviate.collection.classes.config import (
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client(
-        "http://localhost:8087", additional_config=Config(grpc_port_experimental=50051)
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8087, grpc_port=50051
     )
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     yield client
     client.schema.delete_all()

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -5,7 +5,6 @@ from typing import List
 import pytest as pytest
 
 import weaviate
-from weaviate import Config
 from weaviate.collection.classes.config import (
     ConfigFactory,
     Property,
@@ -34,9 +33,10 @@ UUID3 = uuid.uuid4()
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client(
-        "http://localhost:8080", additional_config=Config(grpc_port_experimental=50051)
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
     )
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     yield client
     client.schema.delete_all()

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -34,7 +34,7 @@ UUID3 = uuid.uuid4()
 @pytest.fixture(scope="module")
 def client():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+        scheme="http", host="localhost", port=8080, grpc_port=50051
     )
     client = weaviate.Client(connection_params)
     client.schema.delete_all()

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 
 from pydantic_core._pydantic_core import PydanticUndefined
 
-from weaviate import Config
 from weaviate.collection.classes.grpc import MetadataQuery
 from weaviate.exceptions import WeaviateAddInvalidPropertyError
 from weaviate.types import UUIDS
@@ -35,9 +34,10 @@ class Group(BaseProperty):
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client(
-        "http://localhost:8080", additional_config=Config(grpc_port_experimental=50051)
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
     )
+    client = weaviate.Client(connection_params)
     client.collection_model.delete(Group)
     collection = client.collection_model.create(
         CollectionModelConfig[Group](model=Group, vectorizer_config=ConfigFactory.Vectorizer.none())

--- a/integration/test_collection_model.py
+++ b/integration/test_collection_model.py
@@ -35,7 +35,7 @@ class Group(BaseProperty):
 @pytest.fixture(scope="module")
 def client():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+        scheme="http", host="localhost", port=8080, grpc_port=50051
     )
     client = weaviate.Client(connection_params)
     client.collection_model.delete(Group)

--- a/integration/test_collection_multi_node.py
+++ b/integration/test_collection_multi_node.py
@@ -14,7 +14,7 @@ from weaviate.collection.classes.grpc import MetadataQuery
 @pytest.fixture(scope="module")
 def client():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8087, grpc_port=50058
+        scheme="http", host="localhost", port=8087, grpc_port=50058
     )
     client = weaviate.Client(connection_params)
     client.schema.delete_all()

--- a/integration/test_collection_multi_node.py
+++ b/integration/test_collection_multi_node.py
@@ -1,7 +1,6 @@
 import pytest
 
 import weaviate
-from weaviate import Config
 from weaviate.collection.classes.config import (
     ConfigFactory,
     Property,
@@ -14,9 +13,10 @@ from weaviate.collection.classes.grpc import MetadataQuery
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client(
-        "http://localhost:8087", additional_config=Config(grpc_port_experimental=50058)
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8087, grpc_port=50058
     )
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     yield client
     client.schema.delete_all()

--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -21,7 +21,7 @@ def client():
         pytest.skip("No OpenAI API key found.")
 
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8086, grpc_port=50057
+        scheme="http", host="localhost", port=8086, grpc_port=50057
     )  # ports with generative module
     client = weaviate.Client(
         connection_params,
@@ -371,7 +371,7 @@ def test_near_vector_generate_with_everything(client: weaviate.Client):
 
 def test_openapi_invalid_key():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8086, grpc_port=50057
+        scheme="http", host="localhost", port=8086, grpc_port=50057
     )  # ports with generative module
     local_client = weaviate.Client(
         connection_params,
@@ -392,7 +392,7 @@ def test_openapi_invalid_key():
 
 def test_openapi_no_module():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+        scheme="http", host="localhost", port=8080, grpc_port=50051
     )  # main version that does not have a generative module
     local_client = weaviate.Client(
         connection_params,

--- a/integration/test_collection_openai.py
+++ b/integration/test_collection_openai.py
@@ -4,7 +4,6 @@ from typing import List
 import pytest
 
 import weaviate
-from weaviate import Config
 from weaviate.collection.classes.config import (
     ConfigFactory,
     DataType,
@@ -21,9 +20,11 @@ def client():
     if api_key is None:
         pytest.skip("No OpenAI API key found.")
 
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8086, grpc_port=50057
+    )  # ports with generative module
     client = weaviate.Client(
-        "http://localhost:8086",
-        additional_config=Config(grpc_port_experimental=50057),  # ports with generative module
+        connection_params,
         additional_headers={"X-OpenAI-Api-Key": api_key},
     )
     client.schema.delete_all()
@@ -369,9 +370,11 @@ def test_near_vector_generate_with_everything(client: weaviate.Client):
 
 
 def test_openapi_invalid_key():
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8086, grpc_port=50057
+    )  # ports with generative module
     local_client = weaviate.Client(
-        "http://localhost:8086",
-        additional_config=Config(grpc_port_experimental=50057),
+        connection_params,
         additional_headers={"X-OpenAI-Api-Key": "IamNotValid"},
     )
 
@@ -388,9 +391,11 @@ def test_openapi_invalid_key():
 
 
 def test_openapi_no_module():
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+    )  # main version that does not have a generative module
     local_client = weaviate.Client(
-        "http://localhost:8080",  # main version that does not have a generative module
-        additional_config=Config(grpc_port_experimental=50051),
+        connection_params,
         additional_headers={"X-OpenAI-Api-Key": "doesnt matter"},
     )
 

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -30,7 +30,7 @@ from weaviate.collection.grpc import MetadataQuery
 @pytest.fixture(scope="module")
 def client():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+        scheme="http", host="localhost", port=8080, grpc_port=50051
     )
     client = weaviate.Client(connection_params)
     client.schema.delete_all()

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -15,7 +15,6 @@ else:
 
 
 import weaviate
-from weaviate import Config
 from weaviate.collection.classes.config import (
     ConfigFactory,
     Property,
@@ -30,9 +29,10 @@ from weaviate.collection.grpc import MetadataQuery
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client(
-        "http://localhost:8080", additional_config=Config(grpc_port_experimental=50051)
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
     )
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     yield client
     client.schema.delete_all()

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -82,7 +82,7 @@ def people_schema() -> str:
 
 
 def test_load_scheme(people_schema):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
@@ -96,7 +96,7 @@ def test_load_scheme(people_schema):
 
 @pytest.fixture(scope="module")
 def client(people_schema):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
@@ -108,15 +108,13 @@ def client(people_schema):
 @pytest.mark.parametrize("timeout, error", [(None, TypeError), ((5,), ValueError)])
 def test_timeout_error(timeout, error):
     with pytest.raises(error):
-        connection_params = weaviate.ConnectionParams(
-            scheme="http", host="localhost", rest_port=8080
-        )
+        connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
         weaviate.Client(connection_params, timeout_config=timeout)
 
 
 @pytest.mark.parametrize("timeout", [(5, 5), 5, 5.0, (5.0, 5.0), (5, 5.0)])
 def test_timeout(people_schema, timeout):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params, timeout_config=timeout)
     client.schema.delete_all()
     client.schema.create(people_schema)
@@ -132,7 +130,7 @@ def test_timeout(people_schema, timeout):
 
 @pytest.mark.parametrize("limit", [None, 1, 5, 20, 50])
 def test_query_get_with_limit(people_schema, limit: Optional[int]):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
@@ -151,7 +149,7 @@ def test_query_get_with_limit(people_schema, limit: Optional[int]):
 
 
 def test_query_get_with_after(people_schema):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
@@ -172,7 +170,7 @@ def test_query_get_with_after(people_schema):
 
 @pytest.mark.parametrize("offset", [None, 0, 1, 5, 20, 50])
 def test_query_get_with_offset(people_schema, offset: Optional[int]):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
@@ -227,7 +225,7 @@ def test_query_get_with_offset(people_schema, offset: Optional[int]):
 def test_query_get_with_sort(
     sort: Optional[Dict[str, Union[str, bool, List[bool], List[str]]]], expected: List[str]
 ):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(SHIP_SCHEMA)
@@ -270,7 +268,7 @@ def test_query_data(client: weaviate.Client):
 
 
 def test_create_schema():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     single_class = {
         "class": "Barbecue",
@@ -492,7 +490,7 @@ def test_add_vector_and_vectorizer(client: weaviate.Client):
 
 
 def test_beacon_refs(people_schema: dict):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
@@ -528,7 +526,7 @@ def test_beacon_refs(people_schema: dict):
 
 
 def test_beacon_refs_multiple(people_schema: dict):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create_class(
@@ -596,7 +594,7 @@ def test_beacon_refs_multiple(people_schema: dict):
 
 
 def test_beacon_refs_nested():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create_class(
@@ -684,7 +682,7 @@ def test_beacon_refs_nested():
 
 
 def test_tenants():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     tenants = [

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -82,7 +82,8 @@ def people_schema() -> str:
 
 
 def test_load_scheme(people_schema):
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
 
@@ -95,7 +96,8 @@ def test_load_scheme(people_schema):
 
 @pytest.fixture(scope="module")
 def client(people_schema):
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
 
@@ -106,12 +108,16 @@ def client(people_schema):
 @pytest.mark.parametrize("timeout, error", [(None, TypeError), ((5,), ValueError)])
 def test_timeout_error(timeout, error):
     with pytest.raises(error):
-        weaviate.Client("http://localhost:8080", timeout_config=timeout)
+        connection_params = weaviate.ConnectionParams(
+            scheme="http", host="localhost", rest_port=8080
+        )
+        weaviate.Client(connection_params, timeout_config=timeout)
 
 
 @pytest.mark.parametrize("timeout", [(5, 5), 5, 5.0, (5.0, 5.0), (5, 5.0)])
 def test_timeout(people_schema, timeout):
-    client = weaviate.Client("http://localhost:8080", timeout_config=timeout)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params, timeout_config=timeout)
     client.schema.delete_all()
     client.schema.create(people_schema)
     expected_name = "Sophie Scholl"
@@ -126,7 +132,8 @@ def test_timeout(people_schema, timeout):
 
 @pytest.mark.parametrize("limit", [None, 1, 5, 20, 50])
 def test_query_get_with_limit(people_schema, limit: Optional[int]):
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
 
@@ -144,7 +151,8 @@ def test_query_get_with_limit(people_schema, limit: Optional[int]):
 
 
 def test_query_get_with_after(people_schema):
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
 
@@ -164,7 +172,8 @@ def test_query_get_with_after(people_schema):
 
 @pytest.mark.parametrize("offset", [None, 0, 1, 5, 20, 50])
 def test_query_get_with_offset(people_schema, offset: Optional[int]):
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
 
@@ -218,7 +227,8 @@ def test_query_get_with_offset(people_schema, offset: Optional[int]):
 def test_query_get_with_sort(
     sort: Optional[Dict[str, Union[str, bool, List[bool], List[str]]]], expected: List[str]
 ):
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(SHIP_SCHEMA)
 
@@ -249,7 +259,7 @@ def test_query_get_with_sort(
     client.schema.delete_all()
 
 
-def test_query_data(client):
+def test_query_data(client: weaviate.Client):
     expected_name = "Sophie Scholl"
     client.data_object.create(
         {"name": expected_name}, "Person", "594b7827-f795-40d0-aabb-5e0553953dad"
@@ -260,7 +270,8 @@ def test_query_data(client):
 
 
 def test_create_schema():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     single_class = {
         "class": "Barbecue",
         "description": "Barbecue or BBQ where meat and vegetables get grilled",
@@ -281,7 +292,7 @@ def test_create_schema():
     client.schema.delete_class("Barbecue")
 
 
-def test_replace_and_update(client):
+def test_replace_and_update(client: weaviate.Client):
     """Test updating an object with put (replace) and patch (update)."""
     uuid = "28954264-0449-57a2-ade5-e9e08d11f51a"
     client.data_object.create({"name": "Someone"}, "Person", uuid)
@@ -296,7 +307,7 @@ def test_replace_and_update(client):
     client.data_object.delete(uuid, class_name="Person")
 
 
-def test_crud(client):
+def test_crud(client: weaviate.Client):
     chemists: List[str] = []
     _create_objects_batch(client)
     _create_objects(client, chemists)
@@ -480,8 +491,9 @@ def test_add_vector_and_vectorizer(client: weaviate.Client):
     assert object_without_vector["vector"] != [1] * 300
 
 
-def test_beacon_refs(people_schema):
-    client = weaviate.Client("http://localhost:8080")
+def test_beacon_refs(people_schema: dict):
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(people_schema)
 
@@ -515,8 +527,9 @@ def test_beacon_refs(people_schema):
     assert all("randomName" + str(i) in all_names for i in range(5))
 
 
-def test_beacon_refs_multiple(people_schema):
-    client = weaviate.Client("http://localhost:8080")
+def test_beacon_refs_multiple(people_schema: dict):
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create_class(
         {
@@ -583,7 +596,8 @@ def test_beacon_refs_multiple(people_schema):
 
 
 def test_beacon_refs_nested():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create_class(
         {
@@ -670,7 +684,8 @@ def test_beacon_refs_nested():
 
 
 def test_tenants():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     tenants = [
         Tenant(name="tenantA"),

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -96,7 +96,7 @@ def client(request):
             for _, c in enumerate(schema["classes"]):
                 c["replicationConfig"] = {"factor": 2}
 
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=port)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=port)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(schema)
@@ -532,7 +532,7 @@ def test_generative_openai(single: str, grouped: str):
     if api_key is None:
         pytest.skip("No OpenAI API key found.")
 
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8086)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8086)
     client = weaviate.Client(connection_params, additional_headers={"X-OpenAI-Api-Key": api_key})
     client.schema.delete_all()
     wine_class = {
@@ -571,7 +571,7 @@ def test_generative_openai(single: str, grouped: str):
 
 
 def test_graphql_with_tenant():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     schema_class = {

--- a/integration/test_graphql.py
+++ b/integration/test_graphql.py
@@ -96,7 +96,8 @@ def client(request):
             for _, c in enumerate(schema["classes"]):
                 c["replicationConfig"] = {"factor": 2}
 
-    client = weaviate.Client(f"http://localhost:{port}")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=port)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(schema)
     with client.batch as batch:
@@ -531,9 +532,8 @@ def test_generative_openai(single: str, grouped: str):
     if api_key is None:
         pytest.skip("No OpenAI API key found.")
 
-    client = weaviate.Client(
-        "http://127.0.0.1:8086", additional_headers={"X-OpenAI-Api-Key": api_key}
-    )
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8086)
+    client = weaviate.Client(connection_params, additional_headers={"X-OpenAI-Api-Key": api_key})
     client.schema.delete_all()
     wine_class = {
         "class": "Wine",
@@ -571,7 +571,8 @@ def test_generative_openai(single: str, grouped: str):
 
 
 def test_graphql_with_tenant():
-    client = weaviate.Client("http://127.0.0.1:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     schema_class = {
         "class": "GraphQlTenantClass",

--- a/integration/test_grcp.py
+++ b/integration/test_grcp.py
@@ -55,7 +55,7 @@ def test_grcp(
     with_limit: bool, additional_props, search: Dict[str, Any], properties, grpc_port: Optional[int]
 ):
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=grpc_port
+        scheme="http", host="localhost", port=8080, grpc_port=grpc_port
     )
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
@@ -101,7 +101,7 @@ def test_grcp(
 
 def test_additional():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+        scheme="http", host="localhost", port=8080, grpc_port=50051
     )
     client_grpc = weaviate.Client(connection_params)
     client_grpc.schema.delete_all()
@@ -109,7 +109,7 @@ def test_additional():
     client_grpc.schema.create_class(CLASS1)
     client_grpc.data_object.create({"test": "test"}, "Test", vector=VECTOR)
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50052
+        scheme="http", host="localhost", port=8080, grpc_port=50052
     )
     client_gql = weaviate.Client(connection_params)
 
@@ -139,7 +139,7 @@ def test_additional():
 
 def test_grpc_errors():
     connection_params = weaviate.ConnectionParams(
-        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
+        scheme="http", host="localhost", port=8080, grpc_port=50051
     )
     client = weaviate.Client(connection_params)
     classname = CLASS1["class"]

--- a/integration/test_grcp.py
+++ b/integration/test_grcp.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 import pytest as pytest
 
 import weaviate
-from weaviate import Config
 
 CLASS1 = {
     "class": "Test",
@@ -55,10 +54,10 @@ UUID2 = "577887c1-4c6b-5594-aa62-f0c17883d9cf"
 def test_grcp(
     with_limit: bool, additional_props, search: Dict[str, Any], properties, grpc_port: Optional[int]
 ):
-    client = weaviate.Client(
-        "http://localhost:8080",
-        additional_config=Config(grpc_port_experimental=grpc_port),
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=grpc_port
     )
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
 
     client.schema.create_class(CLASS1)
@@ -101,15 +100,18 @@ def test_grcp(
 
 
 def test_additional():
-    client_grpc = weaviate.Client(
-        "http://localhost:8080",
-        additional_config=Config(grpc_port_experimental=50051),
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
     )
+    client_grpc = weaviate.Client(connection_params)
     client_grpc.schema.delete_all()
 
     client_grpc.schema.create_class(CLASS1)
     client_grpc.data_object.create({"test": "test"}, "Test", vector=VECTOR)
-    client_gql = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50052
+    )
+    client_gql = weaviate.Client(connection_params)
 
     results = []
     for client in [client_gql, client_grpc]:
@@ -136,10 +138,10 @@ def test_additional():
 
 
 def test_grpc_errors():
-    client = weaviate.Client(
-        "http://localhost:8080",
-        additional_config=Config(grpc_port_experimental=50051),
+    connection_params = weaviate.ConnectionParams(
+        scheme="http", host="localhost", rest_port=8080, grpc_port=50051
     )
+    client = weaviate.Client(connection_params)
     classname = CLASS1["class"]
     if client.schema.exists(classname):
         client.schema.delete_class(classname)

--- a/integration/test_schema.py
+++ b/integration/test_schema.py
@@ -9,7 +9,8 @@ from weaviate import Tenant, TenantActivityStatus
 
 @pytest.fixture(scope="module")
 def client():
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     yield client
     client.schema.delete_all()
 

--- a/integration/test_schema.py
+++ b/integration/test_schema.py
@@ -9,7 +9,7 @@ from weaviate import Tenant, TenantActivityStatus
 
 @pytest.fixture(scope="module")
 def client():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     yield client
     client.schema.delete_all()

--- a/integration/test_stress.py
+++ b/integration/test_stress.py
@@ -106,7 +106,8 @@ class Article:
 @pytest.mark.parametrize("dynamic", [False])
 @pytest.mark.parametrize("batch_size", [50])
 def test_stress(batch_size, dynamic):
-    client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(schema)
     client.batch.configure(batch_size=batch_size, dynamic=dynamic, num_workers=4)
@@ -153,7 +154,8 @@ def test_stress(batch_size, dynamic):
     ],
 )
 def client(request):
-    local_client = weaviate.Client("http://localhost:8080")
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    local_client = weaviate.Client(connection_params)
     if request.param[0] > 0:
         local_client.batch.configure(
             batch_size=request.param[0], dynamic=False, num_workers=request.param[1]

--- a/integration/test_stress.py
+++ b/integration/test_stress.py
@@ -106,7 +106,7 @@ class Article:
 @pytest.mark.parametrize("dynamic", [False])
 @pytest.mark.parametrize("batch_size", [50])
 def test_stress(batch_size, dynamic):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params)
     client.schema.delete_all()
     client.schema.create(schema)
@@ -154,7 +154,7 @@ def test_stress(batch_size, dynamic):
     ],
 )
 def client(request):
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     local_client = weaviate.Client(connection_params)
     if request.param[0] > 0:
         local_client.batch.configure(

--- a/integration/test_timeout.py
+++ b/integration/test_timeout.py
@@ -16,7 +16,8 @@ schema = {
 
 
 def test_low_timeout():
-    client = weaviate.Client("http://localhost:8080", timeout_config=(1, 1))
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    client = weaviate.Client(connection_params, timeout_config=(1, 1))
     client.schema.delete_all()
     client.schema.create(schema)
     client.batch.configure(dynamic=True, batch_size=10, num_workers=4)

--- a/integration/test_timeout.py
+++ b/integration/test_timeout.py
@@ -16,7 +16,7 @@ schema = {
 
 
 def test_low_timeout():
-    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+    connection_params = weaviate.ConnectionParams(scheme="http", host="localhost", port=8080)
     client = weaviate.Client(connection_params, timeout_config=(1, 1))
     client.schema.delete_all()
     client.schema.create(schema)

--- a/mock_tests/conftest.py
+++ b/mock_tests/conftest.py
@@ -10,7 +10,7 @@ MOCK_IP = "127.0.0.1"
 MOCK_PORT = 23536
 CLIENT_ID = "DoesNotMatter"
 MOCK_SERVER_URL = "http://" + MOCK_IP + ":" + str(MOCK_PORT)
-MOCK_SERVER_CONNECTION_PARAMS = ConnectionParams(scheme="http", host=MOCK_IP, rest_port=MOCK_PORT)
+MOCK_SERVER_CONNECTION_PARAMS = ConnectionParams(scheme="http", host=MOCK_IP, port=MOCK_PORT)
 
 # pytest_httpserver 'Authorization' HeaderValueMatcher does not work with Bearer tokens.
 # Hence, overwrite it with the default header value matcher that just compares for equality.

--- a/mock_tests/conftest.py
+++ b/mock_tests/conftest.py
@@ -4,10 +4,13 @@ import pytest
 from pytest_httpserver import HTTPServer, HeaderValueMatcher
 from werkzeug.wrappers import Response
 
+from weaviate.connect.connection import ConnectionParams
+
 MOCK_IP = "127.0.0.1"
 MOCK_PORT = 23536
 CLIENT_ID = "DoesNotMatter"
 MOCK_SERVER_URL = "http://" + MOCK_IP + ":" + str(MOCK_PORT)
+MOCK_SERVER_CONNECTION_PARAMS = ConnectionParams(scheme="http", host=MOCK_IP, rest_port=MOCK_PORT)
 
 # pytest_httpserver 'Authorization' HeaderValueMatcher does not work with Bearer tokens.
 # Hence, overwrite it with the default header value matcher that just compares for equality.

--- a/mock_tests/test_auth.py
+++ b/mock_tests/test_auth.py
@@ -6,7 +6,7 @@ import pytest
 from werkzeug import Request, Response
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL, CLIENT_ID
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS, CLIENT_ID
 from weaviate.exceptions import MissingScopeException
 
 ACCESS_TOKEN = "HELLO!IamAnAccessToken"
@@ -33,7 +33,7 @@ def test_user_password(weaviate_auth_mock):
     ).respond_with_json({})
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL, auth_client_secret=weaviate.AuthClientPassword(user, pw)
+        MOCK_SERVER_CONNECTION_PARAMS, auth_client_secret=weaviate.AuthClientPassword(user, pw)
     )
     client.schema.delete_all()  # some call that includes authorization
 
@@ -45,7 +45,7 @@ def test_bearer_token(weaviate_auth_mock):
     ).respond_with_json({})
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        MOCK_SERVER_CONNECTION_PARAMS,
         auth_client_secret=weaviate.AuthBearerToken(ACCESS_TOKEN, refresh_token=REFRESH_TOKEN),
     )
     client.schema.delete_all()  # some call that includes authorization
@@ -61,7 +61,7 @@ def test_client_credentials(weaviate_auth_mock):
     ).respond_with_json({})
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        MOCK_SERVER_CONNECTION_PARAMS,
         auth_client_secret=weaviate.AuthClientCredentials(client_secret=CLIENT_SECRET, scope=SCOPE),
     )
     client.schema.delete_all()  # some call that includes authorization
@@ -87,7 +87,7 @@ def test_auth_header_priority(recwarn, weaviate_auth_mock, header_name: str):
     weaviate_auth_mock.expect_request("/v1/schema").respond_with_handler(handler)
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        MOCK_SERVER_CONNECTION_PARAMS,
         auth_client_secret=weaviate.AuthBearerToken(
             access_token=ACCESS_TOKEN, refresh_token="SOMETHING"
         ),
@@ -114,7 +114,7 @@ def test_refresh(weaviate_auth_mock):
         {"access_token": ACCESS_TOKEN, "expires_in": 1, "refresh_token": REFRESH_TOKEN}
     )
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        MOCK_SERVER_CONNECTION_PARAMS,
         auth_client_secret=weaviate.AuthBearerToken(
             ACCESS_TOKEN, refresh_token=REFRESH_TOKEN, expires_in=1
         ),
@@ -131,7 +131,7 @@ def test_auth_header_without_weaviate_auth(weaviate_mock):
     ).respond_with_json({})
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        MOCK_SERVER_CONNECTION_PARAMS,
         additional_headers={"Authorization": "Bearer " + bearer_token},
     )
     client.schema.delete_all()  # some call that includes authorization
@@ -145,7 +145,7 @@ def test_auth_header_with_catchall_proxy(weaviate_mock, recwarn):
     )
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        MOCK_SERVER_CONNECTION_PARAMS,
         auth_client_secret=weaviate.AuthClientPassword(
             username="test-username", password="test-password"
         ),
@@ -161,7 +161,7 @@ def test_auth_header_with_catchall_proxy(weaviate_mock, recwarn):
 def test_missing_scope(weaviate_auth_mock):
     with pytest.raises(MissingScopeException):
         weaviate.Client(
-            url=MOCK_SERVER_URL,
+            MOCK_SERVER_CONNECTION_PARAMS,
             auth_client_secret=weaviate.AuthClientCredentials(
                 client_secret=CLIENT_SECRET, scope=None
             ),
@@ -189,7 +189,7 @@ def test_token_refresh_timeout(weaviate_auth_mock, recwarn):
     ).respond_with_json({})
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        MOCK_SERVER_CONNECTION_PARAMS,
         auth_client_secret=weaviate.AuthBearerToken(
             ACCESS_TOKEN, refresh_token=REFRESH_TOKEN, expires_in=1  # force immediate refresh
         ),
@@ -210,7 +210,7 @@ def test_with_simple_auth_no_oidc_via_api_key(weaviate_mock, recwarn):
     ).respond_with_json({})
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL,
+        connection_params=MOCK_SERVER_CONNECTION_PARAMS,
         auth_client_secret=weaviate.AuthApiKey(api_key="Super-secret-key"),
     )
     client.schema.delete_all()
@@ -225,7 +225,8 @@ def test_with_simple_auth_no_oidc_via_additional_headers(weaviate_mock, recwarn)
     ).respond_with_json({})
 
     client = weaviate.Client(
-        url=MOCK_SERVER_URL, additional_headers={"Authorization": "Bearer " + "Super-secret-key"}
+        connection_params=MOCK_SERVER_CONNECTION_PARAMS,
+        additional_headers={"Authorization": "Bearer " + "Super-secret-key"},
     )
     client.schema.delete_all()
 

--- a/mock_tests/test_automatic_retries.py
+++ b/mock_tests/test_automatic_retries.py
@@ -6,7 +6,7 @@ import uuid
 from werkzeug.wrappers import Request, Response
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS
 from weaviate.batch.crud_batch import WeaviateErrorRetryConf, BatchResponse
 from weaviate.util import check_batch_result
 
@@ -43,7 +43,7 @@ def test_automatic_retry_obs(weaviate_mock, error):
 
     weaviate_mock.expect_request("/v1/batch/objects").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
     added_uuids = []
     batch_size = 4  # Do not change, affects how many failed requests there are
     n = (
@@ -88,7 +88,7 @@ def test_automatic_retry_refs(weaviate_mock):
 
     weaviate_mock.expect_request("/v1/batch/references").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
     batch_size = 4  # Do not change, affects how many failed requests there are
     n = (
         50 * batch_size
@@ -132,7 +132,7 @@ def test_automatic_retry_unsuccessful(weaviate_mock):
 
     weaviate_mock.expect_request("/v1/batch/objects").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
     batch_size = 20
     n = batch_size * 2
     with client.batch(
@@ -171,7 +171,7 @@ def test_print_threadsafety(weaviate_mock, capfd, retry_config):
 
     weaviate_mock.expect_request("/v1/batch/objects").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     added_uuids = []
     n = 200 * 4
@@ -227,7 +227,7 @@ def test_include_error(weaviate_mock, retry_config, expected):
 
     weaviate_mock.expect_request("/v1/batch/objects").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     added_uuids = []
     n = 400 * 2
@@ -260,7 +260,7 @@ def test_callback_for_successful_responses(weaviate_mock, capfd):
 
     weaviate_mock.expect_request("/v1/batch/objects").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     def callback_print_all(results: Optional[BatchResponse]):
         if results is None:

--- a/mock_tests/test_batching_manual.py
+++ b/mock_tests/test_batching_manual.py
@@ -1,13 +1,13 @@
 import uuid
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS
 
 
 def test_manual_batching_warning_object(recwarn, weaviate_mock):
     weaviate_mock.expect_request("/v1/batch/objects").respond_with_json([])
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     client.batch.configure(batch_size=None, dynamic=False)
     client.batch.add_data_object({}, "ExistingClass")
@@ -22,7 +22,7 @@ def test_manual_batching_warning_object(recwarn, weaviate_mock):
 def test_manual_batching_warning_ref(recwarn, weaviate_mock):
     weaviate_mock.expect_request("/v1/batch/references").respond_with_json([])
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
     client.batch.configure(batch_size=None, dynamic=False)
 
     client.batch.add_reference(

--- a/mock_tests/test_collection.py
+++ b/mock_tests/test_collection.py
@@ -3,14 +3,14 @@ from datetime import datetime
 from pytest_httpserver import HTTPServer
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS
 
 
 def test_warning_old_weaviate(recwarn, ready_mock: HTTPServer):
     ready_mock.expect_request("/v1/meta").respond_with_json({"version": "1.21.0"})
     ready_mock.expect_request("/v1/objects").respond_with_json({})
 
-    client = weaviate.Client(MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
     client.collection.get("Class").data.insert(
         {
             "date": datetime.now(),

--- a/mock_tests/test_connection.py
+++ b/mock_tests/test_connection.py
@@ -7,7 +7,7 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL, MOCK_IP, MOCK_PORT
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS, MOCK_IP, MOCK_PORT
 
 
 @pytest.mark.parametrize(
@@ -29,7 +29,9 @@ def test_additional_headers(weaviate_mock, header: Dict[str, str]):
 
     weaviate_mock.expect_request("/v1/schema").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL, additional_headers=header)
+    client = weaviate.Client(
+        connection_params=MOCK_SERVER_CONNECTION_PARAMS, additional_headers=header
+    )
     client.schema.delete_all()  # some call that includes headers
 
 
@@ -37,7 +39,7 @@ def test_additional_headers(weaviate_mock, header: Dict[str, str]):
 def test_warning_old_weaviate(recwarn, ready_mock: HTTPServer, version: str, warning: bool):
     """Test that we warn if a new client version is using an old weaviate server."""
     ready_mock.expect_request("/v1/meta").respond_with_json({"version": version})
-    weaviate.Client(url=MOCK_SERVER_URL)
+    weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     if warning:
         assert len(recwarn) == 2
@@ -66,9 +68,12 @@ def test_wait_for_weaviate(httpserver: HTTPServer):
     httpserver.expect_request("/v1/meta").respond_with_handler(handler_meta)
     httpserver.expect_request("/v1/.well-known/ready").respond_with_handler(handler)
     start_time = time.time()
-    weaviate.Client(url=MOCK_SERVER_URL, startup_period=30)
+    weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS, startup_period=30)
 
 
 def test_user_pw_in_url(weaviate_mock):
     """Test that user and pw can be in the url."""
-    weaviate.Client(url="http://user:pw@" + MOCK_IP + ":" + str(MOCK_PORT))  # no exception
+    connection_params = weaviate.ConnectionParams.from_connection_string(
+        "http://user:pw@" + MOCK_IP + ":" + str(MOCK_PORT)
+    )
+    weaviate.Client(connection_params)  # no exception

--- a/mock_tests/test_exception.py
+++ b/mock_tests/test_exception.py
@@ -1,7 +1,7 @@
 import pytest
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS
 from weaviate.exceptions import ResponseCannotBeDecodedException
 
 
@@ -10,7 +10,7 @@ def test_json_decode_exception_dict(weaviate_mock):
 
     weaviate_mock.expect_request("/v1/schema").respond_with_data("JsonCannotParseThis")
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
     with pytest.raises(ResponseCannotBeDecodedException) as e:
         client.schema.get()
 
@@ -22,7 +22,7 @@ def test_json_decode_exception_list(weaviate_mock):
 
     weaviate_mock.expect_request("/v1/schema/Test/shards").respond_with_data("JsonCannotParseThis")
 
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
     with pytest.raises(ResponseCannotBeDecodedException) as e:
         client.schema.get_class_shards("Test")
         assert "JsonCannotParseThis" in e.value

--- a/mock_tests/test_graphql.py
+++ b/mock_tests/test_graphql.py
@@ -3,7 +3,7 @@ from http.server import HTTPServer
 import pytest as pytest
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS
 
 
 @pytest.mark.parametrize(
@@ -11,7 +11,7 @@ from mock_tests.conftest import MOCK_SERVER_URL
 )
 def test_warning_old_weaviate(recwarn, ready_mock: HTTPServer, version: str, warning: bool):
     ready_mock.expect_request("/v1/meta").respond_with_json({"version": version})
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     client.query.get("Class", ["Property"]).with_generate(single_prompt="something")
 

--- a/mock_tests/test_resend.py
+++ b/mock_tests/test_resend.py
@@ -8,7 +8,7 @@ from requests import ReadTimeout
 from werkzeug.wrappers import Request, Response
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS
 
 
 def test_no_retry_on_timeout(weaviate_no_auth_mock):
@@ -20,7 +20,7 @@ def test_no_retry_on_timeout(weaviate_no_auth_mock):
 
     weaviate_no_auth_mock.expect_request("/v1/batch/objects").respond_with_handler(handler)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL, timeout_config=(1, 1))
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS, timeout_config=(1, 1))
 
     n = 10
     with pytest.raises(ReadTimeout):
@@ -84,7 +84,7 @@ def test_retry_on_timeout(weaviate_no_auth_mock):
         re.compile("^/v1/objects/Test/"), method="GET"
     ).respond_with_handler(handler_get_object)
 
-    client = weaviate.Client(url=MOCK_SERVER_URL, timeout_config=(1, 1))
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS, timeout_config=(1, 1))
     with client.batch(batch_size=n, timeout_retries=1, dynamic=False) as batch:
         for _ in range(n):
             added_uuids.append(str(uuid.uuid4()))
@@ -115,7 +115,7 @@ def test_retry_on_timeout_all_succesfull(weaviate_no_auth_mock):
         re.compile("^/v1/objects/Test/"), method="GET"
     ).respond_with_json({"properties": {"name": "test"}})
 
-    client = weaviate.Client(url=MOCK_SERVER_URL, timeout_config=(1, 1))
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS, timeout_config=(1, 1))
     with client.batch(batch_size=n, timeout_retries=1, dynamic=False) as batch:
         for _ in range(n):
             batch.add_data_object({"name": "test"}, "test", uuid.uuid4())

--- a/mock_tests/test_schema.py
+++ b/mock_tests/test_schema.py
@@ -5,7 +5,7 @@ from requests import ReadTimeout
 from werkzeug.wrappers import Request, Response
 
 import weaviate
-from mock_tests.conftest import MOCK_SERVER_URL
+from mock_tests.conftest import MOCK_SERVER_CONNECTION_PARAMS
 
 
 def test_schema_timeout_error(weaviate_mock):
@@ -16,7 +16,7 @@ def test_schema_timeout_error(weaviate_mock):
         return Response(status=200)
 
     weaviate_mock.expect_request("/v1/schema/Test").respond_with_handler(handler)
-    client = weaviate.Client(url=MOCK_SERVER_URL, timeout_config=(1, 1))
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS, timeout_config=(1, 1))
 
     with pytest.raises(ReadTimeout):
         client.schema.exists("Test")
@@ -29,7 +29,7 @@ def test_schema_unknown_status_code(weaviate_mock):
         return Response(status=403)
 
     weaviate_mock.expect_request("/v1/schema/Test").respond_with_handler(handler)
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     with pytest.raises(weaviate.UnexpectedStatusCodeException):
         client.schema.exists("Test")
@@ -47,7 +47,7 @@ def test_schema_exists(weaviate_mock):
     weaviate_mock.expect_request("/v1/schema/DoesNotExists").respond_with_handler(
         lambda r: handler(r, 404)
     )
-    client = weaviate.Client(url=MOCK_SERVER_URL)
+    client = weaviate.Client(connection_params=MOCK_SERVER_CONNECTION_PARAMS)
 
     assert client.schema.exists("Exists") is True
     assert client.schema.exists("DoesNotExists") is False

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -44,7 +44,7 @@ class TestWeaviateClient(unittest.TestCase):
                 startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="http://localhost:8080",
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies=None,
@@ -52,7 +52,6 @@ class TestWeaviateClient(unittest.TestCase):
                 additional_headers=None,
                 startup_period=None,
                 embedded_db=None,
-                grcp_port=None,
                 connection_config=ConnectionConfig(),
             )
 
@@ -68,7 +67,7 @@ class TestWeaviateClient(unittest.TestCase):
                 startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="http://localhost:8080",
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies=None,
@@ -76,7 +75,6 @@ class TestWeaviateClient(unittest.TestCase):
                 additional_headers={"Test": True},
                 startup_period=None,
                 embedded_db=None,
-                grcp_port=None,
                 connection_config=ConnectionConfig(),
             )
 
@@ -91,7 +89,7 @@ class TestWeaviateClient(unittest.TestCase):
                 startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="http://localhost:8080",
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(5, 20),
                 proxies=None,
@@ -99,7 +97,6 @@ class TestWeaviateClient(unittest.TestCase):
                 additional_headers=None,
                 startup_period=None,
                 embedded_db=None,
-                grcp_port=None,
                 connection_config=ConnectionConfig(),
             )
 
@@ -117,7 +114,7 @@ class TestWeaviateClient(unittest.TestCase):
                 startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="http://localhost:8080",
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies={"http": "test"},
@@ -125,7 +122,6 @@ class TestWeaviateClient(unittest.TestCase):
                 additional_headers=None,
                 startup_period=None,
                 embedded_db=None,
-                grcp_port=None,
                 connection_config=ConnectionConfig(),
             )
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -133,7 +133,10 @@ class TestWeaviateClient(unittest.TestCase):
                 with patch("weaviate.embedded.EmbeddedDB.start") as mocked_start:
                     Client(embedded_options=EmbeddedOptions())
                     args, kwargs = mock_obj.call_args_list[0]
-                    self.assertEqual(kwargs["url"], "http://localhost:8079")
+                    self.assertEqual(
+                        kwargs["connection_params"],
+                        ConnectionParams(scheme="http", host="localhost", port=8079),
+                    )
                     self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))
                     self.assertTrue(kwargs["embedded_db"] is not None)
                     self.assertEqual(kwargs["embedded_db"].options.port, 8079)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -135,7 +135,9 @@ class TestWeaviateClient(unittest.TestCase):
                     args, kwargs = mock_obj.call_args_list[0]
                     self.assertEqual(
                         kwargs["connection_params"],
-                        ConnectionParams(scheme="http", host="localhost", port=8079),
+                        ConnectionParams(
+                            scheme="http", host="localhost", port=8079, grpc_port=50051
+                        ),
                     )
                     self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))
                     self.assertTrue(kwargs["embedded_db"] is not None)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -37,7 +37,7 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 additional_headers=None,
@@ -61,7 +61,7 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 additional_headers={"Test": True},
@@ -85,7 +85,7 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(5, 20),
                 startup_period=None,
@@ -108,7 +108,7 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
+                connection_params=ConnectionParams(scheme="http", host="localhost", port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies={"http": "test"},
@@ -148,7 +148,7 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `is_ready` method.
         """
-        connection_params = ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+        connection_params = ConnectionParams(scheme="http", host="localhost", port=8080)
         client = Client(connection_params)
         # Request to weaviate returns 200
         connection_mock = mock_connection_func("get")
@@ -173,7 +173,7 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `is_live` method.
         """
-        connection_params = ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+        connection_params = ConnectionParams(scheme="http", host="localhost", port=8080)
         client = Client(connection_params)
         # Request to weaviate returns 200
         connection_mock = mock_connection_func("get")
@@ -217,7 +217,7 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `get_open_id_configuration` method.
         """
-        connection_params = ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+        connection_params = ConnectionParams(scheme="http", host="localhost", port=8080)
         client = Client(connection_params)
         # Request to weaviate returns 200
         connection_mock = mock_connection_func("get", return_json={"status": "OK!"})
@@ -245,7 +245,7 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `set_timeout_config` method.
         """
-        connection_params = ConnectionParams(scheme="http", host="some_url.com", rest_port=80)
+        connection_params = ConnectionParams(scheme="http", host="some_url.com", port=80)
         client = Client(connection_params, auth_client_secret=None, timeout_config=(1, 2))
         self.assertEqual(client.timeout_config, (1, 2))
         client.timeout_config = (4, 20)  # ;)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, Mock
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from test.util import mock_connection_func, check_error_message
-from weaviate import Client, ConnectionConfig
+from weaviate import Client, ConnectionConfig, ConnectionParams
 from weaviate.embedded import EmbeddedOptions, EmbeddedDB
 from weaviate.exceptions import UnexpectedStatusCodeException
 
@@ -18,14 +18,18 @@ class TestWeaviateClient(unittest.TestCase):
         Test the `__init__` method.
         """
 
-        type_error_message = "Either url or embedded options must be present."
+        type_error_message = "Either connection_params or embedded_options must be present."
         # test invalid calls
         with self.assertRaises(TypeError) as error:
             Client(None)
         check_error_message(self, error, type_error_message)
         with self.assertRaises(TypeError) as error:
             Client(42)
-        check_error_message(self, error, "URL is expected to be string but is " + str(int))
+        check_error_message(
+            self,
+            error,
+            "connection_params is expected to be a ConnectionParams object but is " + str(int),
+        )
 
         # test valid calls
         with patch(
@@ -33,14 +37,14 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                url="some_URL",
+                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 additional_headers=None,
                 startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="some_URL",
+                url="http://localhost:8080",
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies=None,
@@ -57,14 +61,14 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                url="some_URL",
+                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 additional_headers={"Test": True},
                 startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="some_URL",
+                url="http://localhost:8080",
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies=None,
@@ -81,10 +85,13 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                "some_URL/", auth_client_secret=None, timeout_config=(5, 20), startup_period=None
+                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
+                auth_client_secret=None,
+                timeout_config=(5, 20),
+                startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="some_URL",
+                url="http://localhost:8080",
                 auth_client_secret=None,
                 timeout_config=(5, 20),
                 proxies=None,
@@ -101,7 +108,7 @@ class TestWeaviateClient(unittest.TestCase):
             Mock(side_effect=lambda **kwargs: Mock(timeout_config=kwargs["timeout_config"])),
         ) as mock_obj:
             Client(
-                url="some_URL",
+                connection_params=ConnectionParams(scheme="http", host="localhost", rest_port=8080),
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies={"http": "test"},
@@ -110,7 +117,7 @@ class TestWeaviateClient(unittest.TestCase):
                 startup_period=None,
             )
             mock_obj.assert_called_with(
-                url="some_URL",
+                url="http://localhost:8080",
                 auth_client_secret=None,
                 timeout_config=(1, 2),
                 proxies={"http": "test"},
@@ -130,10 +137,10 @@ class TestWeaviateClient(unittest.TestCase):
                 with patch("weaviate.embedded.EmbeddedDB.start") as mocked_start:
                     Client(embedded_options=EmbeddedOptions())
                     args, kwargs = mock_obj.call_args_list[0]
-                    self.assertEqual(kwargs["url"], "http://localhost:6666")
+                    self.assertEqual(kwargs["url"], "http://localhost:8079")
                     self.assertTrue(isinstance(kwargs["embedded_db"], EmbeddedDB))
                     self.assertTrue(kwargs["embedded_db"] is not None)
-                    self.assertEqual(kwargs["embedded_db"].options.port, 6666)
+                    self.assertEqual(kwargs["embedded_db"].options.port, 8079)
                     mocked_start.assert_called_once()
 
     @patch("weaviate.client.Client.get_meta", return_value={"version": "1.13.2"})
@@ -141,8 +148,8 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `is_ready` method.
         """
-
-        client = Client("http://localhost:8080")
+        connection_params = ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+        client = Client(connection_params)
         # Request to weaviate returns 200
         connection_mock = mock_connection_func("get")
         client._connection = connection_mock
@@ -166,8 +173,8 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `is_live` method.
         """
-
-        client = Client("http://localhost:8080")
+        connection_params = ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+        client = Client(connection_params)
         # Request to weaviate returns 200
         connection_mock = mock_connection_func("get")
         client._connection = connection_mock
@@ -210,8 +217,8 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `get_open_id_configuration` method.
         """
-
-        client = Client("http://localhost:8080")
+        connection_params = ConnectionParams(scheme="http", host="localhost", rest_port=8080)
+        client = Client(connection_params)
         # Request to weaviate returns 200
         connection_mock = mock_connection_func("get", return_json={"status": "OK!"})
         client._connection = connection_mock
@@ -238,8 +245,8 @@ class TestWeaviateClient(unittest.TestCase):
         """
         Test the `set_timeout_config` method.
         """
-
-        client = Client("http://some_url.com", auth_client_secret=None, timeout_config=(1, 2))
+        connection_params = ConnectionParams(scheme="http", host="some_url.com", rest_port=80)
+        client = Client(connection_params, auth_client_secret=None, timeout_config=(1, 2))
         self.assertEqual(client.timeout_config, (1, 2))
         client.timeout_config = (4, 20)  # ;)
         self.assertEqual(client.timeout_config, (4, 20))

--- a/weaviate/__init__.py
+++ b/weaviate/__init__.py
@@ -48,6 +48,7 @@ __all__ = [
     "EmbeddedOptions",
     "Config",
     "ConnectionConfig",
+    "ConnectionParams",
     "AdditionalProperties",
     "LinkTo",
     "Tenant",
@@ -66,6 +67,7 @@ except PackageNotFoundError:
 from .auth import AuthClientCredentials, AuthClientPassword, AuthBearerToken, AuthApiKey
 from .batch.crud_batch import WeaviateErrorRetryConf
 from .client import Client
+from .connect.connection import ConnectionParams
 from .data.replication import ConsistencyLevel
 from .schema.crud_schema import Tenant, TenantActivityStatus
 from .embedded import EmbeddedOptions

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -267,7 +267,7 @@ class Client:
                     scheme="http",
                     host="localhost",
                     port=embedded_db.options.port,
-                    grpc_port=embedded_db.options.port + 1,
+                    grpc_port=50051,
                 ),
                 embedded_db,
             )

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -267,7 +267,7 @@ class Client:
                 ConnectionParams(
                     scheme="http",
                     host="localhost",
-                    rest_port=embedded_db.options.port,
+                    port=embedded_db.options.port,
                     grpc_port=embedded_db.options.port + 1,
                 ),
                 embedded_db,

--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -123,7 +123,7 @@ class Client:
         config = Config() if additional_config is None else additional_config
 
         self._connection = Connection(
-            url=connection_params._to_rest_url(),
+            connection_params=connection_params,
             auth_client_secret=auth_client_secret,
             timeout_config=_get_valid_timeout_config(timeout_config),
             proxies=proxies,
@@ -131,7 +131,6 @@ class Client:
             additional_headers=additional_headers,
             startup_period=startup_period,
             embedded_db=embedded_db,
-            grcp_port=connection_params.grpc_port,
             connection_config=config.connection_config,
         )
         self.classification = Classification(self._connection)

--- a/weaviate/collection/queries/base.py
+++ b/weaviate/collection/queries/base.py
@@ -47,6 +47,7 @@ from weaviate.collection.classes.types import (
 )
 from weaviate.collection.grpc_query import _QueryGRPC, GroupByResult, SearchResponse, SearchResult
 from weaviate.connect import Connection
+from weaviate.exceptions import WeaviateGrpcUnavailable
 from weaviate.util import file_encoder_b64
 from weaviate_grpc import weaviate_pb2
 
@@ -65,6 +66,8 @@ class _Grpc:
         self.__consistency_level = consistency_level
 
     def _query(self) -> _QueryGRPC:
+        if not self.__connection._grpc_available:
+            raise WeaviateGrpcUnavailable()
         return _QueryGRPC(self.__connection, self.__name, self.__tenant, self.__consistency_level)
 
     @staticmethod

--- a/weaviate/config.py
+++ b/weaviate/config.py
@@ -1,32 +1,10 @@
-from dataclasses import dataclass, field
-from typing import Optional
+from pydantic import BaseModel, Field
 
 
-@dataclass
-class ConnectionConfig:
-    session_pool_connections: int = 20
-    session_pool_maxsize: int = 20
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.session_pool_connections, int):
-            raise TypeError(
-                f"session_pool_connections must be {int}, received {type(self.session_pool_connections)}"
-            )
-        if not isinstance(self.session_pool_maxsize, int):
-            raise TypeError(
-                f"session_pool_maxsize must be {int}, received {type(self.session_pool_maxsize)}"
-            )
+class ConnectionConfig(BaseModel):
+    session_pool_connections: int = Field(default=20)
+    session_pool_maxsize: int = Field(default=20)
 
 
-@dataclass
-class Config:
-    grpc_port_experimental: Optional[int] = None
-    connection_config: ConnectionConfig = field(default_factory=ConnectionConfig)
-
-    def __post_init__(self) -> None:
-        if self.grpc_port_experimental is not None and not isinstance(
-            self.grpc_port_experimental, int
-        ):
-            raise TypeError(
-                f"grpc_port_experimental must be {int}, received {type(self.grpc_port_experimental)}"
-            )
+class Config(BaseModel):
+    connection_config: ConnectionConfig = Field(default_factory=ConnectionConfig)

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -102,6 +102,16 @@ class ConnectionParams(BaseModel):
     def _to_rest_url(self) -> str:
         return f"{self.scheme}://{self.host}:{self.rest_port}"
 
+    @classmethod
+    def from_connection_string(cls, url: str, grpc_port: Optional[int] = None) -> ConnectionParams:
+        parsed = urlparse(url)
+        return cls(
+            scheme=parsed.scheme,
+            host=cast(str, parsed.hostname),
+            rest_port=cast(int, parsed.port),
+            grpc_port=grpc_port,
+        )
+
 
 class Connection:
     """

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -57,7 +57,7 @@ MAX_GRPC_MESSAGE_LENGTH = 104858000  # 10mb, needs to be synchronized with GRPC 
 class ConnectionParams(BaseModel):
     scheme: str
     host: str
-    rest_port: int
+    port: int
     grpc_port: Optional[int] = Field(default=None)
     grpc_url: Optional[str] = Field(default=None)
 
@@ -73,10 +73,10 @@ class ConnectionParams(BaseModel):
             raise ValueError("host must not be empty")
         return v
 
-    @field_validator("rest_port")
-    def _check_rest_port(cls, v: int) -> int:
+    @field_validator("port")
+    def _check_port(cls, v: int) -> int:
         if v < 0 or v > 65535:
-            raise ValueError("rest_port must be between 0 and 65535")
+            raise ValueError("port must be between 0 and 65535")
         return v
 
     @field_validator("grpc_port")
@@ -89,8 +89,8 @@ class ConnectionParams(BaseModel):
 
     @model_validator(mode="after")
     def _check_port_collision(self) -> ConnectionParams:
-        if self.rest_port == self.grpc_port:
-            raise ValueError("rest_port and grpc_port must be different")
+        if self.port == self.grpc_port:
+            raise ValueError("port and grpc_port must be different")
         return self
 
     @model_validator(mode="after")
@@ -100,7 +100,7 @@ class ConnectionParams(BaseModel):
         return self
 
     def _to_rest_url(self) -> str:
-        return f"{self.scheme}://{self.host}:{self.rest_port}"
+        return f"{self.scheme}://{self.host}:{self.port}"
 
     @classmethod
     def from_connection_string(cls, url: str, grpc_port: Optional[int] = None) -> ConnectionParams:
@@ -108,7 +108,7 @@ class ConnectionParams(BaseModel):
         return cls(
             scheme=parsed.scheme,
             host=cast(str, parsed.hostname),
-            rest_port=cast(int, parsed.port),
+            port=cast(int, parsed.port),
             grpc_port=grpc_port,
         )
 

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -31,7 +31,7 @@ class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", DEFAULT_PERSISTENCE_DATA_PATH)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", DEFAULT_BINARY_PATH)
     version: str = "1.21.1"
-    port: int = 6666
+    port: int = 8079
     hostname: str = "127.0.0.1"
     additional_env_vars: Optional[Dict[str, str]] = None
 

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -192,3 +192,11 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
     def __init__(self, data: dict):
         msg = f"""It is forbidden to insert `id` or `vector` inside properties: {data}. Only properties defined in your collection's config can be insterted as properties of the object, `id` is totally forbidden as it is reserved and `vector` is forbidden at this level. You should use the `DataObject` class if you wish to insert an object with a custom `vector` whilst inserting its properties."""
         super().__init__(msg)
+
+
+class WeaviateGrpcUnavailable(WeaviateBaseError):
+    """Is raised when a gRPC-backed query is made with no gRPC connection present."""
+
+    def __init__(self) -> None:
+        msg = """gRPC is not available. Please make sure that gRPC is configured correctly in the client and on the server."""
+        super().__init__(msg)


### PR DESCRIPTION
This PR refactors the client creation process by introducing the `ConnectionParams(pydantic.BaseModel)` object for use when defining the scheme, host, and ports (REST & gRPC) of the user's connection to their Weaviate instance

Achieving a unified port for REST and gRPC is not feasible due to complications and intricacies when deploying cloud load balancers so the client must specify these ports separately. In addition, there is a potential use-case where the REST and gRPC URLs are also different so the `grpc_url` field is introduced for this edge use-case 