### PR TITLE
add new object dataTypes and write tests for them

### DIFF
--- a/ci/docker-compose-azure.yml
+++ b/ci/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -25,7 +25,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     ports:
       - 8088:8080
       - 6061:6060

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-openai.yml
+++ b/ci/docker-compose-openai.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-make-proto-naming-consistent-4b98dfa
+    image: semitechnologies/weaviate:preview-nested-objects-4dc2c30
     ports:
       - "8080:8080"
       - "50051:50051"

--- a/integration/test_batch.py
+++ b/integration/test_batch.py
@@ -416,3 +416,36 @@ def test_add_ref_batch_with_tenant():
 
     for name in reversed(class_names):
         client.schema.delete_class(name)
+
+
+def test_add_nested_object_with_batch():
+    client = weaviate.Client("http://localhost:8080")
+    client.schema.delete_all()
+
+    client.schema.create_class(
+        {
+            "class": "BatchTestNested",
+            "vectorizer": "none",
+            "properties": [
+                {
+                    "name": "nested",
+                    "dataType": ["object"],
+                    "nestedProperties": [
+                        {"name": "name", "dataType": ["text"]},
+                        {"name": "names", "dataType": ["text[]"]},
+                    ],
+                }
+            ],
+        },
+    )
+
+    uuid_ = uuid.uuid4()
+    with client.batch as batch:
+        batch.add_data_object(
+            class_name="BatchTestNested",
+            data_object={"nested": {"name": "nested", "names": ["nested1", "nested2"]}},
+            uuid=uuid_,
+        )
+
+    obj = client.data_object.get_by_id(uuid_, class_name="BatchTestNested")
+    assert obj["properties"]["nested"] == {"name": "nested", "names": ["nested1", "nested2"]}

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -4,8 +4,8 @@ import pytest
 
 import weaviate
 
-GIT_HASH = "4b98dfa"
-SERVER_VERSION = "1.21.3"
+GIT_HASH = "4dc2c30"
+SERVER_VERSION = "1.21.4"
 NODE_NAME = "node1"
 NUM_OBJECT = 10
 

--- a/integration/test_crud.py
+++ b/integration/test_crud.py
@@ -879,3 +879,116 @@ def test_tenants():
             tenant=tenants[i].name,
         )
         assert not exists
+
+
+@pytest.mark.parametrize(
+    "prop_defs,props",
+    [
+        (
+            {
+                "dataType": ["text"],
+                "name": "name",
+            },
+            {
+                "name": "test",
+            },
+        ),
+        (
+            {
+                "dataType": ["text[]"],
+                "name": "names",
+            },
+            {
+                "names": ["test1", "test2"],
+            },
+        ),
+        (
+            {
+                "dataType": ["int"],
+                "name": "age",
+            },
+            {
+                "age": 42,
+            },
+        ),
+        (
+            {
+                "dataType": ["int[]"],
+                "name": "ages",
+            },
+            {
+                "ages": [42, 43],
+            },
+        ),
+        (
+            {
+                "dataType": ["number"],
+                "name": "height",
+            },
+            {
+                "height": 1.80,
+            },
+        ),
+        (
+            {
+                "dataType": ["number[]"],
+                "name": "heights",
+            },
+            {
+                "heights": [1.00, 1.80],
+            },
+        ),
+        (
+            {
+                "dataType": ["boolean"],
+                "name": "isTall",
+            },
+            {
+                "isTall": True,
+            },
+        ),
+        (
+            {
+                "dataType": ["boolean[]"],
+                "name": "areTall",
+            },
+            {
+                "areTall": [False, True],
+            },
+        ),
+        (
+            {
+                "dataType": ["date"],
+                "name": "birthday",
+            },
+            {
+                "birthday": "2021-01-01T00:00:00Z",
+            },
+        ),
+        (
+            {
+                "dataType": ["date[]"],
+                "name": "birthdays",
+            },
+            {
+                "birthdays": ["2021-01-01T00:00:00Z", "2021-01-02T00:00:00Z"],
+            },
+        ),
+    ],
+)
+def test_nested_object_datatype(prop_defs: dict, props: dict):
+    client = weaviate.Client("http://localhost:8080")
+    client.schema.delete_all()
+    client.schema.create_class(
+        {
+            "class": "A",
+            "properties": [
+                {"name": "nested", "dataType": ["object"], "nestedProperties": [prop_defs]},
+            ],
+            "vectorizer": "none",
+        }
+    )
+
+    uuid_ = client.data_object.create({"nested": props}, "A")
+    obj = client.data_object.get_by_id(uuid_, class_name="A")
+    assert obj["properties"]["nested"] == props

--- a/integration/test_schema.py
+++ b/integration/test_schema.py
@@ -46,7 +46,7 @@ def test_create_class_with_implicit_and_explicit_replication_factor(
 
 
 @pytest.mark.parametrize("data_type", ["uuid", "uuid[]"])
-def test_uuid_datatype(client, data_type):
+def test_uuid_datatype(client: weaviate.Client, data_type: str):
     single_class = {"class": "UuidTest", "properties": [{"dataType": [data_type], "name": "heat"}]}
 
     client.schema.create_class(single_class)
@@ -56,8 +56,53 @@ def test_uuid_datatype(client, data_type):
     client.schema.delete_class("UuidTest")
 
 
+@pytest.mark.parametrize("object_", ["object", "object[]"])
+@pytest.mark.parametrize(
+    "nested",
+    [
+        {
+            "dataType": ["text"],
+            "name": "name",
+        },
+        {"dataType": ["text[]"], "name": "names"},
+        {"dataType": ["int"], "name": "age"},
+        {"dataType": ["int[]"], "name": "ages"},
+        {"dataType": ["number"], "name": "weight"},
+        {"dataType": ["number[]"], "name": "weights"},
+        {"dataType": ["boolean"], "name": "isAlive"},
+        {"dataType": ["boolean[]"], "name": "areAlive"},
+        {"dataType": ["date"], "name": "birthDate"},
+        {"dataType": ["date[]"], "name": "birthDates"},
+        {"dataType": ["uuid"], "name": "uuid"},
+        {"dataType": ["uuid[]"], "name": "uuids"},
+        {"dataType": ["blob"], "name": "blob"},
+        {
+            "dataType": ["object"],
+            "name": "object",
+            "nestedProperties": [{"dataType": ["text"], "name": "name"}],
+        },
+        {
+            "dataType": ["object[]"],
+            "name": "objects",
+            "nestedProperties": [{"dataType": ["text"], "name": "name"}],
+        },
+    ],
+)
+def test_object_datatype(client: weaviate.Client, object_: str, nested: dict):
+    single_class = {
+        "class": "ObjectTest",
+        "properties": [{"dataType": [object_], "name": "heat", "nestedProperties": [nested]}],
+    }
+
+    client.schema.create_class(single_class)
+    created_class = client.schema.get("ObjectTest")
+    assert created_class["class"] == "ObjectTest"
+
+    client.schema.delete_class("ObjectTest")
+
+
 @pytest.mark.parametrize("tokenization", ["word", "whitespace", "lowercase", "field"])
-def test_tokenization(client, tokenization):
+def test_tokenization(client: weaviate.Client, tokenization):
     single_class = {
         "class": "TokenTest",
         "properties": [{"dataType": ["text"], "name": "heat", "tokenization": tokenization}],

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -61,6 +61,8 @@ _PRIMITIVE_WEAVIATE_TYPES_SET = {
     "phoneNumber",
     "uuid",
     "uuid[]",
+    "object",
+    "object[]",
 }
 
 


### PR DESCRIPTION
This PR adds the `object` and `object[]` data types to the allowed types when users define their schema. It then also provides a number of tests to ensure that the functionality from the client is as expected using these new data types.

@antas-marcin, please let me know if I'm missing any specific implementation with these data types that are not covered by the tests!