### PR TITLE
Replace REST get object with GRPC+filtering

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -1557,7 +1557,7 @@ def test_return_properties_with_general_typed_dict(client: weaviate.WeaviateClie
 
 def test_return_properties_with_query_specific_typed_dict_overwriting_general_typed_dict(
     client: weaviate.WeaviateClient,
-):
+) -> None:
     name = "TestReturnListWithModel"
     client.collections.delete(name)
 
@@ -1582,6 +1582,11 @@ def test_return_properties_with_query_specific_typed_dict_overwriting_general_ty
     assert len(objects) == 1
     assert objects[0].properties["int_"] == 1
     assert "ints" not in objects[0].properties
+
+    obj = collection.query.fetch_object_by_id(objects[0].uuid, return_properties=_Data)
+    assert obj is not None
+    assert "ints" not in obj.properties
+    assert obj.properties["int_"] == 1
 
 
 def test_batch_with_arrays(client: weaviate.WeaviateClient) -> None:

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -27,6 +27,7 @@ from weaviate.collections.classes.data import (
     DataObject,
 )
 from weaviate.collections.classes.grpc import (
+    FromReferenceMultiTarget,
     HybridFusion,
     FromReference,
     MetadataQuery,
@@ -35,7 +36,7 @@ from weaviate.collections.classes.grpc import (
     METADATA,
     PROPERTIES,
 )
-from weaviate.collections.classes.internal import Reference
+from weaviate.collections.classes.internal import _Reference, Reference
 from weaviate.collections.classes.tenants import Tenant, TenantActivityStatus
 from weaviate.collections.classes.types import Properties
 from weaviate.collections.data import _Data
@@ -191,7 +192,7 @@ def test_get_with_pydantic_dataclass_generic(client: weaviate.WeaviateClient):
     "which_generic",
     ["typed_dict", "dict", "none"],
 )
-def test_insert(client: weaviate.WeaviateClient, which_generic: str):
+def test_insert(client: weaviate.WeaviateClient, which_generic: str) -> None:
     name = "TestInsert"
     client.collections.delete(name)
 
@@ -216,6 +217,8 @@ def test_insert(client: weaviate.WeaviateClient, which_generic: str):
     else:
         collection = client.collections.create(**create_args)
         uuid = collection.data.insert(properties=insert_data)
+    objects = collection.query.fetch_objects()
+    assert len(objects.objects) == 1
     name = collection.query.fetch_object_by_id(uuid).properties["name"]
     assert name == insert_data["name"]
 
@@ -379,7 +382,7 @@ def test_insert_many_with_typed_dict(client: weaviate.WeaviateClient):
     client.collections.delete(name)
 
 
-def test_insert_many_with_refs(client: weaviate.WeaviateClient):
+def test_insert_many_with_refs(client: weaviate.WeaviateClient) -> None:
     name_target = "RefClassBatchTarget"
     client.collections.delete(name_target)
 
@@ -428,16 +431,31 @@ def test_insert_many_with_refs(client: weaviate.WeaviateClient):
             ),
         ]
     )
-    obj1 = collection.query.fetch_object_by_id(ret.uuids[0])
+    obj1 = collection.query.fetch_object_by_id(
+        ret.uuids[0],
+        return_properties=[
+            "name",
+            FromReference(link_on="ref_single"),
+            FromReferenceMultiTarget(link_on="ref_many", target_collection=collection.name),
+        ],
+    )
+    assert obj1 is not None
     assert obj1.properties["name"] == "some name"
-    assert obj1.properties["ref_single"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to1}"
-    assert obj1.properties["ref_single"][1]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to2}"
-    assert obj1.properties["ref_many"][0]["beacon"] == BEACON_START + f"/{name}/{uuid_from}"
+    assert isinstance(obj1.properties["ref_many"], _Reference)
+    assert isinstance(obj1.properties["ref_single"], _Reference)
 
-    obj1 = collection.query.fetch_object_by_id(ret.uuids[1])
+    obj1 = collection.query.fetch_object_by_id(
+        ret.uuids[1],
+        return_properties=[
+            "name",
+            FromReference(link_on="ref_single"),
+            FromReferenceMultiTarget(link_on="ref_many", target_collection=name_target),
+        ],
+    )
+    assert obj1 is not None
     assert obj1.properties["name"] == "some other name"
-    assert obj1.properties["ref_single"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to2}"
-    assert obj1.properties["ref_many"][0]["beacon"] == BEACON_START + f"/{name_target}/{uuid_to1}"
+    assert isinstance(obj1.properties["ref_many"], _Reference)
+    assert isinstance(obj1.properties["ref_single"], _Reference)
 
 
 def test_insert_many_error(client: weaviate.WeaviateClient):
@@ -1805,7 +1823,7 @@ def test_iterator_arguments(
             assert all(obj.metadata is None for obj in iter_)
 
 
-def test_iterator_dict_hint(client: weaviate.WeaviateClient):
+def test_iterator_dict_hint(client: weaviate.WeaviateClient) -> None:
     name = "TestIteratorTypedDict"
     client.collections.delete(name)
 

--- a/integration/test_collection_batch.py
+++ b/integration/test_collection_batch.py
@@ -13,7 +13,7 @@ from weaviate.collections.classes.config import (
     Property,
     ReferenceProperty,
 )
-from weaviate.collections.classes.internal import FromReference
+from weaviate.collections.classes.internal import _Reference, FromReference
 from weaviate.collections.classes.tenants import Tenant
 
 UUID = Union[str, uuid.UUID]
@@ -98,9 +98,8 @@ def test_add_reference(
     from_object_uuid: UUID,
     to_object_uuid: UUID,
     to_object_collection: Optional[str],
-):
+) -> None:
     """Test the `add_reference` method"""
-
     with client_sync_indexing.batch as batch:
         batch.add_object(
             properties={},
@@ -125,11 +124,16 @@ def test_add_reference(
         )
         assert batch.num_objects() == 2
         assert batch.num_references() == 1
-    objs = client_sync_indexing.collections.get("Test").query.fetch_objects().objects
-    obj = client_sync_indexing.collections.get("Test").query.fetch_object_by_id(from_object_uuid)
+    objs = (
+        client_sync_indexing.collections.get("Test")
+        .query.fetch_objects(return_properties=FromReference(link_on="test"))
+        .objects
+    )
+    obj = client_sync_indexing.collections.get("Test").query.fetch_object_by_id(
+        from_object_uuid, return_properties=FromReference(link_on="test")
+    )
     assert len(objs) == 2
-    print(obj.properties)
-    assert isinstance(obj.properties["test"][0]["beacon"], str)
+    assert isinstance(obj.properties["test"], _Reference)
 
 
 def test_add_data_object_and_get_class_shards_readiness(
@@ -210,7 +214,7 @@ def test_add_object_batch_with_tenant(client_sync_indexing: weaviate.WeaviateCli
         client_sync_indexing.collections.delete(name)
 
 
-def test_add_ref_batch_with_tenant(client_sync_indexing: weaviate.WeaviateClient):
+def test_add_ref_batch_with_tenant(client_sync_indexing: weaviate.WeaviateClient) -> None:
     client_sync_indexing.collections.delete_all()
 
     # create two classes and add 5 tenants each
@@ -269,21 +273,21 @@ def test_add_ref_batch_with_tenant(client_sync_indexing: weaviate.WeaviateClient
         ret_obj = (
             client_sync_indexing.collections.get(collections[1])
             .with_tenant(obj[1])
-            .query.fetch_object_by_id(obj[0])
+            .query.fetch_object_by_id(
+                obj[0], return_properties=["tenantAsProp", FromReference(link_on="ref")]
+            )
         )
+        assert ret_obj is not None
         assert ret_obj.properties["tenantAsProp"] == obj[1]
-        assert (
-            ret_obj.properties["ref"][0]["beacon"]
-            == f"weaviate://localhost/{collections[0]}/{objects_class0[i]}"
-        )
+        assert ret_obj.properties["ref"].objects[0].uuid == objects_class0[i]
 
     for name in reversed(collections):
         client_sync_indexing.collections.delete(name)
 
 
-def test_add_ten_thousand_data_objects(client_sync_indexing: weaviate.WeaviateClient):
+def test_add_thousand_data_objects(client_sync_indexing: weaviate.WeaviateClient):
     """Test adding ten thousand data objects"""
-    nr_objects = 10000
+    nr_objects = 1000
     client_sync_indexing.batch.configure(num_workers=4)
     with client_sync_indexing.batch as batch:
         for i in range(nr_objects):
@@ -318,7 +322,7 @@ def make_refs(uuids: List[uuid.UUID]) -> List[dict]:
 
 def test_add_one_hundred_objects_and_references_between_all(
     client_sync_indexing: weaviate.WeaviateClient,
-):
+) -> None:
     """Test adding one hundred objects and references between all of them"""
 
     nr_objects = 100
@@ -419,7 +423,7 @@ def test_manual_batching(client_sync_indexing: weaviate.WeaviateClient):
     assert len(objs) == 10
 
 
-def test_add_1000_objects_with_async_indexing_and_wait(
+def test_add_100_objects_with_async_indexing_and_wait(
     client_async_indexing: weaviate.WeaviateClient,
 ) -> None:
     name = "BatchTestAsyncTenants"
@@ -456,7 +460,7 @@ def test_add_1000_objects_with_async_indexing_and_wait(
 @pytest.mark.skip(
     reason="This test flakes when the number is too low and brakes if too high due to gRPC message sizing. Needs to be fixed."
 )
-def test_add_1000000_objects_with_async_indexing_and_dont_wait(
+def test_add_100000_objects_with_async_indexing_and_dont_wait(
     client_async_indexing: weaviate.WeaviateClient,
 ):
     name = "BatchTestAsyncTenants"
@@ -468,7 +472,7 @@ def test_add_1000000_objects_with_async_indexing_and_dont_wait(
             Property(name="text", data_type=DataType.TEXT),
         ],
     )
-    nr_objects = 1000000
+    nr_objects = 100000
     objs = [
         {
             "collection": name,
@@ -489,7 +493,7 @@ def test_add_1000000_objects_with_async_indexing_and_dont_wait(
     assert old_client.schema.get_class_shards(name)[0]["vectorQueueSize"] > 0
 
 
-def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_all(
+def test_add_100_tenant_objects_with_async_indexing_and_wait_for_all(
     client_async_indexing: weaviate.WeaviateClient,
 ):
     name = "BatchTestAsyncTenants"
@@ -504,7 +508,7 @@ def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_all(
     )
     tenants = [Tenant(name="tenant" + str(i)) for i in range(5)]
     test.tenants.create(tenants)
-    nr_objects = 1000
+    nr_objects = 100
     objs = [
         {
             "collection": name,
@@ -528,7 +532,7 @@ def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_all(
         assert shard["vectorQueueSize"] == 0
 
 
-def test_add_10000_tenant_objects_with_async_indexing_and_wait_for_only_one(
+def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_only_one(
     client_async_indexing: weaviate.WeaviateClient,
 ):
     name = "BatchTestAsyncTenants"
@@ -543,7 +547,7 @@ def test_add_10000_tenant_objects_with_async_indexing_and_wait_for_only_one(
     )
     tenants = [Tenant(name="tenant" + str(i)) for i in range(2)]
     test.tenants.create(tenants)
-    nr_objects = 10000
+    nr_objects = 1000
     objs = [
         {
             "collection": name,

--- a/profiling/test_profiling.py
+++ b/profiling/test_profiling.py
@@ -106,9 +106,36 @@ def test_get_float_properties(client: weaviate.WeaviateClient) -> None:
     client.collections.delete(name)
 
 
+def test_object_by_id(client: weaviate.WeaviateClient) -> None:
+    name = "TestProfileObjectByID"
+    client.collections.delete(name)
+
+    col = client.collections.create(
+        name=name,
+        properties=[
+            Property(name="index", data_type=DataType.INT),
+        ],
+        vectorizer_config=Configure.Vectorizer.none(),
+    )
+
+    col = client.collections.get(name)
+
+    batchReturn = col.data.insert_many([{"index": i} for i in range(1000)])
+
+    for i in range(1000):
+        obj = col.query.fetch_object_by_id(batchReturn.uuids[i])
+        assert obj is not None
+        assert obj.properties["index"] == i
+        assert obj.uuid == batchReturn.uuids[i]
+
+
 def test_benchmark_get_vector(benchmark: Any, client: weaviate.WeaviateClient) -> None:
     benchmark(test_get_vector, client)
 
 
 def test_benchmark_get_float_properties(benchmark: Any, client: weaviate.WeaviateClient) -> None:
     benchmark(test_get_float_properties, client)
+
+
+def test_benchmark_get_object_by_id(benchmark: Any, client: weaviate.WeaviateClient) -> None:
+    benchmark(test_object_by_id, client)

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -96,6 +96,21 @@ class _Object(Generic[P]):
 
 
 @dataclass
+class _MetadataSingleObjectReturn:
+    creation_time_unix: int
+    last_update_time_unix: int
+    is_consistent: Optional[bool]
+
+
+@dataclass
+class _ObjectSingleReturn(Generic[P]):
+    uuid: uuid_package.UUID
+    metadata: _MetadataSingleObjectReturn
+    properties: P
+    vector: Optional[List[float]]
+
+
+@dataclass
 class _GroupByObject(Generic[P], _Object[P]):
     belongs_to_group: str
 

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -158,6 +158,9 @@ class _RawGQLReturn:
 
 
 QueryReturn: TypeAlias = Union[_QueryReturn[Properties], _QueryReturn[TProperties]]
+QuerySingleObjectReturn: TypeAlias = Union[
+    _ObjectSingleReturn[Properties], _ObjectSingleReturn[TProperties]
+]
 GenerativeReturn: TypeAlias = Union[_GenerativeReturn[Properties], _GenerativeReturn[TProperties]]
 GroupByReturn: TypeAlias = Union[_GroupByReturn[Properties], _GroupByReturn[TProperties]]
 

--- a/weaviate/collections/collection.py
+++ b/weaviate/collections/collection.py
@@ -79,7 +79,7 @@ class Collection(_CollectionBase, Generic[Properties]):
         )
         """This namespace includes all the querying methods available to you when using Weaviate's querying group-by capabilities."""
         self.query = _QueryCollection[Properties](
-            connection, self.name, self.data, consistency_level, tenant, type_
+            connection, self.name, consistency_level, tenant, type_
         )
         """This namespace includes all the querying methods available to you when using Weaviate's standard query capabilities."""
         self.tenants = _Tenants(connection, self.name)

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -455,6 +455,10 @@ class _Grpc(Generic[Properties]):
             )  # is sourced from collection-specific generic
         else:
             assert return_properties is not None
+            if not is_typeddict(return_properties):
+                raise TypeError(
+                    f"return_properties must only be a TypedDict or PROPERTIES within this context but is {type(return_properties)}"
+                )
             return _extract_properties_from_data_model(
                 return_properties
             )  # is sourced from query-specific generic

--- a/weaviate/collections/queries/fetch_object_by_id.py
+++ b/weaviate/collections/queries/fetch_object_by_id.py
@@ -1,28 +1,50 @@
-from typing import Generic, Optional
+from typing import Generic, Optional, Type, cast, overload
 
 from weaviate.collections.classes.filters import (
     FilterMetadata,
 )
-from weaviate.collections.classes.grpc import MetadataQuery
+from weaviate.collections.classes.grpc import PROPERTIES, MetadataQuery
 
 from weaviate.collections.classes.internal import (
     _MetadataSingleObjectReturn,
     _ObjectSingleReturn,
+    QuerySingleObjectReturn,
     ReturnProperties,
     _QueryOptions,
 )
-from weaviate.collections.classes.types import Properties
+from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _Grpc
 from weaviate.types import UUID
+from typing_extensions import is_typeddict
 
 
 class _FetchObjectByIDQuery(Generic[Properties], _Grpc[Properties]):
+    @overload
     def fetch_object_by_id(
         self,
         uuid: UUID,
-        return_properties: Optional[ReturnProperties[Properties]] = None,
         include_vector: bool = False,
-    ) -> Optional[_ObjectSingleReturn[Properties]]:
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+    ) -> _ObjectSingleReturn[Properties]:
+        ...
+
+    @overload
+    def fetch_object_by_id(
+        self,
+        uuid: UUID,
+        include_vector: bool = False,
+        *,
+        return_properties: Type[TProperties],
+    ) -> _ObjectSingleReturn[TProperties]:
+        ...
+
+    def fetch_object_by_id(
+        self,
+        uuid: UUID,
+        include_vector: bool = False,
+        return_properties: Optional[ReturnProperties[TProperties]] = None,
+    ) -> Optional[QuerySingleObjectReturn[Properties, TProperties]]:
         """Retrieve an object from the server by its UUID.
 
         Arguments:
@@ -62,13 +84,25 @@ class _FetchObjectByIDQuery(Generic[Properties], _Grpc[Properties]):
         assert obj.metadata.creation_time_unix is not None
         assert obj.metadata.last_update_time_unix is not None
 
-        return _ObjectSingleReturn(
-            uuid=obj.uuid,
-            vector=obj.vector,
-            properties=obj.properties,
-            metadata=_MetadataSingleObjectReturn(
-                creation_time_unix=obj.metadata.creation_time_unix,
-                last_update_time_unix=obj.metadata.last_update_time_unix,
-                is_consistent=obj.metadata.is_consistent,
-            ),
-        )
+        if is_typeddict(return_properties):
+            return _ObjectSingleReturn[TProperties](
+                uuid=obj.uuid,
+                vector=obj.vector,
+                properties=cast(TProperties, obj.properties),
+                metadata=_MetadataSingleObjectReturn(
+                    creation_time_unix=obj.metadata.creation_time_unix,
+                    last_update_time_unix=obj.metadata.last_update_time_unix,
+                    is_consistent=obj.metadata.is_consistent,
+                ),
+            )
+        else:
+            return _ObjectSingleReturn[Properties](
+                uuid=obj.uuid,
+                vector=obj.vector,
+                properties=cast(Properties, obj.properties),
+                metadata=_MetadataSingleObjectReturn(
+                    creation_time_unix=obj.metadata.creation_time_unix,
+                    last_update_time_unix=obj.metadata.last_update_time_unix,
+                    is_consistent=obj.metadata.is_consistent,
+                ),
+            )

--- a/weaviate/collections/queries/fetch_object_by_id.py
+++ b/weaviate/collections/queries/fetch_object_by_id.py
@@ -1,0 +1,59 @@
+from typing import Generic, Optional
+
+from weaviate.collections.classes.filters import (
+    FilterMetadata,
+)
+from weaviate.collections.classes.grpc import MetadataQuery
+
+from weaviate.collections.classes.internal import (
+    _Object,
+    ReturnProperties,
+    _QueryOptions,
+)
+from weaviate.collections.classes.types import Properties
+from weaviate.collections.queries.base import _Grpc
+from weaviate.types import UUID
+
+
+class _FetchObjectByIDQuery(Generic[Properties], _Grpc[Properties]):
+    def fetch_object_by_id(
+        self,
+        uuid: UUID,
+        return_properties: Optional[ReturnProperties[Properties]] = None,
+        include_vector: bool = False,
+    ) -> Optional[_Object[Properties]]:
+        """Retrieve an object from the server by its UUID.
+
+        Arguments:
+            `uuid`
+                The UUID of the object to retrieve, REQUIRED.
+            `return_properties`
+                The properties to return for each object.
+            `include_vector`
+                Whether to include the vector in the returned object.
+
+        Raises:
+            `weaviate.exceptions.WeaviateQueryException`:
+                If the network connection to Weaviate fails.
+            `weaviate.exceptions.WeaviateInsertInvalidPropertyError`:
+                If a property is invalid. I.e., has name `id` or `vector`, which are reserved.
+        """
+        return_metadata = MetadataQuery(
+            creation_time_unix=True, last_update_time_unix=True, is_consistent=True
+        )
+        res = self._query().get(
+            limit=1,
+            filters=FilterMetadata.ById.equal(uuid),
+            return_metadata=self._parse_return_metadata(return_metadata, include_vector),
+            return_properties=self._parse_return_properties(return_properties),
+        )
+        objects = self._result_to_query_return(
+            res,
+            return_properties,
+            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+        )
+
+        if len(objects.objects) == 0:
+            return None
+
+        return objects.objects[0]

--- a/weaviate/collections/query.py
+++ b/weaviate/collections/query.py
@@ -6,12 +6,10 @@ from typing import (
 
 from weaviate.collections.classes.config import ConsistencyLevel
 
-from weaviate.collections.classes.internal import _Object
 from weaviate.collections.classes.types import TProperties
 
-from weaviate.collections.data import _DataCollection
-
 from weaviate.collections.queries.bm25 import _BM25Generate, _BM25Query
+from weaviate.collections.queries.fetch_object_by_id import _FetchObjectByIDQuery
 from weaviate.collections.queries.fetch_objects import _FetchObjectsGenerate, _FetchObjectsQuery
 from weaviate.collections.queries.hybrid import _HybridGenerate, _HybridQuery
 from weaviate.collections.queries.near_audio import (
@@ -46,13 +44,13 @@ from weaviate.collections.queries.near_video import (
 )
 
 from weaviate.connect import Connection
-from weaviate.types import UUID
 
 
 class _QueryCollection(
     Generic[TProperties],
     _BM25Query[TProperties],
     _FetchObjectsQuery[TProperties],
+    _FetchObjectByIDQuery[TProperties],
     _HybridQuery,
     _NearAudioQuery,
     _NearImageQuery,
@@ -65,35 +63,11 @@ class _QueryCollection(
         self,
         connection: Connection,
         name: str,
-        rest_query: _DataCollection[TProperties],
         consistency_level: Optional[ConsistencyLevel],
         tenant: Optional[str],
         type_: Optional[Type[TProperties]],
     ):
         super().__init__(connection, name, consistency_level, tenant, type_)
-        self.__data = rest_query
-
-    def fetch_object_by_id(
-        self, uuid: UUID, include_vector: bool = False
-    ) -> Optional[_Object[TProperties]]:
-        """Retrieve an object from the server by its UUID.
-
-        Arguments:
-            `uuid`
-                The UUID of the object to retrieve, REQUIRED.
-            `include_vector`
-                Whether to include the vector in the returned object.
-
-        Raises:
-            `weaviate.exceptions.WeaviateQueryException`:
-                If the network connection to Weaviate fails.
-            `weaviate.exceptions.WeaviateInsertInvalidPropertyError`:
-                If a property is invalid. I.e., has name `id` or `vector`, which are reserved.
-        """
-        ret = self.__data._get_by_id(uuid=uuid, include_vector=include_vector)
-        if ret is None:
-            return ret
-        return self.__data._json_to_object(ret)
 
 
 class _GenerateCollection(


### PR DESCRIPTION
- title
- Returns a different object for get_by_id. Here we know which metadata is present and can make it non-optional
- changed the runtime of a few batch-tests as it took forever