### PR TITLE
[Feature] Add support for `text2vec-aws` and `generative-aws`

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -543,7 +543,7 @@ TEST_CONFIG_WITH_GENERATIVE_MODULE = [
     (
         Configure.Generative.aws(model="cohere.command-light-text-v14", region="us-east-1"),
         {
-            "generative-cohere": {
+            "generative-aws": {
                 "model": "cohere.command-light-text-v14",
                 "region": "us-east-1",
             }

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -149,6 +149,20 @@ TEST_CONFIG_WITH_MODULE_PARAMETERS = [
         },
     ),
     (
+        Configure.Vectorizer.text2vec_aws(
+            vectorize_class_name=False,
+            model="cohere.embed-english-v3",
+            region="us-east-1"
+        ),
+        {
+            "text2vec-aws": {
+                "vectorizeClassName": False,
+                "model": "cohere.embed-english-v3",
+                "region": "us-east-1",
+            }
+        },
+    ),
+    (
         Configure.Vectorizer.text2vec_openai(),
         {
             "text2vec-openai": {
@@ -525,6 +539,18 @@ TEST_CONFIG_WITH_GENERATIVE_MODULE = [
                 "temperature": 0.5,
                 "topK": 10,
                 "topP": 0.5,
+            }
+        },
+    ),
+    (
+        Configure.Generative.aws(
+            model="cohere.command-light-text-v14",
+            region="us-east-1"
+        ),
+        {
+            "generative-cohere": {
+                "model": "cohere.command-light-text-v14",
+                "region": "us-east-1",
             }
         },
     ),

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -150,9 +150,7 @@ TEST_CONFIG_WITH_MODULE_PARAMETERS = [
     ),
     (
         Configure.Vectorizer.text2vec_aws(
-            vectorize_class_name=False,
-            model="cohere.embed-english-v3",
-            region="us-east-1"
+            vectorize_class_name=False, model="cohere.embed-english-v3", region="us-east-1"
         ),
         {
             "text2vec-aws": {
@@ -543,10 +541,7 @@ TEST_CONFIG_WITH_GENERATIVE_MODULE = [
         },
     ),
     (
-        Configure.Generative.aws(
-            model="cohere.command-light-text-v14",
-            region="us-east-1"
-        ),
+        Configure.Generative.aws(model="cohere.command-light-text-v14", region="us-east-1"),
         {
             "generative-cohere": {
                 "model": "cohere.command-light-text-v14",

--- a/weaviate/classes.py
+++ b/weaviate/classes.py
@@ -13,6 +13,7 @@ from weaviate.collections.classes.config import (
 )
 from weaviate.collections.classes.data import (
     DataObject,
+    DataReference,
 )
 from weaviate.collections.classes.filters import Filter
 from weaviate.collections.classes.grpc import (
@@ -35,6 +36,7 @@ __all__ = [
     "Reconfigure",
     "CrossReference",
     "DataObject",
+    "DataReference",
     "DataType",
     "Filter",
     "HybridFusion",

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -721,12 +721,15 @@ class _Text2VecAWSConfig(_VectorizerConfigCreate):
 CohereModel = Literal[
     "embed-multilingual-v2.0",
     "embed-multilingual-v3.0",
+    "embed-multilingual-light-v3.0",
     "small",
     "medium",
     "large",
     "multilingual-22-12",
     "embed-english-v2.0",
     "embed-english-light-v2.0",
+    "embed-english-v3.0",
+    "embed-english-light-v3.0"
 ]
 CohereTruncation = Literal["RIGHT", "NONE"]
 

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -695,7 +695,6 @@ class _Text2VecContextionaryConfig(_VectorizerConfigCreate):
     vectorizeClassName: bool
 
 
-
 AWSModel = Literal[
     "amazon.titan-embed-text-v1",
     "cohere.embed-english-v3",
@@ -721,7 +720,7 @@ CohereModel = Literal[
     "embed-english-v2.0",
     "embed-english-light-v2.0",
     "embed-english-v3.0",
-    "embed-english-light-v3.0"
+    "embed-english-light-v3.0",
 ]
 CohereTruncation = Literal["NONE", "START", "END", "LEFT", "RIGHT"]
 
@@ -1058,9 +1057,7 @@ class _Vectorizer:
             `pydantic.ValidationError` if `model` or `truncate` are not valid values from the `CohereModel` and `CohereTruncate` types.
         """
         return _Text2VecAWSConfig(
-            model=model,
-            region=region,
-            vectorizeClassName=vectorize_class_name
+            model=model, region=region, vectorizeClassName=vectorize_class_name
         )
 
     @staticmethod

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -723,7 +723,7 @@ CohereModel = Literal[
     "embed-english-v3.0",
     "embed-english-light-v3.0"
 ]
-CohereTruncation = Literal["RIGHT", "NONE"]
+CohereTruncation = Literal["NONE", "START", "END", "LEFT", "RIGHT"]
 
 
 class _Text2VecCohereConfig(_VectorizerConfigCreate):

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -472,10 +472,6 @@ class _GenerativeAWSConfig(_GenerativeConfigCreate):
     model: str
     region: str
 
-    def _to_dict(self) -> Dict[str, Any]:
-        ret_dict = super()._to_dict()
-        return ret_dict
-
 
 class _VectorizerConfigCreate(_ConfigCreateModel):
     vectorizer: Vectorizer
@@ -712,10 +708,6 @@ class _Text2VecAWSConfig(_VectorizerConfigCreate):
     model: AWSModel
     region: str
     vectorizeClassName: bool
-
-    def _to_dict(self) -> Dict[str, Any]:
-        ret_dict = super()._to_dict()
-        return ret_dict
 
 
 CohereModel = Literal[

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -97,6 +97,8 @@ class Vectorizer(str, Enum):
     Attributes:
         `NONE`
             No vectorizer.
+        `TEXT2VEC_AWS`
+            Weaviate module backed by AWS text-based embedding models.
         `TEXT2VEC_COHERE`
             Weaviate module backed by Cohere text-based embedding models.
         `TEXT2VEC_CONTEXTIONARY`
@@ -122,6 +124,7 @@ class Vectorizer(str, Enum):
     """
 
     NONE = "none"
+    TEXT2VEC_AWS = "text2vec-aws"
     TEXT2VEC_COHERE = "text2vec-cohere"
     TEXT2VEC_CONTEXTIONARY = "text2vec-contextionary"
     TEXT2VEC_GPT4ALL = "text2vec-gpt4all"
@@ -148,11 +151,14 @@ class GenerativeSearches(str, Enum):
             Weaviate module backed by Cohere generative models.
         `PALM`
             Weaviate module backed by PaLM generative models.
+        `AWS`
+            Weaviate module backed by AWS Bedrock generative models.
     """
 
     OPENAI = "generative-openai"
     COHERE = "generative-cohere"
     PALM = "generative-palm"
+    AWS = "generative-aws"
 
 
 class VectorDistance(str, Enum):
@@ -459,6 +465,18 @@ class _GenerativePaLMConfig(_GenerativeConfigCreate):
         return ret_dict
 
 
+class _GenerativeAWSConfig(_GenerativeConfigCreate):
+    generative: GenerativeSearches = Field(
+        default=GenerativeSearches.AWS, frozen=True, exclude=True
+    )
+    model: str
+    region: str
+
+    def _to_dict(self) -> Dict[str, Any]:
+        ret_dict = super()._to_dict()
+        return ret_dict
+
+
 class _VectorizerConfigCreate(_ConfigCreateModel):
     vectorizer: Vectorizer
 
@@ -638,6 +656,27 @@ class _Generative:
             topP=top_p,
         )
 
+    @staticmethod
+    def aws(
+        model: str,
+        region: str,
+    ) -> _GenerativeConfigCreate:
+        """Create a `_GenerativeAWSConfig` object for use when performing AI generation using the `generative-aws` module.
+
+        See the [documentation](https://weaviate.io/developers/weaviate/modules/reader-generator-modules/generative-aws)
+        for detailed usage.
+
+        Arguments:
+            `model`
+                The model to use, REQUIRED.
+            `region`
+                The AWS region to run the model from, REQUIRED.
+        """
+        return _GenerativeAWSConfig(
+            model=model,
+            region=region,
+        )
+
 
 class _Text2VecAzureOpenAIConfig(_VectorizerConfigCreate):
     vectorizer: Vectorizer = Field(default=Vectorizer.TEXT2VEC_OPENAI, frozen=True, exclude=True)
@@ -658,6 +697,25 @@ class _Text2VecContextionaryConfig(_VectorizerConfigCreate):
         default=Vectorizer.TEXT2VEC_CONTEXTIONARY, frozen=True, exclude=True
     )
     vectorizeClassName: bool
+
+
+
+AWSModel = Literal[
+    "amazon.titan-embed-text-v1",
+    "cohere.embed-english-v3",
+    "cohere.embed-multilingual-v3",
+]
+
+
+class _Text2VecAWSConfig(_VectorizerConfigCreate):
+    vectorizer: Vectorizer = Field(default=Vectorizer.TEXT2VEC_AWS, frozen=True, exclude=True)
+    model: AWSModel
+    region: str
+    vectorizeClassName: bool
+
+    def _to_dict(self) -> Dict[str, Any]:
+        ret_dict = super()._to_dict()
+        return ret_dict
 
 
 CohereModel = Literal[
@@ -980,6 +1038,34 @@ class _Vectorizer:
         return _Ref2VecCentroidConfig(
             referenceProperties=reference_properties,
             method=method,
+        )
+
+    @staticmethod
+    def text2vec_aws(
+        model: AWSModel,
+        region: str,
+        vectorize_class_name: bool = True,
+    ) -> _VectorizerConfigCreate:
+        """Create a `Text2VecAWSConfig` object for use when vectorizing using the `text2vec-aws` model.
+
+        See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-aws)
+        for detailed usage.
+
+        Arguments:
+            `model`
+                The model to use, REQUIRED.
+            `region`
+                The AWS region to run the model from, REQUIRED.
+            `vectorize_class_name`
+                Whether to vectorize the class name. Defaults to `True`.
+
+        Raises:
+            `pydantic.ValidationError` if `model` or `truncate` are not valid values from the `CohereModel` and `CohereTruncate` types.
+        """
+        return _Text2VecAWSConfig(
+            model=model,
+            region=region,
+            vectorizeClassName=vectorize_class_name
         )
 
     @staticmethod


### PR DESCRIPTION
This PR 
- Adds support for `text2vec-aws` and `generative-aws` in the collection configuration `_Vectorizer` and `_Generative` classes.
- Updates available `text2vec-cohere` models & truncation options to correspond to https://github.com/weaviate/weaviate/blob/master/modules/text2vec-cohere/vectorizer/class_settings.go#L42
- Exposes `weaviate.collections.classes.data.DataReference` through `weaviate.classes`