### PR TITLE
Bump embedded to 1.22.3

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+Version 3.25.3
+--------------
+This patch version includes
+
+- Bump of the default version for Weaviate Embedded DB to v1.22.3
+
 Version 3.25.2
 --------------
 This patch version includes

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -33,7 +33,7 @@ DEFAULT_GRPC_PORT = 50060
 class EmbeddedOptions:
     persistence_data_path: str = os.environ.get("XDG_DATA_HOME", DEFAULT_PERSISTENCE_DATA_PATH)
     binary_path: str = os.environ.get("XDG_CACHE_HOME", DEFAULT_BINARY_PATH)
-    version: str = "1.22.0"
+    version: str = "1.22.3"
     port: int = DEFAULT_PORT
     hostname: str = "127.0.0.1"
     additional_env_vars: Optional[Dict[str, str]] = None


### PR DESCRIPTION
This PR bumps the version of EmbeddedDB to the latest Weaviate