### PR TITLE
use query options to determine whether results should be parsed

### DIFF
--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -16,6 +16,7 @@ from weaviate.collections.classes.grpc import (
     FromReference,
     FromReferenceMultiTarget,
     MetadataQuery,
+    METADATA,
     PROPERTIES,
     Generate,
 )
@@ -146,6 +147,28 @@ GenerativeReturn: TypeAlias = Union[_GenerativeReturn[Properties], _GenerativeRe
 GroupByReturn: TypeAlias = Union[_GroupByReturn[Properties], _GroupByReturn[TProperties]]
 
 ReturnProperties: TypeAlias = Union[PROPERTIES, Type[TProperties]]
+
+
+@dataclass
+class _QueryOptions(Generic[TProperties]):
+    include_metadata: bool
+    include_properties: bool
+    include_vector: bool
+
+    @classmethod
+    def from_input(
+        cls,
+        return_metadata: Optional[METADATA],
+        return_properties: Optional[ReturnProperties[TProperties]],
+        include_vector: bool,
+    ) -> "_QueryOptions":
+        return cls(
+            include_metadata=return_metadata is not None,
+            include_properties=not (
+                isinstance(return_properties, list) and len(return_properties) == 0
+            ),
+            include_vector=include_vector,
+        )
 
 
 class _Generative:

--- a/weaviate/collections/queries/bm25.py
+++ b/weaviate/collections/queries/bm25.py
@@ -11,6 +11,7 @@ from weaviate.collections.classes.internal import (
     GenerativeReturn,
     QueryReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _Grpc
@@ -99,7 +100,11 @@ class _BM25Query(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _BM25Generate(Generic[Properties], _Grpc[Properties]):
@@ -205,4 +210,8 @@ class _BM25Generate(Generic[Properties], _Grpc[Properties]):
                 grouped_properties=grouped_properties,
             ),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/fetch_objects.py
+++ b/weaviate/collections/queries/fetch_objects.py
@@ -15,6 +15,7 @@ from weaviate.collections.classes.internal import (
     GenerativeReturn,
     QueryReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _Grpc
@@ -103,7 +104,11 @@ class _FetchObjectsQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _FetchObjectsGenerate(Generic[Properties], _Grpc[Properties]):
@@ -207,4 +212,8 @@ class _FetchObjectsGenerate(Generic[Properties], _Grpc[Properties]):
                 grouped_properties=grouped_properties,
             ),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/hybrid.py
+++ b/weaviate/collections/queries/hybrid.py
@@ -11,6 +11,7 @@ from weaviate.collections.classes.internal import (
     GenerativeReturn,
     QueryReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _Grpc
@@ -117,7 +118,11 @@ class _HybridQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
@@ -241,4 +246,8 @@ class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
                 grouped_properties=grouped_properties,
             ),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/near_audio.py
+++ b/weaviate/collections/queries/near_audio.py
@@ -19,6 +19,7 @@ from weaviate.collections.classes.internal import (
     GroupByReturn,
     QueryReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import (
     Properties,
@@ -119,7 +120,11 @@ class _NearAudioQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
@@ -228,7 +233,11 @@ class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
@@ -343,4 +352,8 @@ class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_groupby_return(res, return_properties)
+        return self._result_to_groupby_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/near_image.py
+++ b/weaviate/collections/queries/near_image.py
@@ -16,6 +16,7 @@ from weaviate.collections.classes.internal import (
     GroupByReturn,
     QueryReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import (
     Properties,
@@ -116,7 +117,11 @@ class _NearImageQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearImageGenerate(Generic[Properties], _Grpc[Properties]):
@@ -231,7 +236,11 @@ class _NearImageGenerate(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearImageGroupBy(Generic[Properties], _Grpc[Properties]):
@@ -346,4 +355,8 @@ class _NearImageGroupBy(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_groupby_return(res, return_properties)
+        return self._result_to_groupby_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/near_object.py
+++ b/weaviate/collections/queries/near_object.py
@@ -17,6 +17,7 @@ from weaviate.collections.classes.internal import (
     GenerativeReturn,
     GroupByReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _Grpc
@@ -112,7 +113,11 @@ class _NearObjectQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearObjectGenerate(Generic[Properties], _Grpc[Properties]):
@@ -218,7 +223,11 @@ class _NearObjectGenerate(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearObjectGroupBy(Generic[Properties], _Grpc[Properties]):
@@ -330,4 +339,8 @@ class _NearObjectGroupBy(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_groupby_return(res, return_properties)
+        return self._result_to_groupby_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/near_text.py
+++ b/weaviate/collections/queries/near_text.py
@@ -18,6 +18,7 @@ from weaviate.collections.classes.internal import (
     GenerativeReturn,
     GroupByReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _Grpc
@@ -127,7 +128,11 @@ class _NearTextQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearTextGenerate(Generic[Properties], _Grpc[Properties]):
@@ -254,7 +259,11 @@ class _NearTextGenerate(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearTextGroupBy(Generic[Properties], _Grpc[Properties]):
@@ -381,4 +390,8 @@ class _NearTextGroupBy(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_groupby_return(res, return_properties)
+        return self._result_to_groupby_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/near_vector.py
+++ b/weaviate/collections/queries/near_vector.py
@@ -17,6 +17,7 @@ from weaviate.collections.classes.internal import (
     GroupByReturn,
     QueryReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import (
     Properties,
@@ -114,7 +115,11 @@ class _NearVectorQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
@@ -226,7 +231,11 @@ class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearVectorGroupBy(Generic[Properties], _Grpc[Properties]):
@@ -338,4 +347,8 @@ class _NearVectorGroupBy(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_groupby_return(res, return_properties)
+        return self._result_to_groupby_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )

--- a/weaviate/collections/queries/near_video.py
+++ b/weaviate/collections/queries/near_video.py
@@ -19,6 +19,7 @@ from weaviate.collections.classes.internal import (
     GenerativeReturn,
     GroupByReturn,
     ReturnProperties,
+    _QueryOptions,
 )
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _Grpc
@@ -114,7 +115,11 @@ class _NearVideoQuery(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_query_return(res, return_properties)
+        return self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
@@ -226,7 +231,11 @@ class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_generative_return(res, return_properties)
+        return self._result_to_generative_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
 
 
 class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
@@ -338,4 +347,8 @@ class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
         )
-        return self._result_to_groupby_return(res, return_properties)
+        return self._result_to_groupby_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )


### PR DESCRIPTION
This PR uses the user-provided options for `return_properties`, `return_metadata`, and `include_vector` to determine whether those parts of the gRPC message should be processed thereby improving performance