### PR TITLE
Reimplement `connect_to_wcs` helper function

### DIFF
--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -139,8 +139,12 @@ class ConnectionParams(BaseModel):
 
     @model_validator(mode="after")
     def _check_port_collision(self) -> ConnectionParams:
-        if self.grpc is not None and self.http.port == self.grpc.port:
-            raise ValueError("http.port and grpc.port must be different")
+        if (
+            self.grpc is not None
+            and self.http.host == self.grpc.host
+            and self.http.port == self.grpc.port
+        ):
+            raise ValueError("http.port and grpc.port must be different if using the same host")
         return self
 
     @property

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -1,3 +1,6 @@
+"""Helper functions for creating a new WeaviateClient in common scenarios."""
+from socket import gethostbyname, gaierror
+from urllib.parse import urlparse
 from typing import Optional, Tuple
 
 from weaviate.auth import AuthCredentials
@@ -5,10 +8,11 @@ from weaviate.client import WeaviateClient
 from weaviate.config import AdditionalConfig
 from weaviate.connect.connection import ConnectionParams, ProtocolParams
 from weaviate.embedded import EmbeddedOptions
+from weaviate.exceptions import WeaviateGrpcUnavailable
 
 
 def connect_to_wcs(
-    cluster_id: str,
+    cluster_url: str,
     auth_credentials: Optional[AuthCredentials],
     headers: Optional[dict] = None,
     timeout: Tuple[int, int] = (10, 60),
@@ -17,8 +21,8 @@ def connect_to_wcs(
     Connect to your own Weaviate Cloud Service (WCS) instance.
 
     Arguments:
-        `cluster_id`
-            The WCS cluster id to connect to.
+        `cluster_url`
+            The WCS cluster URL or hostname to connect to.
         `auth_credentials`
             The credentials to use for authentication with your WCS instance. This can be an API key, in which case use `weaviate.auth.AuthApiKey`,
             a bearer token, in which case use `weaviate.auth.AuthBearerToken`, a client secret, in which case use `weaviate.auth.AuthClientCredentials`
@@ -33,16 +37,24 @@ def connect_to_wcs(
         `weaviate.WeaviateClient`
             The client connected to the cluster with the required parameters set appropriately.
     """
-    raise NotImplementedError("WCS doesn't support gRPC yet")
-    # return WeaviateClient(
-    #     connection_params=ConnectionParams(
-    #         http=ProtocolParams(host=f"{cluster_id}.weaviate.network", port=443, secure=True),
-    #         grpc=ProtocolParams(host=f"{cluster_id}.weaviate.network", port=50051, secure=True),
-    #     ),
-    #     auth_client_secret=auth_credentials,
-    #     additional_headers=headers,
-    #     additional_config=AdditionalConfig(timeout=timeout),
-    # )
+    if cluster_url.startswith("http"):
+        # Handle the common case of copy/pasting a URL instead of the hostname.
+        cluster_url = urlparse(cluster_url).netloc
+    # Check the grpc- endpoint is available for this cluster:
+    grpc_host = f"grpc-{cluster_url}"
+    try:
+        gethostbyname(grpc_host)
+    except gaierror as exc:
+        raise WeaviateGrpcUnavailable() from exc
+    return WeaviateClient(
+        connection_params=ConnectionParams(
+            http=ProtocolParams(host=cluster_url, port=443, secure=True),
+            grpc=ProtocolParams(host=grpc_host, port=443, secure=True),
+        ),
+        auth_client_secret=auth_credentials,
+        additional_headers=headers,
+        additional_config=AdditionalConfig(timeout=timeout),
+    )
 
 
 def connect_to_local(

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -47,7 +47,7 @@ def connect_to_wcs(
         gethostbyname(grpc_host)
     except gaierror as exc:
         raise WeaviateGrpcUnavailable(
-            "The client was unable to resolve the gRPC endpoint of your WCS cluster!"
+            "the client was unable to resolve the gRPC endpoint of your WCS cluster!"
         ) from exc
     # Some WCS regions have wildcard DNS, so we can get a valid DNS response even
     # without a grpc server.
@@ -56,7 +56,7 @@ def connect_to_wcs(
     resp = requests.get(f"https://{grpc_host}:443/", timeout=timeout)
     if resp.status_code == 404:
         raise WeaviateGrpcUnavailable(
-            "The client was unable to resolve the proxy of gRPC endpoint of your WCS cluster!"
+            "your cluster may need upgrading to the latest Weaviate version to support gRPC."
         )
     return WeaviateClient(
         connection_params=ConnectionParams(

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -46,14 +46,18 @@ def connect_to_wcs(
     try:
         gethostbyname(grpc_host)
     except gaierror as exc:
-        raise WeaviateGrpcUnavailable() from exc
+        raise WeaviateGrpcUnavailable(
+            "The client was unable to resolve the gRPC endpoint of your WCS cluster!"
+        ) from exc
     # Some WCS regions have wildcard DNS, so we can get a valid DNS response even
     # without a grpc server.
     # An ordinary https GET will get a 415 from the grpc server if present
     # but (usefully for us) a simple 404 from the proxy if there is no grpc backend.
     resp = requests.get(f"https://{grpc_host}:443/", timeout=timeout)
     if resp.status_code == 404:
-        raise WeaviateGrpcUnavailable()
+        raise WeaviateGrpcUnavailable(
+            "The client was unable to resolve the proxy of gRPC endpoint of your WCS cluster!"
+        )
     return WeaviateClient(
         connection_params=ConnectionParams(
             http=ProtocolParams(host=cluster_url, port=443, secure=True),

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -215,6 +215,6 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
 class WeaviateGrpcUnavailable(WeaviateBaseError):
     """Is raised when a gRPC-backed query is made with no gRPC connection present."""
 
-    def __init__(self) -> None:
-        msg = """gRPC is not available. Please make sure that gRPC is configured correctly in the client and on the server."""
+    def __init__(self, message: str = "") -> None:
+        msg = f"""gRPC is not available. Please make sure that gRPC is configured correctly in the client and on the server: {message}"""
         super().__init__(msg)


### PR DESCRIPTION
This PR, developed by @mikewyer, reimplements the `connect_to_wcs` helper function since the introduction of full support for gRPC in WCS. 

- It fixes a data validation bug within `ConnectionParams` associated with checking port collision when the hosts are different.
- It also adds connection validation to the function so that the gRPC connection is tested before the client is successfully instantiated. In its current form, this makes it a blocking function since it makes sync I/O calls to WCS. When replicating this method for the async client, this should be taken into account.
- In these validation steps, a verbose error message string is added to help in potential debugging scenarios.
- Finally, it renames `cluster_id` to `cluster_url` for ease of use and an improved UX for users when interacting with their WCS instance through its address. Nuances of the raw URL mean passing a full URL is easier than the specific cluster ID.