### PR TITLE
add tenant to failed objects

### DIFF
--- a/weaviate/batch/requests.py
+++ b/weaviate/batch/requests.py
@@ -330,5 +330,6 @@ class ObjectsBatchRequest(BatchRequest):
                 class_name=obj["class"],
                 uuid=obj["id"],
                 vector=obj.get("vector", None),
+                tenant=obj.get("tenant", None),
             )
         return successful_responses


### PR DESCRIPTION
This PR fixes an issue whereby a failed batch insertion of an object with multi-tenancy would subsequently retry the object without its tenant specified