### PR TITLE
Beta/split properties and references

### DIFF
--- a/ci/docker-compose-async.yml
+++ b/ci/docker-compose-async.yml
@@ -9,7 +9,7 @@ services:
       - '8090'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - "8090:8090"
       - "50060:50051"

--- a/ci/docker-compose-azure.yml
+++ b/ci/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -26,7 +26,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - 8088:8080
       - "50059:50051"

--- a/ci/docker-compose-generative.yml
+++ b/ci/docker-compose-generative.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - 8086:8086
       - "50057:50051"

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:preview-introduce-custom-pb-properties-message-to-contain-type-aware-properties-within-search-result-7002ea3
+    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
     ports:
       - "8080:8080"
       - "50051:50051"

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -4,7 +4,7 @@ import pytest
 
 import weaviate
 
-GIT_HASH = "7002ea3"
+GIT_HASH = "b454247"
 SERVER_VERSION = "1.23.0-rc.0"
 NODE_NAME = "node1"
 NUM_OBJECT = 10

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -1675,7 +1675,7 @@ def test_optional_ref_returns(client: weaviate.WeaviateClient):
         ],
         vectorizer_config=Configure.Vectorizer.none(),
     )
-    collection.data.insert(properties={"ref": Reference.to(uuid_to1)})
+    collection.data.insert({}, references={"ref": Reference.to(uuid_to1)})
 
     objects = collection.query.fetch_objects(
         return_references=[FromReference(link_on="ref")]

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -38,7 +38,8 @@ from weaviate.collections.classes.grpc import (
 from weaviate.collections.classes.internal import Reference
 from weaviate.collections.classes.tenants import Tenant, TenantActivityStatus
 from weaviate.collections.classes.types import Properties
-from weaviate.collections.data import _Data
+
+# from weaviate.collections.data import _Data
 from weaviate.collections.iterator import ITERATOR_CACHE_SIZE
 from weaviate.exceptions import (
     InvalidDataModelException,
@@ -123,19 +124,19 @@ def test_get_with_dict_generic(client: weaviate.WeaviateClient, use_typed_dict: 
     assert isinstance(col, Collection)
 
 
-def test_data_with_data_model_with_dict_generic(client: weaviate.WeaviateClient):
-    name = "TestDataWithDictGeneric"
+# def test_data_with_data_model_with_dict_generic(client: weaviate.WeaviateClient):
+#     name = "TestDataWithDictGeneric"
 
-    class Right(TypedDict):
-        name: str
+#     class Right(TypedDict):
+#         name: str
 
-    col = client.collections.get(name)
-    assert isinstance(col, Collection)
-    data = col.data.with_data_model(Right)
-    assert isinstance(data, _Data)
+#     col = client.collections.get(name)
+#     assert isinstance(col, Collection)
+#     data = col.data.with_data_model(Right)
+#     assert isinstance(data, _Data)
 
 
-WRONG_GENERIC_ERROR_MSG = "data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"
+WRONG_GENERIC_ERROR_MSG = "properties can only be a dict type, e.g. Dict[str, Any], or a class that inherits from TypedDict"
 
 
 def test_get_with_empty_class_generic(client: weaviate.WeaviateClient):
@@ -1670,11 +1671,11 @@ def test_optional_ref_returns(client: weaviate.WeaviateClient):
     collection.data.insert(properties={"ref": Reference.to(uuid_to1)})
 
     objects = collection.query.fetch_objects(
-        return_properties=[FromReference(link_on="ref")]
+        return_references=[FromReference(link_on="ref")]
     ).objects
 
-    assert objects[0].properties["ref"].objects[0].properties["text"] == "ref text"
-    assert objects[0].properties["ref"].objects[0].uuid is not None
+    assert objects[0].references["ref"].objects[0].properties["text"] == "ref text"
+    assert objects[0].references["ref"].objects[0].uuid is not None
 
 
 @pytest.mark.parametrize(

--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -40,7 +40,7 @@ from weaviate.collections.classes.internal import _Reference, Reference
 from weaviate.collections.classes.tenants import Tenant, TenantActivityStatus
 from weaviate.collections.classes.types import Properties
 
-# from weaviate.collections.data import _Data
+from weaviate.collections.data import _Data
 from weaviate.collections.iterator import ITERATOR_CACHE_SIZE
 from weaviate.exceptions import (
     InvalidDataModelException,
@@ -124,16 +124,16 @@ def test_get_with_dict_generic(client: weaviate.WeaviateClient, use_typed_dict: 
     assert isinstance(col, Collection)
 
 
-# def test_data_with_data_model_with_dict_generic(client: weaviate.WeaviateClient):
-#     name = "TestDataWithDictGeneric"
+def test_data_with_data_model_with_dict_generic(client: weaviate.WeaviateClient):
+    name = "TestDataWithDictGeneric"
 
-#     class Right(TypedDict):
-#         name: str
+    class Right(TypedDict):
+        name: str
 
-#     col = client.collections.get(name)
-#     assert isinstance(col, Collection)
-#     data = col.data.with_data_model(Right)
-#     assert isinstance(data, _Data)
+    col = client.collections.get(name)
+    assert isinstance(col, Collection)
+    data = col.data.with_data_model(Right)
+    assert isinstance(data, _Data)
 
 
 WRONG_GENERIC_ERROR_MSG = "properties can only be a dict type, e.g. Dict[str, Any], or a class that inherits from TypedDict"

--- a/integration/test_collection_batch.py
+++ b/integration/test_collection_batch.py
@@ -126,14 +126,14 @@ def test_add_reference(
         assert batch.num_references() == 1
     objs = (
         client_sync_indexing.collections.get("Test")
-        .query.fetch_objects(return_properties=FromReference(link_on="test"))
+        .query.fetch_objects(return_references=FromReference(link_on="test"))
         .objects
     )
     obj = client_sync_indexing.collections.get("Test").query.fetch_object_by_id(
-        from_object_uuid, return_properties=FromReference(link_on="test")
+        from_object_uuid, return_references=FromReference(link_on="test")
     )
     assert len(objs) == 2
-    assert isinstance(obj.properties["test"], _Reference)
+    assert isinstance(obj.references["test"], _Reference)
 
 
 def test_add_data_object_and_get_class_shards_readiness(
@@ -274,12 +274,14 @@ def test_add_ref_batch_with_tenant(client_sync_indexing: weaviate.WeaviateClient
             client_sync_indexing.collections.get(collections[1])
             .with_tenant(obj[1])
             .query.fetch_object_by_id(
-                obj[0], return_properties=["tenantAsProp", FromReference(link_on="ref")]
+                obj[0],
+                return_properties="tenantAsProp",
+                return_references=FromReference(link_on="ref"),
             )
         )
         assert ret_obj is not None
         assert ret_obj.properties["tenantAsProp"] == obj[1]
-        assert ret_obj.properties["ref"].objects[0].uuid == objects_class0[i]
+        assert ret_obj.references["ref"].objects[0].uuid == objects_class0[i]
 
     for name in reversed(collections):
         client_sync_indexing.collections.delete(name)

--- a/integration/test_collection_batch.py
+++ b/integration/test_collection_batch.py
@@ -335,12 +335,12 @@ def test_add_one_hundred_objects_and_references_between_all(
             batch.add_reference(**ref)
     objs = (
         client_sync_indexing.collections.get("Test")
-        .query.fetch_objects(limit=nr_objects, return_properties=FromReference(link_on="test"))
+        .query.fetch_objects(limit=nr_objects, return_references=FromReference(link_on="test"))
         .objects
     )
     assert len(objs) == nr_objects
     for obj in objs:
-        assert len(obj.properties["test"].objects) == nr_objects - 1
+        assert len(obj.references["test"].objects) == nr_objects - 1
     client_sync_indexing.collections.delete("Test")
 
 

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -346,8 +346,12 @@ def test_ref_filters(
     )
 
     uuids_from = [
-        from_collection.data.insert({"ref": Reference.to(uuids_to[0]), "name": "first"}),
-        from_collection.data.insert({"ref": Reference.to(uuids_to[1]), "name": "second"}),
+        from_collection.data.insert(
+            properties={"name": "first"}, references={"ref": Reference.to(uuids_to[0])}
+        ),
+        from_collection.data.insert(
+            properties={"name": "second"}, references={"ref": Reference.to(uuids_to[1])}
+        ),
     ]
 
     objects = from_collection.query.fetch_objects(filters=weaviate_filter).objects
@@ -382,27 +386,35 @@ def test_ref_filters_multi_target(client: weaviate.WeaviateClient) -> None:
 
     uuid_from_to_target1 = from_collection.data.insert(
         {
-            "ref": Reference.to_multi_target(uuids=uuid_to, target_collection=target),
             "name": "first",
-        }
+        },
+        references={
+            "ref": Reference.to_multi_target(uuids=uuid_to, target_collection=target),
+        },
     )
     uuid_from_to_target2 = from_collection.data.insert(
         {
-            "ref": Reference.to_multi_target(uuids=uuid_to2, target_collection=target),
             "name": "second",
-        }
+        },
+        references={
+            "ref": Reference.to_multi_target(uuids=uuid_to2, target_collection=target),
+        },
     )
     from_collection.data.insert(
         {
-            "ref": Reference.to_multi_target(uuids=uuid_from_to_target1, target_collection=source),
             "name": "third",
-        }
+        },
+        references={
+            "ref": Reference.to_multi_target(uuids=uuid_from_to_target1, target_collection=source),
+        },
     )
     from_collection.data.insert(
         {
-            "ref": Reference.to_multi_target(uuids=uuid_from_to_target2, target_collection=source),
             "name": "fourth",
-        }
+        },
+        references={
+            "ref": Reference.to_multi_target(uuids=uuid_from_to_target2, target_collection=source),
+        },
     )
 
     objects = from_collection.query.fetch_objects(

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -39,7 +39,9 @@ def test_reference_add_delete_replace(client: weaviate.WeaviateClient) -> None:
     )
 
     uuid_from1 = collection.data.insert({}, uuid.uuid4())
-    uuid_from2 = collection.data.insert({"ref": Reference.to(uuids=uuid_to)}, uuid.uuid4())
+    uuid_from2 = collection.data.insert(
+        {}, references={"ref": Reference.to(uuids=uuid_to)}, uuid=uuid.uuid4()
+    )
     collection.data.reference_add(
         from_uuid=uuid_from1, from_property="ref", ref=Reference.to(uuids=uuid_to)
     )
@@ -108,7 +110,7 @@ def test_mono_references_grpc(client: weaviate.WeaviateClient):
         ],
         vectorizer_config=Configure.Vectorizer.none(),
     )
-    uuid_B = B.data.insert({"Name": "B", "a": Reference.to(uuids=uuid_A1)})
+    uuid_B = B.data.insert({"Name": "B"}, references={"a": Reference.to(uuids=uuid_A1)})
     B.data.reference_add(from_uuid=uuid_B, from_property="a", ref=Reference.to(uuids=uuid_A2))
 
     objects = B.query.bm25(
@@ -141,7 +143,7 @@ def test_mono_references_grpc(client: weaviate.WeaviateClient):
         ],
         vectorizer_config=Configure.Vectorizer.none(),
     )
-    C.data.insert({"Name": "find me", "b": Reference.to(uuids=uuid_B)})
+    C.data.insert({"Name": "find me"}, references={"b": Reference.to(uuids=uuid_B)})
 
     objects = C.query.bm25(
         query="find",
@@ -211,7 +213,7 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.WeaviateClient, level
         vectorizer_config=Configure.Vectorizer.text2vec_contextionary(vectorize_class_name=False),
     )
     B = client.collections.get("BTypedDicts", BProps)
-    uuid_B = B.data.insert(properties={"name": "B", "a": Reference.to(uuids=uuid_A1)})
+    uuid_B = B.data.insert(properties={"name": "B"}, references={"a": Reference.to(uuids=uuid_A1)})
     B.data.reference_add(
         from_uuid=uuid_B,
         from_property="a",
@@ -236,7 +238,7 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.WeaviateClient, level
         vectorizer_config=Configure.Vectorizer.text2vec_contextionary(vectorize_class_name=False),
     )
     C = client.collections.get("CTypedDicts", CProps)
-    C.data.insert(properties={"name": "find me", "b": Reference.to(uuids=uuid_B)})
+    C.data.insert(properties={"name": "find me"}, references={"b": Reference.to(uuids=uuid_B)})
 
     if level == "col-col":
         objects = (
@@ -339,14 +341,18 @@ def test_multi_references_grpc(client: weaviate.WeaviateClient):
     C.data.insert(
         {
             "Name": "first",
+        },
+        references={
             "ref": Reference.to_multi_target(uuids=uuid_A, target_collection="A"),
-        }
+        },
     )
     C.data.insert(
         {
             "Name": "second",
+        },
+        references={
             "ref": Reference.to_multi_target(uuids=uuid_B, target_collection="B"),
-        }
+        },
     )
 
     objects = C.query.bm25(
@@ -503,7 +509,9 @@ def test_references_with_string_syntax(client: weaviate.WeaviateClient):
         vectorizer_config=Configure.Vectorizer.none(),
     )
 
-    client.collections.get(name2).data.insert({"Name": "B", "ref": Reference.to(uuids=uuid_A)})
+    client.collections.get(name2).data.insert(
+        {"Name": "B"}, references={"ref": Reference.to(uuids=uuid_A)}
+    )
 
     objects = (
         client.collections.get(name2)

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -50,9 +50,9 @@ def test_reference_add_delete_replace(client: weaviate.WeaviateClient) -> None:
     assert (
         len(
             collection.query.fetch_object_by_id(
-                uuid_from1, return_properties=FromReference(link_on="ref")
+                uuid_from1, return_references=FromReference(link_on="ref")
             )
-            .properties["ref"]
+            .references["ref"]
             .objects
         )
         == 0
@@ -62,11 +62,11 @@ def test_reference_add_delete_replace(client: weaviate.WeaviateClient) -> None:
         from_uuid=uuid_from2, from_property="ref", ref=Reference.to(uuids=uuid_to)
     )
     obj = collection.query.fetch_object_by_id(
-        uuid_from2, return_properties=FromReference(link_on="ref")
+        uuid_from2, return_references=FromReference(link_on="ref")
     )
     assert obj is not None
-    assert len(obj.properties["ref"].objects) == 2
-    assert uuid_to in [x.uuid for x in obj.properties["ref"].objects]
+    assert len(obj.references["ref"].objects) == 2
+    assert uuid_to in [x.uuid for x in obj.references["ref"].objects]
 
     collection.data.reference_replace(
         from_uuid=uuid_from2, from_property="ref", ref=Reference.to(uuids=[])
@@ -74,9 +74,9 @@ def test_reference_add_delete_replace(client: weaviate.WeaviateClient) -> None:
     assert (
         len(
             collection.query.fetch_object_by_id(
-                uuid_from2, return_properties=FromReference(link_on="ref")
+                uuid_from2, return_references=FromReference(link_on="ref")
             )
-            .properties["ref"]
+            .references["ref"]
             .objects
         )
         == 0

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -83,78 +83,71 @@ def test_mono_references_grpc(client: weaviate.WeaviateClient):
         name="B",
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
-            ReferenceProperty(name="ref", target_collection="A"),
+            ReferenceProperty(name="a", target_collection="A"),
         ],
         vectorizer_config=Configure.Vectorizer.none(),
     )
-    uuid_B = B.data.insert({"Name": "B", "ref": Reference.to(uuids=uuid_A1)})
-    B.data.reference_add(from_uuid=uuid_B, from_property="ref", ref=Reference.to(uuids=uuid_A2))
+    uuid_B = B.data.insert({"Name": "B", "a": Reference.to(uuids=uuid_A1)})
+    B.data.reference_add(from_uuid=uuid_B, from_property="a", ref=Reference.to(uuids=uuid_A2))
 
     objects = B.query.bm25(
         query="B",
-        return_properties=FromReference(
-            link_on="ref",
+        return_references=FromReference(
+            link_on="a",
+            return_properties="name",
+        ),
+    ).objects
+    assert objects[0].references["a"].objects[0].properties["name"] == "A1"
+    assert objects[0].references["a"].objects[1].properties["name"] == "A2"
+
+    objects = B.query.bm25(
+        query="B",
+        return_references=FromReference(
+            link_on="a",
             return_properties=["name"],
         ),
     ).objects
-    assert objects[0].properties["ref"].objects[0].properties["name"] == "A1"
-    assert objects[0].properties["ref"].objects[1].properties["name"] == "A2"
-
-    objects = B.query.bm25(
-        query="B",
-        return_properties=[
-            FromReference(
-                link_on="ref",
-                return_properties=["name"],
-            )
-        ],
-    ).objects
-    assert objects[0].properties["ref"].objects[0].properties["name"] == "A1"
-    assert objects[0].properties["ref"].objects[0].uuid == uuid_A1
-    assert objects[0].properties["ref"].objects[1].properties["name"] == "A2"
-    assert objects[0].properties["ref"].objects[1].uuid == uuid_A2
+    assert objects[0].references["a"].objects[0].properties["name"] == "A1"
+    assert objects[0].references["a"].objects[0].uuid == uuid_A1
+    assert objects[0].references["a"].objects[1].properties["name"] == "A2"
+    assert objects[0].references["a"].objects[1].uuid == uuid_A2
 
     C = client.collections.create(
         name="C",
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
-            ReferenceProperty(name="ref", target_collection="B"),
+            ReferenceProperty(name="b", target_collection="B"),
         ],
         vectorizer_config=Configure.Vectorizer.none(),
     )
-    C.data.insert({"Name": "find me", "ref": Reference.to(uuids=uuid_B)})
+    C.data.insert({"Name": "find me", "b": Reference.to(uuids=uuid_B)})
 
     objects = C.query.bm25(
         query="find",
-        return_properties=[
-            "name",
-            FromReference(
-                link_on="ref",
-                return_properties=[
-                    "name",
-                    FromReference(
-                        link_on="ref",
-                        return_properties=["name"],
-                    ),
-                ],
-                return_metadata=MetadataQuery(last_update_time_unix=True),
+        return_properties="name",
+        return_references=FromReference(
+            link_on="b",
+            return_properties="name",
+            return_metadata=MetadataQuery(last_update_time_unix=True),
+            return_references=FromReference(
+                link_on="a",
+                return_properties="name",
             ),
-        ],
+        ),
     ).objects
     assert objects[0].properties["name"] == "find me"
-    assert objects[0].properties["ref"].objects[0].properties["name"] == "B"
-    assert objects[0].properties["ref"].objects[0].metadata.last_update_time_unix is not None
+    assert objects[0].references["b"].objects[0].properties["name"] == "B"
+    assert objects[0].references["b"].objects[0].metadata.last_update_time_unix is not None
     assert (
-        objects[0].properties["ref"].objects[0].properties["ref"].objects[0].properties["name"]
-        == "A1"
+        objects[0].references["b"].objects[0].references["a"].objects[0].properties["name"] == "A1"
     )
     assert (
-        objects[0].properties["ref"].objects[0].properties["ref"].objects[1].properties["name"]
-        == "A2"
+        objects[0].references["b"].objects[0].references["a"].objects[1].properties["name"] == "A2"
     )
 
 
-def test_mono_references_grpc_typed_dicts(client: weaviate.WeaviateClient):
+@pytest.mark.parametrize("level", ["col-col", "col-query", "query-col", "query-query"])
+def test_mono_references_grpc_typed_dicts(client: weaviate.WeaviateClient, level: str):
     client.collections.delete("ATypedDicts")
     client.collections.delete("BTypedDicts")
     client.collections.delete("CTypedDicts")
@@ -164,14 +157,18 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.WeaviateClient):
 
     class BProps(TypedDict):
         name: str
-        ref: Annotated[
-            CrossReference[AProps],
+
+    class BRefs(TypedDict):
+        a: Annotated[
+            CrossReference[AProps, None],
             ReferenceAnnotation(metadata=MetadataQuery(creation_time_unix=True)),
         ]
 
     class CProps(TypedDict):
         name: str
-        ref: Annotated[CrossReference[BProps], ReferenceAnnotation(include_vector=True)]
+
+    class CRefs(TypedDict):
+        b: Annotated[CrossReference[BProps, BRefs], ReferenceAnnotation(include_vector=True)]
 
     client.collections.create(
         name="ATypedDicts",
@@ -188,43 +185,75 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.WeaviateClient):
         name="BTypedDicts",
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
-            ReferenceProperty(name="ref", target_collection="ATypedDicts"),
+            ReferenceProperty(name="a", target_collection="ATypedDicts"),
         ],
         vectorizer_config=Configure.Vectorizer.text2vec_contextionary(vectorize_class_name=False),
     )
     B = client.collections.get("BTypedDicts", BProps)
-    uuid_B = B.data.insert(
-        properties=BProps(name="B", ref=Reference.to(uuids=uuid_A1, data_model=AProps))
-    )
+    uuid_B = B.data.insert(properties={"name": "B", "a": Reference.to(uuids=uuid_A1)})
     B.data.reference_add(
         from_uuid=uuid_B,
-        from_property="ref",
-        ref=Reference.to(uuids=uuid_A2, data_model=AProps),
+        from_property="a",
+        ref=Reference.to(uuids=uuid_A2, properties=AProps),
     )
+
+    objects = B.query.bm25(query="B", return_references=BRefs).objects
+    assert objects[0].references["a"].objects[0].properties["name"] == "A1"
+    assert objects[0].references["a"].objects[0].uuid == uuid_A1
+    assert objects[0].references["a"].objects[0].references is None
+    assert objects[0].references["a"].objects[1].properties["name"] == "A2"
+    assert objects[0].references["a"].objects[1].uuid == uuid_A2
+    assert objects[0].references["a"].objects[1].references is None
 
     client.collections.create(
         name="CTypedDicts",
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
             Property(name="Age", data_type=DataType.INT),
-            ReferenceProperty(name="ref", target_collection="BTypedDicts"),
+            ReferenceProperty(name="b", target_collection="BTypedDicts"),
         ],
         vectorizer_config=Configure.Vectorizer.text2vec_contextionary(vectorize_class_name=False),
     )
     C = client.collections.get("CTypedDicts", CProps)
-    C.data.insert(
-        properties=CProps(name="find me", ref=Reference.to(uuids=uuid_B, data_model=BProps))
-    )
+    C.data.insert(properties={"name": "find me", "b": Reference.to(uuids=uuid_B)})
 
-    objects = (
-        client.collections.get("CTypedDicts")
-        .query.bm25(
-            query="find",
-            include_vector=True,
-            return_properties=CProps,
+    if level == "col-col":
+        objects = (
+            client.collections.get("CTypedDicts", CProps, CRefs)
+            .query.bm25(query="find", include_vector=True)
+            .objects
         )
-        .objects
-    )
+    elif level == "col-query":
+        objects = (
+            client.collections.get("CTypedDicts", CProps)
+            .query.bm25(
+                query="find",
+                include_vector=True,
+                return_references=CRefs,
+            )
+            .objects
+        )
+    elif level == "query-col":
+        objects = (
+            client.collections.get("CTypedDicts", references=CRefs)
+            .query.bm25(
+                query="find",
+                include_vector=True,
+                return_properties=CProps,
+            )
+            .objects
+        )
+    else:
+        objects = (
+            client.collections.get("CTypedDicts")
+            .query.bm25(
+                query="find",
+                include_vector=True,
+                return_properties=CProps,
+                return_references=CRefs,
+            )
+            .objects
+        )
     assert (
         objects[0].properties["name"] == "find me"
     )  # happy path (in type and in return_properties)
@@ -233,35 +262,24 @@ def test_mono_references_grpc_typed_dicts(client: weaviate.WeaviateClient):
     assert (
         objects[0].properties.get("not_specified") is None
     )  # type is str but instance is None (in type but not in return_properties)
-    assert objects[0].properties["ref"].objects[0].properties["name"] == "B"
-    assert objects[0].properties["ref"].objects[0].uuid == uuid_B
-    assert objects[0].properties["ref"].objects[0].vector is not None
+    print(objects[0].references)
+    assert objects[0].references["b"].objects[0].properties["name"] == "B"
+    assert objects[0].references["b"].objects[0].uuid == uuid_B
+    assert objects[0].references["b"].objects[0].vector is not None
     assert (
-        objects[0].properties["ref"].objects[0].properties["ref"].objects[0].properties["name"]
-        == "A1"
+        objects[0].references["b"].objects[0].references["a"].objects[0].properties["name"] == "A1"
     )
-    assert objects[0].properties["ref"].objects[0].properties["ref"].objects[0].uuid == uuid_A1
+    assert objects[0].references["b"].objects[0].references["a"].objects[0].uuid == uuid_A1
     assert (
-        objects[0]
-        .properties["ref"]
-        .objects[0]
-        .properties["ref"]
-        .objects[0]
-        .metadata.creation_time_unix
+        objects[0].references["b"].objects[0].references["a"].objects[0].metadata.creation_time_unix
         is not None
     )
     assert (
-        objects[0].properties["ref"].objects[0].properties["ref"].objects[1].properties["name"]
-        == "A2"
+        objects[0].references["b"].objects[0].references["a"].objects[1].properties["name"] == "A2"
     )
-    assert objects[0].properties["ref"].objects[0].properties["ref"].objects[1].uuid == uuid_A2
+    assert objects[0].references["b"].objects[0].references["a"].objects[1].uuid == uuid_A2
     assert (
-        objects[0]
-        .properties["ref"]
-        .objects[0]
-        .properties["ref"]
-        .objects[1]
-        .metadata.creation_time_unix
+        objects[0].references["b"].objects[0].references["a"].objects[1].metadata.creation_time_unix
         is not None
     )
 
@@ -312,39 +330,35 @@ def test_multi_references_grpc(client: weaviate.WeaviateClient):
 
     objects = C.query.bm25(
         query="first",
-        return_properties=[
-            "name",
-            FromReferenceMultiTarget(
-                link_on="ref",
-                target_collection="A",
-                return_properties=["name"],
-                return_metadata=MetadataQuery(last_update_time_unix=True),
-            ),
-        ],
+        return_properties="name",
+        return_references=FromReferenceMultiTarget(
+            link_on="ref",
+            target_collection="A",
+            return_properties=["name"],
+            return_metadata=MetadataQuery(last_update_time_unix=True),
+        ),
     ).objects
     assert objects[0].properties["name"] == "first"
-    assert len(objects[0].properties["ref"].objects) == 1
-    assert objects[0].properties["ref"].objects[0].properties["name"] == "A"
-    assert objects[0].properties["ref"].objects[0].metadata.last_update_time_unix is not None
+    assert len(objects[0].references["ref"].objects) == 1
+    assert objects[0].references["ref"].objects[0].properties["name"] == "A"
+    assert objects[0].references["ref"].objects[0].metadata.last_update_time_unix is not None
 
     objects = C.query.bm25(
         query="second",
-        return_properties=[
-            "name",
-            FromReferenceMultiTarget(
-                link_on="ref",
-                target_collection="B",
-                return_properties=[
-                    "name",
-                ],
-                return_metadata=MetadataQuery(last_update_time_unix=True),
-            ),
-        ],
+        return_properties="name",
+        return_references=FromReferenceMultiTarget(
+            link_on="ref",
+            target_collection="B",
+            return_properties=[
+                "name",
+            ],
+            return_metadata=MetadataQuery(last_update_time_unix=True),
+        ),
     ).objects
     assert objects[0].properties["name"] == "second"
-    assert len(objects[0].properties["ref"].objects) == 1
-    assert objects[0].properties["ref"].objects[0].properties["name"] == "B"
-    assert objects[0].properties["ref"].objects[0].metadata.last_update_time_unix is not None
+    assert len(objects[0].references["ref"].objects) == 1
+    assert objects[0].references["ref"].objects[0].properties["name"] == "B"
+    assert objects[0].references["ref"].objects[0].metadata.last_update_time_unix is not None
 
     client.collections.delete("A")
     client.collections.delete("B")
@@ -394,12 +408,14 @@ def test_references_batch(client: weaviate.WeaviateClient):
     objects = collection.query.fetch_objects(
         return_properties=[
             "num",
+        ],
+        return_references=[
             FromReference(link_on="ref"),
         ],
     ).objects
 
     for obj in objects:
-        assert obj.properties["num"] == obj.properties["ref"].objects[0].properties["num"]
+        assert obj.properties["num"] == obj.references["ref"].objects[0].properties["num"]
 
 
 def test_references_batch_with_errors(client: weaviate.WeaviateClient):

--- a/test/collection/test_queries.py
+++ b/test/collection/test_queries.py
@@ -1,3 +1,5 @@
+# TODO: re-enable tests once string syntax is re-enabled in the API
+
 # from typing import List, Optional, Union
 
 # import pytest
@@ -9,8 +11,6 @@
 # )
 # from weaviate.collections.queries.base import _PropertiesParser
 
-
-# @pytest.mark.skip(reason="string syntax has been temporarily removed from the API")
 # @pytest.mark.parametrize(
 #     "properties,output",
 #     [

--- a/test/collection/test_queries.py
+++ b/test/collection/test_queries.py
@@ -1,75 +1,75 @@
-from typing import List, Optional, Union
+# from typing import List, Optional, Union
 
-import pytest
+# import pytest
 
-from weaviate.collections.classes.grpc import (
-    PROPERTIES,
-    FromReference,
-    FromReferenceMultiTarget,
-)
-from weaviate.collections.queries.base import _PropertiesParser
-
-
-@pytest.mark.skip(reason="string syntax has been temporarily removed from the API")
-@pytest.mark.parametrize(
-    "properties,output",
-    [
-        (["name"], ["name"]),
-        ([FromReference(link_on="name")], [FromReference(link_on="name")]),
-        (["name", FromReference(link_on="name")], ["name", FromReference(link_on="name")]),
-        (
-            [FromReferenceMultiTarget(link_on="name", target_collection="Test"), "name"],
-            ["name", FromReferenceMultiTarget(link_on="name", target_collection="Test")],
-        ),
-        (
-            ["__article__properties__name"],
-            [FromReference(link_on="article", return_properties=["name"])],
-        ),
-        (
-            ["__article__properties__name", "name", "__article__properties__age"],
-            ["name", FromReference(link_on="article", return_properties=["name", "age"])],
-        ),
-        (["__article"], [FromReference(link_on="article")]),
-        (
-            ["__article", "__article__properties__name"],
-            [FromReference(link_on="article", return_properties=["name"])],
-        ),
-        (
-            ["__article__properties__name", "__article"],
-            [FromReference(link_on="article", return_properties=["name"])],
-        ),
-        (None, None),
-        ([None, "name"], ["name"]),
-        (["__article", "name"], ["name", FromReference(link_on="article")]),
-        ("__article", [FromReference(link_on="article")]),
-        ("__article__", [FromReference(link_on="article")]),
-    ],
-)
-def test_properties_parser_success(properties: Optional[PROPERTIES], output: Optional[PROPERTIES]):
-    assert output == _PropertiesParser().parse(properties)
+# from weaviate.collections.classes.grpc import (
+#     PROPERTIES,
+#     FromReference,
+#     FromReferenceMultiTarget,
+# )
+# from weaviate.collections.queries.base import _PropertiesParser
 
 
-ERROR_MESSAGE = (
-    lambda s: f"return reference property {s} must be in the format __{{prop_name}} or __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
-)
+# @pytest.mark.skip(reason="string syntax has been temporarily removed from the API")
+# @pytest.mark.parametrize(
+#     "properties,output",
+#     [
+#         (["name"], ["name"]),
+#         ([FromReference(link_on="name")], [FromReference(link_on="name")]),
+#         (["name", FromReference(link_on="name")], ["name", FromReference(link_on="name")]),
+#         (
+#             [FromReferenceMultiTarget(link_on="name", target_collection="Test"), "name"],
+#             ["name", FromReferenceMultiTarget(link_on="name", target_collection="Test")],
+#         ),
+#         (
+#             ["__article__properties__name"],
+#             [FromReference(link_on="article", return_properties=["name"])],
+#         ),
+#         (
+#             ["__article__properties__name", "name", "__article__properties__age"],
+#             ["name", FromReference(link_on="article", return_properties=["name", "age"])],
+#         ),
+#         (["__article"], [FromReference(link_on="article")]),
+#         (
+#             ["__article", "__article__properties__name"],
+#             [FromReference(link_on="article", return_properties=["name"])],
+#         ),
+#         (
+#             ["__article__properties__name", "__article"],
+#             [FromReference(link_on="article", return_properties=["name"])],
+#         ),
+#         (None, None),
+#         ([None, "name"], ["name"]),
+#         (["__article", "name"], ["name", FromReference(link_on="article")]),
+#         ("__article", [FromReference(link_on="article")]),
+#         ("__article__", [FromReference(link_on="article")]),
+#     ],
+# )
+# def test_properties_parser_success(properties: Optional[PROPERTIES], output: Optional[PROPERTIES]):
+#     assert output == _PropertiesParser().parse(properties)
 
 
-@pytest.mark.skip(reason="string syntax has been temporarily removed from the API")
-@pytest.mark.parametrize(
-    "wrong",
-    [
-        ["__article__propertie__uuid"],
-        ["__article__propertiess__uuid"],
-        ["__article__metadat__uuid"],
-        ["__article__metadataa__uuid"],
-        "__article__propertie__uuid",
-        "__article__propertiess__uuid",
-        "__article__metadat__uuid",
-        "__article__metadataa__uuid",
-    ],
-)
-def test_properties_parser_error(wrong: Union[str, List[str]]):
-    with pytest.raises(ValueError) as e:
-        out = _PropertiesParser().parse(wrong)
-        print(out)
-    assert e.value.args[0] == ERROR_MESSAGE(wrong[0] if len(wrong) == 1 else wrong)
+# ERROR_MESSAGE = (
+#     lambda s: f"return reference property {s} must be in the format __{{prop_name}} or __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
+# )
+
+
+# @pytest.mark.skip(reason="string syntax has been temporarily removed from the API")
+# @pytest.mark.parametrize(
+#     "wrong",
+#     [
+#         ["__article__propertie__uuid"],
+#         ["__article__propertiess__uuid"],
+#         ["__article__metadat__uuid"],
+#         ["__article__metadataa__uuid"],
+#         "__article__propertie__uuid",
+#         "__article__propertiess__uuid",
+#         "__article__metadat__uuid",
+#         "__article__metadataa__uuid",
+#     ],
+# )
+# def test_properties_parser_error(wrong: Union[str, List[str]]):
+#     with pytest.raises(ValueError) as e:
+#         out = _PropertiesParser().parse(wrong)
+#         print(out)
+#     assert e.value.args[0] == ERROR_MESSAGE(wrong[0] if len(wrong) == 1 else wrong)

--- a/weaviate/collections/classes/grpc.py
+++ b/weaviate/collections/classes/grpc.py
@@ -156,8 +156,9 @@ class FromReference(_WeaviateInput):
 
     link_on: str
     include_vector: bool = Field(default=False)
-    return_properties: Optional["PROPERTIES"] = Field(default=None)
     return_metadata: Optional[MetadataQuery] = Field(default=None)
+    return_properties: Optional["PROPERTIES"] = Field(default=None)
+    return_references: Optional["REFERENCES"] = Field(default=None)
 
     def __hash__(self) -> int:  # for set
         return hash(str(self))
@@ -177,13 +178,19 @@ class FromNested(_WeaviateInput):
     """Define the return properties of a nested property."""
 
     name: str
-    properties: "NestedProperties"
+    properties: "PROPERTIES"
 
     def __hash__(self) -> int:  # for set
         return hash(str(self))
 
 
-PROPERTY = Union[str, FromReference, FromNested]
+REFERENCE = Union[FromReference, FromReferenceMultiTarget]
+REFERENCES = Union[List[REFERENCE], REFERENCE]
+
+PROPERTY = Union[str, FromNested]
 PROPERTIES = Union[List[PROPERTY], PROPERTY]
 
 NestedProperties = Union[List[Union[str, FromNested]], str, FromNested]
+
+_PROPERTY = Union[PROPERTY, REFERENCE]
+_PROPERTIES = Union[PROPERTIES, REFERENCES]

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -485,7 +485,8 @@ def _extract_references_from_data_model(type_: Type["References"]) -> Optional[R
     return refs if len(refs) > 0 else None
 
 
-WeaviateReferences = Dict[str, _Reference[WeaviateProperties, "WeaviateReferences"]]
+WeaviateReference = _Reference[WeaviateProperties, "WeaviateReferences"]
+WeaviateReferences = Dict[str, WeaviateReference]
 
 References = TypeVar("References", bound=Optional[Mapping[str, Any]], default=None)
 """`References` is used wherever a single generic type is needed for references"""

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -1,7 +1,7 @@
 import sys
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union, cast
-from typing_extensions import TypeAlias
+from typing import Any, Dict, Generic, List, Mapping, Optional, Tuple, Type, Union, cast
+from typing_extensions import TypeAlias, TypeVar, is_typeddict
 
 import uuid as uuid_package
 
@@ -15,17 +15,21 @@ from weaviate.collections.classes.grpc import (
     FromNested,
     FromReference,
     FromReferenceMultiTarget,
+    Generate,
     MetadataQuery,
     METADATA,
     PROPERTIES,
-    Generate,
+    REFERENCES,
 )
-from weaviate.collections.classes.types import Properties, P, TProperties
-from weaviate.exceptions import WeaviateQueryException
+from weaviate.collections.classes.types import Properties, P, R, TProperties, WeaviateProperties
+from weaviate.exceptions import WeaviateQueryException, InvalidDataModelException
 from weaviate.util import _to_beacons
 from weaviate.types import UUIDS
 
 from weaviate.proto.v1 import search_get_pb2
+
+
+IReferences = TypeVar("IReferences", bound=Optional[Mapping[str, Any]], default=None)
 
 
 @dataclass
@@ -88,47 +92,48 @@ class _MetadataReturn:
 
 
 @dataclass
-class _Object(Generic[P]):
+class _Object(Generic[P, R]):
     uuid: uuid_package.UUID
     metadata: Optional[_MetadataReturn]
     properties: P
+    references: R
     vector: Optional[List[float]]
 
 
 @dataclass
-class _GroupByObject(Generic[P], _Object[P]):
+class _GroupByObject(Generic[P, R], _Object[P, R]):
     belongs_to_group: str
 
 
 @dataclass
-class _GenerativeObject(Generic[P], _Object[P]):
+class _GenerativeObject(Generic[P, R], _Object[P, R]):
     generated: Optional[str]
 
 
 @dataclass
-class _GenerativeReturn(Generic[P]):
-    objects: List[_GenerativeObject[P]]
+class _GenerativeReturn(Generic[P, R]):
+    objects: List[_GenerativeObject[P, R]]
     generated: Optional[str]
 
 
 @dataclass
-class _GroupByResult(Generic[P]):
+class _GroupByResult(Generic[P, R]):
     name: str
     min_distance: float
     max_distance: float
     number_of_objects: int
-    objects: List[_Object[P]]
+    objects: List[_Object[P, R]]
 
 
 @dataclass
-class _GroupByReturn(Generic[P]):
-    objects: List[_GroupByObject[P]]
-    groups: Dict[str, _GroupByResult[P]]
+class _GroupByReturn(Generic[P, R]):
+    objects: List[_GroupByObject[P, R]]
+    groups: Dict[str, _GroupByResult[P, R]]
 
 
 @dataclass
-class _QueryReturn(Generic[P]):
-    objects: List[_Object[P]]
+class _QueryReturn(Generic[P, R]):
+    objects: List[_Object[P, R]]
 
 
 _GQLEntryReturnType: TypeAlias = Dict[str, List[Dict[str, Any]]]
@@ -142,33 +147,20 @@ class _RawGQLReturn:
     errors: Optional[Dict[str, Any]]
 
 
-QueryReturn: TypeAlias = Union[_QueryReturn[Properties], _QueryReturn[TProperties]]
-GenerativeReturn: TypeAlias = Union[_GenerativeReturn[Properties], _GenerativeReturn[TProperties]]
-GroupByReturn: TypeAlias = Union[_GroupByReturn[Properties], _GroupByReturn[TProperties]]
+# mypy fails to make the type inference for the below typealias generics so we define manually in queries :(
 
-ReturnProperties: TypeAlias = Union[PROPERTIES, Type[TProperties]]
-
-
-@dataclass
-class _QueryOptions(Generic[TProperties]):
-    include_metadata: bool
-    include_properties: bool
-    include_vector: bool
-
-    @classmethod
-    def from_input(
-        cls,
-        return_metadata: Optional[METADATA],
-        return_properties: Optional[ReturnProperties[TProperties]],
-        include_vector: bool,
-    ) -> "_QueryOptions":
-        return cls(
-            include_metadata=return_metadata is not None,
-            include_properties=not (
-                isinstance(return_properties, list) and len(return_properties) == 0
-            ),
-            include_vector=include_vector,
-        )
+# GenerativeReturn: TypeAlias = Union[
+#     _GenerativeReturn[Properties, References],
+#     _GenerativeReturn[Properties, TReferences],
+#     _GenerativeReturn[TProperties, References],
+#     _GenerativeReturn[TProperties, TReferences],
+# ]
+# GroupByReturn: TypeAlias = Union[
+#     _GroupByReturn[Properties, References],
+#     _GroupByReturn[Properties, TReferences],
+#     _GroupByReturn[TProperties, References],
+#     _GroupByReturn[TProperties, TReferences],
+# ]
 
 
 class _Generative:
@@ -250,10 +242,10 @@ def __create_nested_property_from_nested(name: str, value: Any) -> FromNested:
     )
 
 
-class _Reference(Generic[P]):
+class _Reference(Generic[Properties, IReferences]):
     def __init__(
         self,
-        objects: Optional[List[_Object[P]]],
+        objects: Optional[List[_Object[Properties, IReferences]]],
         target_collection: Optional[str],
         uuids: Optional[UUIDS],
     ):
@@ -268,7 +260,9 @@ class _Reference(Generic[P]):
         return _to_beacons(self.__uuids, self.__target_collection)
 
     @classmethod
-    def _from(cls, objects: List[_Object[P]]) -> "_Reference[P]":
+    def _from(
+        cls, objects: List[_Object[Properties, IReferences]]
+    ) -> "_Reference[Properties, IReferences]":
         return cls(objects, None, None)
 
     @property
@@ -290,12 +284,12 @@ class _Reference(Generic[P]):
         return self.__target_collection
 
     @property
-    def objects(self) -> List[_Object[P]]:
+    def objects(self) -> List[_Object[Properties, IReferences]]:
         """Returns the objects of the cross reference."""
         return self.__objects or []
 
 
-CrossReference = _Reference[P]
+CrossReference: TypeAlias = _Reference[Properties, IReferences]
 """Use this TypeAlias when you want to type hint a cross reference within a generic data model.
 
 If you want to define a reference property when creating your collection, use `ReferenceProperty` or `ReferencePropertyMultiTarget` instead.
@@ -323,7 +317,12 @@ class Reference:
     """
 
     @classmethod
-    def to(cls, uuids: UUIDS, data_model: Optional[Type[P]] = None) -> CrossReference[P]:
+    def to(
+        cls,
+        uuids: UUIDS,
+        properties: Optional[Type[Properties]] = None,
+        references: Optional[Type[IReferences]] = None,
+    ) -> CrossReference[Properties, IReferences]:
         """Define cross references to other objects by their UUIDs.
 
         Can be made to be generic by supplying a type to the `data_model` argument.
@@ -332,15 +331,16 @@ class Reference:
             `uuids`
                 List of UUIDs of the objects to which the reference should point.
         """
-        return _Reference[P](None, None, uuids)
+        return _Reference[Properties, IReferences](None, None, uuids)
 
     @classmethod
     def to_multi_target(
         cls,
         uuids: UUIDS,
         target_collection: Union[str, _CollectionBase],
-        data_model: Optional[Type[P]] = None,
-    ) -> CrossReference[P]:
+        properties: Optional[Type[Properties]] = None,
+        references: Optional[Type[IReferences]] = None,
+    ) -> CrossReference[Properties, IReferences]:
         """Define cross references to other objects by their UUIDs and the collection in which they are stored.
 
         Can be made to be generic by supplying a type to the `data_model` argument.
@@ -351,7 +351,7 @@ class Reference:
             `target_collection`
                 The collection in which the objects are stored. Can be either the name of the collection or the collection object itself.
         """
-        return _Reference[P](
+        return _Reference[Properties, IReferences](
             None,
             target_collection.name
             if isinstance(target_collection, _CollectionBase)
@@ -383,25 +383,24 @@ class ReferenceAnnotation:
     target_collection: Optional[str] = None
 
 
-def _extract_property_type_from_reference(type_: _Reference[P]) -> Type[P]:
-    """Extract inner type from CrossReference[Properties]."""
-    if getattr(type_, "__origin__", None) == _Reference:
-        args = cast(List[Type[P]], getattr(type_, "__args__", None))
-        return args[0]
-    raise ValueError("Type is not CrossReference[Properties]")
+def _extract_types_from_reference(
+    type_: _Reference[Properties, "References"]
+) -> Tuple[Type[Properties], Type["References"]]:
+    """Extract first inner type from CrossReference[Properties, References]."""
+    if get_origin(type_) == _Reference:
+        return cast(Tuple[Type[Properties], Type[References]], get_args(type_))
+    raise ValueError("Type is not CrossReference[Properties, References]")
 
 
-def _extract_property_type_from_annotated_reference(
-    type_: Annotated[_Reference[P], ReferenceAnnotation]
-) -> Type[P]:
-    """Extract inner type from Annotated[CrossReference[Properties]]."""
+def _extract_types_from_annotated_reference(
+    type_: Annotated[_Reference[Properties, "References"], ReferenceAnnotation]
+) -> Tuple[Type[Properties], Type["References"]]:
+    """Extract inner type from Annotated[CrossReference[Properties, References]]."""
     if get_origin(type_) is Annotated:
-        args = cast(List[_Reference[Type[P]]], getattr(type_, "__args__", None))
-        inner_type = args[0]
-        if get_origin(inner_type) is _Reference:
-            inner_args = cast(List[Type[P]], getattr(inner_type, "__args__", None))
-            return inner_args[0]
-    raise ValueError("Type is not Annotated[CrossReference[Properties]]")
+        args = get_args(type_)
+        inner_type = cast(_Reference[Properties, References], args[0])
+        return _extract_types_from_reference(inner_type)
+    raise ValueError("Type is not Annotated[CrossReference[Properties, References]]")
 
 
 def __is_annotated_reference(value: Any) -> bool:
@@ -413,23 +412,23 @@ def __is_annotated_reference(value: Any) -> bool:
 
 
 def __create_link_to_from_annotated_reference(
-    link_on: str, value: Annotated[_Reference[Properties], ReferenceAnnotation]
+    link_on: str, value: Annotated[_Reference[Properties, "References"], ReferenceAnnotation]
 ) -> Union[FromReference, FromReferenceMultiTarget]:
     """Create FromReference or FromReferenceMultiTarget from Annotated[CrossReference[Properties], ReferenceAnnotation]."""
     assert get_origin(value) is Annotated
-    args = cast(List[_Reference[Properties]], getattr(value, "__args__", None))
+    args = cast(List[_Reference[Properties, References]], get_args(value))
     inner_type = args[0]
     assert get_origin(inner_type) is _Reference
     inner_type_metadata = cast(Tuple[ReferenceAnnotation], getattr(value, "__metadata__", None))
     annotation = inner_type_metadata[0]
+    types = _extract_types_from_annotated_reference(value)
     if annotation.target_collection is not None:
         return FromReferenceMultiTarget(
             link_on=link_on,
             include_vector=annotation.include_vector,
             return_metadata=annotation.metadata,
-            return_properties=_extract_properties_from_data_model(
-                _extract_property_type_from_annotated_reference(value)
-            ),
+            return_properties=_extract_properties_from_data_model(types[0]),
+            return_references=_extract_references_from_data_model(types[1]),
             target_collection=annotation.target_collection,
         )
     else:
@@ -437,9 +436,8 @@ def __create_link_to_from_annotated_reference(
             link_on=link_on,
             include_vector=annotation.include_vector,
             return_metadata=annotation.metadata,
-            return_properties=_extract_properties_from_data_model(
-                _extract_property_type_from_annotated_reference(value)
-            ),
+            return_properties=_extract_properties_from_data_model(types[0]),
+            return_references=_extract_references_from_data_model(types[1]),
         )
 
 
@@ -449,14 +447,14 @@ def __is_reference(value: Any) -> bool:
 
 def __create_link_to_from_reference(
     link_on: str,
-    value: _Reference[Properties],
+    value: _Reference[Properties, "References"],
 ) -> FromReference:
     """Create FromReference from CrossReference[Properties]."""
+    types = _extract_types_from_annotated_reference(value)
     return FromReference(
         link_on=link_on,
-        return_properties=_extract_properties_from_data_model(
-            _extract_property_type_from_reference(value)
-        ),
+        return_properties=_extract_properties_from_data_model(types[0]),
+        return_references=_extract_references_from_data_model(types[1]),
     )
 
 
@@ -467,12 +465,70 @@ def _extract_properties_from_data_model(type_: Type[Properties]) -> PROPERTIES:
     in the data model and lists out the properties as classes readily consumable by the underlying API.
     """
     return [
-        __create_link_to_from_annotated_reference(key, value)
-        if __is_annotated_reference(value)
-        else (
-            __create_link_to_from_reference(key, value)
-            if __is_reference(value)
-            else (__create_nested_property_from_nested(key, value) if __is_nested(value) else key)
-        )
+        __create_nested_property_from_nested(key, value) if __is_nested(value) else key
         for key, value in get_type_hints(type_, include_extras=True).items()
     ]
+
+
+def _extract_references_from_data_model(type_: Type["References"]) -> Optional[REFERENCES]:
+    """Extract references of References recursively from References.
+
+    Checks to see if there is a _Reference[References], Annotated[_Reference[References]], or _Nested[References]
+    in the data model and lists out the references as classes readily consumable by the underlying API.
+    """
+    refs = [
+        __create_link_to_from_annotated_reference(key, value)
+        if __is_annotated_reference(value)
+        else __create_link_to_from_reference(key, value)
+        for key, value in get_type_hints(type_, include_extras=True).items()
+    ]
+    return refs if len(refs) > 0 else None
+
+
+WeaviateReferences = Dict[str, _Reference[WeaviateProperties, "WeaviateReferences"]]
+
+References = TypeVar("References", bound=Optional[Mapping[str, Any]], default=None)
+"""`References` is used wherever a single generic type is needed for references"""
+
+# I wish we could have bound=Mapping[str, CrossReference["P", "R"]] here, but you can't have generic bounds, so Any must suffice
+TReferences = TypeVar("TReferences", bound=Mapping[str, Any])
+"""`TReferences` is used alongside `References` wherever there are two generic types needed"""
+
+
+def _check_references_generic(references: Optional[Type["References"]]) -> None:
+    if (
+        references is not None
+        and get_origin(references) is not dict
+        and not is_typeddict(references)
+    ):
+        raise InvalidDataModelException("references")
+
+
+ReturnProperties: TypeAlias = Union[PROPERTIES, Type[TProperties]]
+ReturnReferences: TypeAlias = Union[Union[FromReference, List[FromReference]], Type[TReferences]]
+
+
+@dataclass
+class _QueryOptions(Generic[Properties, References, TReferences]):
+    include_metadata: bool
+    include_properties: bool
+    include_references: bool
+    include_vector: bool
+
+    @classmethod
+    def from_input(
+        cls,
+        return_metadata: Optional[METADATA],
+        return_properties: Optional[ReturnProperties[Properties]],
+        include_vector: bool,
+        collection_references: Optional[Type[References]],
+        query_references: Optional[ReturnReferences[TReferences]],
+    ) -> "_QueryOptions":
+        return cls(
+            include_metadata=return_metadata is not None,
+            include_properties=not (
+                isinstance(return_properties, list) and len(return_properties) == 0
+            ),
+            include_references=collection_references is not None or query_references is not None,
+            include_vector=include_vector,
+        )

--- a/weaviate/collections/classes/types.py
+++ b/weaviate/collections/classes/types.py
@@ -1,14 +1,17 @@
 from typing import Any, Dict, Mapping, Optional, Type, get_origin
-from typing_extensions import TypeVar, is_typeddict
+from typing_extensions import TypeAlias, TypeVar, is_typeddict
 
 from pydantic import BaseModel, ConfigDict
 
 from weaviate.exceptions import InvalidDataModelException
+from weaviate.types import WeaviateField
 
-Properties = TypeVar("Properties", bound=Mapping[str, Any], default=Dict[str, Any])
-"""`Properties` is used wherever a single generic type is needed"""
+WeaviateProperties: TypeAlias = Dict[str, WeaviateField]
 
-TProperties = TypeVar("TProperties", bound=Mapping[str, Any], default=Dict[str, Any])
+Properties = TypeVar("Properties", bound=Mapping[str, Any], default=WeaviateProperties)
+"""`Properties` is used wherever a single generic type is needed for properties"""
+
+TProperties = TypeVar("TProperties", bound=Mapping[str, Any], default=WeaviateProperties)
 """`TProperties` is used alongside `Properties` wherever there are two generic types needed
 
 E.g., in `_DataCollection`, `Properties` is used when defining the generic of the class while
@@ -22,17 +25,38 @@ P = TypeVar("P")
 """`P` is a completely general type that is used wherever generic properties objects are defined that can be used
 within the non-ORM and ORM APIs interchangeably"""
 
+QP = TypeVar("QP")
+"""`QP` is a completely general type that is used wherever generic properties objects are defined that can be used
+within the non-ORM and ORM APIs interchangeably"""
+
+R = TypeVar("R")
+"""`R` is a completely general type that is used wherever generic reference objects are defined that can be used
+within the non-ORM and ORM APIs interchangeably"""
+
+QR = TypeVar("QR")
+"""`QR` is a completely general type that is used wherever generic reference objects are defined that can be used
+within the non-ORM and ORM APIs interchangeably"""
+
 T = TypeVar("T")
 """`T` is a completely general type that is used in any kind of generic"""
 
 
-def _check_data_model(data_model: Optional[Type[Properties]]) -> None:
+def _check_properties_generic(properties: Optional[Type[Properties]]) -> None:
     if (
-        data_model is not None
-        and get_origin(data_model) is not dict
-        and not is_typeddict(data_model)
+        properties is not None
+        and get_origin(properties) is not dict
+        and not is_typeddict(properties)
+        # and not all([val in [
+        #     str,
+        #     int,
+        #     float,
+        #     bool,
+        #     list,
+        #     dict,
+        #     None,
+        # ] for val in get_type_hints(properties).values()])
     ):
-        raise InvalidDataModelException()
+        raise InvalidDataModelException("properties")
 
 
 class _WeaviateInput(BaseModel):

--- a/weaviate/collections/classes/types.py
+++ b/weaviate/collections/classes/types.py
@@ -46,15 +46,6 @@ def _check_properties_generic(properties: Optional[Type[Properties]]) -> None:
         properties is not None
         and get_origin(properties) is not dict
         and not is_typeddict(properties)
-        # and not all([val in [
-        #     str,
-        #     int,
-        #     float,
-        #     bool,
-        #     list,
-        #     dict,
-        #     None,
-        # ] for val in get_type_hints(properties).values()])
     ):
         raise InvalidDataModelException("properties")
 

--- a/weaviate/collections/collection.py
+++ b/weaviate/collections/collection.py
@@ -1,13 +1,19 @@
 import json
 from dataclasses import asdict
-from typing import Generic, Optional, Type, Union, cast, overload
-from typing_extensions import is_typeddict
+from typing import Generic, Literal, Optional, Type, Union, cast, overload
 from weaviate.collections.backups import _CollectionBackup
 
 from weaviate.collections.classes.config import (
     ConsistencyLevel,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES
+from weaviate.collections.classes.internal import (
+    References,
+    TReferences,
+    ReturnProperties,
+    ReturnReferences,
+    WeaviateReferences,
+)
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.base import _CollectionBase
 from weaviate.collections.aggregate import _AggregateCollection, _AggregateGroupByCollection
@@ -19,7 +25,7 @@ from weaviate.collections.tenants import _Tenants
 from weaviate.connect import Connection
 
 
-class Collection(_CollectionBase, Generic[Properties]):
+class Collection(_CollectionBase, Generic[Properties, References]):
     """The collection class is the main entry point for interacting with a collection in Weaviate.
 
     This class is returned by the `client.collections.create` and `client.collections.get` methods. It provides
@@ -53,7 +59,8 @@ class Collection(_CollectionBase, Generic[Properties]):
         name: str,
         consistency_level: Optional[ConsistencyLevel] = None,
         tenant: Optional[str] = None,
-        type_: Optional[Type[Properties]] = None,
+        properties: Optional[Type[Properties]] = None,
+        references: Optional[Type[References]] = None,
     ) -> None:
         super().__init__(name)
         self._connection = connection
@@ -69,17 +76,19 @@ class Collection(_CollectionBase, Generic[Properties]):
         self.config = _ConfigCollection(self._connection, self.name, tenant)
         """This namespace includes all the CRUD methods available to you when modifying the configuration of the collection in Weaviate."""
         self.data = _DataCollection[Properties](
-            connection, self.name, consistency_level, tenant, type_
+            connection, self.name, consistency_level, tenant, properties
         )
         """This namespace includes all the CUD methods available to you when modifying the data of the collection in Weaviate."""
-        self.generate = _GenerateCollection(connection, self.name, consistency_level, tenant, type_)
+        self.generate = _GenerateCollection(
+            connection, self.name, consistency_level, tenant, properties, references
+        )
         """This namespace includes all the querying methods available to you when using Weaviate's generative capabilities."""
         self.query_group_by = _GroupByCollection(
-            connection, self.name, consistency_level, tenant, type_
+            connection, self.name, consistency_level, tenant, properties, references
         )
         """This namespace includes all the querying methods available to you when using Weaviate's querying group-by capabilities."""
-        self.query = _QueryCollection[Properties](
-            connection, self.name, self.data, consistency_level, tenant, type_
+        self.query = _QueryCollection[Properties, References](
+            connection, self.name, self.data, consistency_level, tenant, properties, references
         )
         """This namespace includes all the querying methods available to you when using Weaviate's standard query capabilities."""
         self.tenants = _Tenants(connection, self.name)
@@ -90,9 +99,10 @@ class Collection(_CollectionBase, Generic[Properties]):
 
         self.__tenant = tenant
         self.__consistency_level = consistency_level
-        self.__type = type_
+        self.__properties = properties
+        self.__references = references
 
-    def with_tenant(self, tenant: Optional[str] = None) -> "Collection[Properties]":
+    def with_tenant(self, tenant: Optional[str] = None) -> "Collection[Properties, References]":
         """Use this method to return a collection object specific to a single tenant.
 
         If multi-tenancy is not configured for this collection then Weaviate will throw an error.
@@ -101,11 +111,18 @@ class Collection(_CollectionBase, Generic[Properties]):
             `tenant`
                 The name of the tenant to use.
         """
-        return Collection[Properties](self._connection, self.name, self.__consistency_level, tenant)
+        return Collection(
+            self._connection,
+            self.name,
+            self.__consistency_level,
+            tenant,
+            self.__properties,
+            self.__references,
+        )
 
     def with_consistency_level(
         self, consistency_level: Optional[ConsistencyLevel] = None
-    ) -> "Collection[Properties]":
+    ) -> "Collection[Properties, References]":
         """Use this method to return a collection object specific to a single consistency level.
 
         If replication is not configured for this collection then Weaviate will throw an error.
@@ -114,7 +131,14 @@ class Collection(_CollectionBase, Generic[Properties]):
             `consistency_level`
                 The consistency level to use.
         """
-        return Collection[Properties](self._connection, self.name, consistency_level, self.__tenant)
+        return Collection(
+            self._connection,
+            self.name,
+            consistency_level,
+            self.__tenant,
+            self.__properties,
+            self.__references,
+        )
 
     def __len__(self) -> int:
         total = self.aggregate.over_all(total_count=True).total_count
@@ -131,8 +155,32 @@ class Collection(_CollectionBase, Generic[Properties]):
         self,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _ObjectIterator[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _ObjectIterator[Properties, References]:
+        ...
+
+    @overload
+    def iterator(
+        self,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _ObjectIterator[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def iterator(
+        self,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _ObjectIterator[Properties, TReferences]:
         ...
 
     @overload
@@ -142,15 +190,46 @@ class Collection(_CollectionBase, Generic[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _ObjectIterator[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _ObjectIterator[TProperties, References]:
+        ...
+
+    @overload
+    def iterator(
+        self,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _ObjectIterator[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def iterator(
+        self,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _ObjectIterator[TProperties, TReferences]:
         ...
 
     def iterator(
         self,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        return_properties: Optional[Union[PROPERTIES, Type[TProperties]]] = None,
-    ) -> Union[_ObjectIterator[Properties], _ObjectIterator[TProperties]]:
+        return_properties: Optional[ReturnProperties[TProperties]] = None,
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _ObjectIterator[Properties, References],
+        _ObjectIterator[Properties, WeaviateReferences],
+        _ObjectIterator[Properties, TReferences],
+        _ObjectIterator[TProperties, References],
+        _ObjectIterator[TProperties, WeaviateReferences],
+        _ObjectIterator[TProperties, TReferences],
+    ]:
         """Use this method to return an iterator over the objects in the collection.
 
         This iterator keeps a record of the last object that it returned to be used in each subsequent call to
@@ -161,44 +240,36 @@ class Collection(_CollectionBase, Generic[Properties]):
         to request the vector back as well.
 
         Arguments:
-            `return_properties`
-                The properties to return with each object.
             `include_vector`
                 Whether to include the vector in the metadata of the returned objects.
+            `return_metadata`
+                The metadata to return with each object.
+            `return_properties`
+                The properties to return with each object.
+            `return_references`
+                The references to return with each object.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
                 If the request to the Weaviate server fails.
         """
-        if is_typeddict(return_properties):
-            return_properties = cast(Type[TProperties], return_properties)
-            return _ObjectIterator[TProperties](
-                lambda limit, alpha: self.query.fetch_objects(
+        return cast(
+            Union[
+                _ObjectIterator[Properties, References],
+                _ObjectIterator[Properties, WeaviateReferences],
+                _ObjectIterator[Properties, TReferences],
+                _ObjectIterator[TProperties, References],
+                _ObjectIterator[TProperties, WeaviateReferences],
+                _ObjectIterator[TProperties, TReferences],
+            ],
+            _ObjectIterator(
+                lambda limit, after: self.query.fetch_objects(
                     limit=limit,
-                    after=alpha,
+                    after=after,
                     include_vector=include_vector,
                     return_metadata=return_metadata,
-                    return_properties=return_properties,
-                ).objects,
-            )
-        if return_properties is None and self.__type is not None:
-            _type = cast(Type[Properties], self.__type)
-            return _ObjectIterator[Properties](
-                lambda limit, alpha: self.query.fetch_objects(
-                    limit=limit,
-                    after=alpha,
-                    include_vector=include_vector,
-                    return_metadata=return_metadata,
-                    return_properties=_type,
-                ).objects,
-            )
-        props = cast(PROPERTIES, return_properties)
-        return _ObjectIterator[Properties](
-            lambda limit, alpha: self.query.fetch_objects(
-                limit=limit,
-                after=alpha,
-                include_vector=include_vector,
-                return_metadata=return_metadata,
-                return_properties=props,
-            ).objects,
+                    return_properties=return_properties or self.__properties,
+                    return_references=return_references,
+                ).objects
+            ),
         )

--- a/weaviate/collections/collections.py
+++ b/weaviate/collections/collections.py
@@ -17,7 +17,8 @@ from weaviate.collections.classes.config import (
     _VectorIndexConfigCreate,
     _VectorIndexType,
 )
-from weaviate.collections.classes.types import Properties, _check_data_model
+from weaviate.collections.classes.internal import References, _check_references_generic
+from weaviate.collections.classes.types import Properties, _check_properties_generic
 from weaviate.collections.collection import Collection
 from weaviate.util import _capitalize_first_letter
 
@@ -37,7 +38,8 @@ class _Collections(_CollectionsBase):
         vector_index_type: _VectorIndexType = _VectorIndexType.HNSW,
         vectorizer_config: Optional[_VectorizerConfigCreate] = None,
         data_model: Optional[Type[Properties]] = None,
-    ) -> Collection[Properties]:
+        references: Optional[Type[References]] = None,
+    ) -> Collection[Properties, References]:
         """Use this method to create a collection in Weaviate and immediately return a collection object.
 
         This method takes several arguments that allow you to configure the collection to your liking. Each argument
@@ -99,11 +101,14 @@ class _Collections(_CollectionsBase):
             raise ValueError(
                 f"Name of created collection ({name}) does not match given name ({config.name})"
             )
-        return self.get(name, data_model)
+        return self.get(name, data_model, references)
 
     def get(
-        self, name: str, data_model: Optional[Type[Properties]] = None
-    ) -> Collection[Properties]:
+        self,
+        name: str,
+        properties: Optional[Type[Properties]] = None,
+        references: Optional[Type[References]] = None,
+    ) -> Collection[Properties, References]:
         """Use this method to return a collection object to be used when interacting with your Weaviate collection.
 
         Arguments:
@@ -118,9 +123,12 @@ class _Collections(_CollectionsBase):
             `weaviate.exceptions.InvalidDataModelException`
                 If the data model is not a valid data model, i.e., it is not a `dict` nor a `TypedDict`.
         """
-        _check_data_model(data_model)
+        _check_properties_generic(properties)
+        _check_references_generic(references)
         name = _capitalize_first_letter(name)
-        return Collection[Properties](self._connection, name, type_=data_model)
+        return Collection[Properties, References](
+            self._connection, name, properties=properties, references=references
+        )
 
     def delete(self, name: Union[str, List[str]]) -> None:
         """Use this method to delete collection(s) from the Weaviate instance by its/their name(s).

--- a/weaviate/collections/grpc/query.py
+++ b/weaviate/collections/grpc/query.py
@@ -6,6 +6,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypeVar,
     Union,
     cast,
 )
@@ -21,13 +22,14 @@ from weaviate.collections.classes.config import ConsistencyLevel
 from weaviate.collections.classes.filters import _Filters
 from weaviate.collections.classes.grpc import (
     HybridFusion,
-    FromReference,
     FromReferenceMultiTarget,
     FromNested,
     _MetadataQuery,
     Move,
     PROPERTIES,
     PROPERTY,
+    REFERENCE,
+    REFERENCES,
     Sort,
 )
 from weaviate.collections.classes.internal import _Generative, _GroupBy
@@ -107,6 +109,9 @@ class _Move:
     objects: List[uuid_lib.UUID]
 
 
+A = TypeVar("A")
+
+
 class _QueryGRPC(_BaseGRPC):
     def __init__(
         self,
@@ -122,12 +127,11 @@ class _QueryGRPC(_BaseGRPC):
         self._tenant = tenant
 
         if default_properties is not None:
-            self._default_props: Optional[Set[PROPERTY]] = self.__convert_properties_to_set(
-                default_properties
-            )
+            self._default_props: Optional[Set[PROPERTY]] = self.__convert_to_set(default_properties)
         else:
             self._default_props = None
         self._metadata: Optional[_MetadataQuery] = None
+        self._refs: Optional[Set[REFERENCE]] = None
 
         self._limit: Optional[int] = None
         self._offset: Optional[int] = None
@@ -181,6 +185,7 @@ class _QueryGRPC(_BaseGRPC):
         sort: Optional[Union[Sort, List[Sort]]] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
         generative: Optional[_Generative] = None,
     ) -> SearchResponse:
         self._limit = limit
@@ -190,6 +195,7 @@ class _QueryGRPC(_BaseGRPC):
         self._metadata = return_metadata
         self.__parse_sort(sort)
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
         self._generative = generative
         return self.__call()
 
@@ -205,6 +211,7 @@ class _QueryGRPC(_BaseGRPC):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
         generative: Optional[_Generative] = None,
     ) -> SearchResponse:
         self._hybrid_query = query
@@ -221,6 +228,7 @@ class _QueryGRPC(_BaseGRPC):
         self._filters = filters
         self._metadata = return_metadata
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
 
         self._generative = generative
 
@@ -235,6 +243,7 @@ class _QueryGRPC(_BaseGRPC):
         filters: Optional[_Filters] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
         generative: Optional[_Generative] = None,
     ) -> SearchResponse:
         self._bm25_query = query
@@ -244,6 +253,7 @@ class _QueryGRPC(_BaseGRPC):
         self._filters = filters
         self._metadata = return_metadata
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
 
         self._generative = generative
 
@@ -261,6 +271,7 @@ class _QueryGRPC(_BaseGRPC):
         generative: Optional[_Generative] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
     ) -> SearchResponse:
         self._near_vector_vec = near_vector
         self._near_certainty = certainty
@@ -272,6 +283,7 @@ class _QueryGRPC(_BaseGRPC):
         self._group_by = group_by
         self._generative = generative
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
 
         return self.__call()
 
@@ -287,6 +299,7 @@ class _QueryGRPC(_BaseGRPC):
         generative: Optional[_Generative] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
     ) -> SearchResponse:
         self._near_object_obj = near_object
         self._near_certainty = certainty
@@ -296,6 +309,7 @@ class _QueryGRPC(_BaseGRPC):
         self._filters = filters
         self._metadata = return_metadata
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
         self._group_by = group_by
         self._generative = generative
         return self.__call()
@@ -314,6 +328,7 @@ class _QueryGRPC(_BaseGRPC):
         generative: Optional[_Generative] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
     ) -> SearchResponse:
         if isinstance(near_text, str):
             near_text = [near_text]
@@ -339,6 +354,7 @@ class _QueryGRPC(_BaseGRPC):
         self._group_by = group_by
         self._metadata = return_metadata
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
 
         return self.__call()
 
@@ -354,6 +370,7 @@ class _QueryGRPC(_BaseGRPC):
         generative: Optional[_Generative] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
     ) -> SearchResponse:
         self._near_image = image
         self._near_certainty = certainty
@@ -366,6 +383,7 @@ class _QueryGRPC(_BaseGRPC):
 
         self._metadata = return_metadata
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
 
         return self.__call()
 
@@ -381,6 +399,7 @@ class _QueryGRPC(_BaseGRPC):
         generative: Optional[_Generative] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
     ) -> SearchResponse:
         self._near_video = video
         self._near_certainty = certainty
@@ -393,6 +412,7 @@ class _QueryGRPC(_BaseGRPC):
 
         self._metadata = return_metadata
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
 
         return self.__call()
 
@@ -408,6 +428,7 @@ class _QueryGRPC(_BaseGRPC):
         generative: Optional[_Generative] = None,
         return_metadata: Optional[_MetadataQuery] = None,
         return_properties: Optional[PROPERTIES] = None,
+        return_references: Optional[REFERENCES] = None,
     ) -> SearchResponse:
         self._near_audio = audio
         self._near_certainty = certainty
@@ -420,6 +441,7 @@ class _QueryGRPC(_BaseGRPC):
 
         self._metadata = return_metadata
         self.__merge_default_and_return_properties(return_properties)
+        self.__merge_return_references(return_references)
 
         return self.__call()
 
@@ -470,7 +492,9 @@ class _QueryGRPC(_BaseGRPC):
                     )
                     if self._near_object_obj is not None
                     else None,
-                    properties=self._translate_properties_from_python_to_grpc(self._default_props),
+                    properties=self._translate_properties_from_python_to_grpc(
+                        self._default_props, self._refs
+                    ),
                     metadata=self._metadata_to_grpc(self._metadata)
                     if self._metadata is not None
                     else None,
@@ -559,44 +583,52 @@ class _QueryGRPC(_BaseGRPC):
             is_consistent=metadata.is_consistent,
         )
 
-    def _translate_properties_from_python_to_grpc(
-        self, properties: Optional[Set[PROPERTY]]
-    ) -> Optional[search_get_pb2.PropertiesRequest]:
-        def resolve_property(prop: FromNested) -> search_get_pb2.ObjectPropertiesRequest:
-            props = prop.properties if isinstance(prop.properties, list) else [prop.properties]
-            return search_get_pb2.ObjectPropertiesRequest(
-                prop_name=prop.name,
-                primitive_properties=[p for p in props if isinstance(p, str)],
-                object_properties=[resolve_property(p) for p in props if isinstance(p, FromNested)],
-            )
+    def __resolve_property(self, prop: FromNested) -> search_get_pb2.ObjectPropertiesRequest:
+        props = prop.properties if isinstance(prop.properties, list) else [prop.properties]
+        return search_get_pb2.ObjectPropertiesRequest(
+            prop_name=prop.name,
+            primitive_properties=[p for p in props if isinstance(p, str)],
+            object_properties=[
+                self.__resolve_property(p) for p in props if isinstance(p, FromNested)
+            ],
+        )
 
-        return (
-            None
+    def _translate_properties_from_python_to_grpc(
+        self, properties: Optional[Set[PROPERTY]], references: Optional[Set[REFERENCE]]
+    ) -> Optional[search_get_pb2.PropertiesRequest]:
+        if properties is None and references is None:
+            return None
+        return search_get_pb2.PropertiesRequest(
+            non_ref_properties=None
             if properties is None
-            else search_get_pb2.PropertiesRequest(
-                non_ref_properties=[prop for prop in properties if isinstance(prop, str)],
-                ref_properties=[
-                    search_get_pb2.RefPropertiesRequest(
-                        reference_property=prop.link_on,
-                        properties=self._translate_properties_from_python_to_grpc(
-                            self.__convert_properties_to_set(prop.return_properties)
-                        )
-                        if prop.return_properties is not None
-                        else None,
-                        metadata=self._metadata_to_grpc(prop._return_metadata)
-                        if prop._return_metadata is not None
-                        else None,
-                        target_collection=prop.target_collection
-                        if isinstance(prop, FromReferenceMultiTarget)
-                        else None,
-                    )
-                    for prop in properties
-                    if isinstance(prop, FromReference)
-                ],
-                object_properties=[
-                    resolve_property(prop) for prop in properties if isinstance(prop, FromNested)
-                ],
-            )
+            else [prop for prop in properties if isinstance(prop, str)],
+            ref_properties=None
+            if references is None
+            else [
+                search_get_pb2.RefPropertiesRequest(
+                    reference_property=ref.link_on,
+                    properties=self._translate_properties_from_python_to_grpc(
+                        None
+                        if ref.return_properties is None
+                        else self.__convert_to_set(ref.return_properties),
+                        None
+                        if ref.return_references is None
+                        else self.__convert_to_set(ref.return_references),
+                    ),
+                    metadata=self._metadata_to_grpc(ref._return_metadata)
+                    if ref._return_metadata is not None
+                    else None,
+                    target_collection=ref.target_collection
+                    if isinstance(ref, FromReferenceMultiTarget)
+                    else None,
+                )
+                for ref in references
+            ],
+            object_properties=None
+            if properties is None
+            else [
+                self.__resolve_property(prop) for prop in properties if isinstance(prop, FromNested)
+            ],
         )
 
     def __merge_default_and_return_properties(
@@ -606,14 +638,22 @@ class _QueryGRPC(_BaseGRPC):
             return
         if self._default_props is not None:
             self._default_props = self._default_props.union(
-                self.__convert_properties_to_set(return_properties)
+                self.__convert_to_set(return_properties)
             )
         else:
-            self._default_props = self.__convert_properties_to_set(return_properties)
+            self._default_props = self.__convert_to_set(return_properties)
+
+    def __merge_return_references(self, return_references: Optional[REFERENCES]) -> None:
+        if return_references is None:
+            return None
+        if self._refs is not None:
+            self._refs = self._refs.union(self.__convert_to_set(return_references))
+        else:
+            self._refs = self.__convert_to_set(return_references)
 
     @staticmethod
-    def __convert_properties_to_set(properties: PROPERTIES) -> Set[PROPERTY]:
-        if isinstance(properties, list):
-            return set(properties)
+    def __convert_to_set(args: Union[A, List[A]]) -> Set[A]:
+        if isinstance(args, list):
+            return set(args)
         else:
-            return {properties}
+            return {cast(A, args)}

--- a/weaviate/collections/iterator.py
+++ b/weaviate/collections/iterator.py
@@ -1,30 +1,28 @@
-from typing import Callable, Generic, Iterable, Iterator, List, Optional, TypeVar
+from typing import Callable, Generic, Iterable, Iterator, List, Optional
 from uuid import UUID
 
 from weaviate.collections.classes.internal import _Object
-from weaviate.collections.classes.types import Properties
+from weaviate.collections.classes.types import P, R
 
 
 ITERATOR_CACHE_SIZE = 100
 
-P = TypeVar("P")
 
-
-class _ObjectIterator(Generic[Properties], Iterable[_Object[Properties]]):
+class _ObjectIterator(Generic[P, R], Iterable[_Object[P, R]]):
     def __init__(
-        self, fetch_objects_query: Callable[[int, Optional[UUID]], List[_Object[Properties]]]
+        self, fetch_objects_query: Callable[[int, Optional[UUID]], List[_Object[P, R]]]
     ) -> None:
         self.__query = fetch_objects_query
 
-        self.__iter_object_cache: List[_Object[Properties]] = []
+        self.__iter_object_cache: List[_Object[P, R]] = []
         self.__iter_object_last_uuid: Optional[UUID] = None
 
-    def __iter__(self) -> Iterator[_Object[Properties]]:
+    def __iter__(self) -> Iterator[_Object[P, R]]:
         self.__iter_object_cache = []
         self.__iter_object_last_uuid = None
         return self
 
-    def __next__(self) -> _Object[Properties]:
+    def __next__(self) -> _Object[P, R]:
         if len(self.__iter_object_cache) == 0:
             objects = self.__query(
                 ITERATOR_CACHE_SIZE,

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -422,6 +422,9 @@ class _BaseQuery(Generic[Properties, References]):
             return file_encoder_b64(media)
 
 
+# TODO: refactor PropertiesParser to handle new schema for specifying query parameters
+# e.g. return_metadata, return_properties, return_references and include_vector
+
 # class _PropertiesParser:
 #     def __init__(self) -> None:
 #         self.__from_references_by_prop_name: Dict[str, FromReference] = {}

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -1,15 +1,12 @@
 import io
 import pathlib
-import re
 import struct
 from typing import (
     Any,
-    Dict,
     Generic,
     List,
     Optional,
     Type,
-    TypeVar,
     Union,
     cast,
 )
@@ -27,6 +24,7 @@ from weaviate.collections.classes.grpc import (
     FromNested,
     METADATA,
     PROPERTIES,
+    REFERENCES,
 )
 from weaviate.collections.classes.internal import (
     _GroupByObject,
@@ -35,15 +33,17 @@ from weaviate.collections.classes.internal import (
     _Object,
     _Reference,
     _extract_properties_from_data_model,
+    _extract_references_from_data_model,
     _GenerativeReturn,
     _GroupByResult,
     _GroupByReturn,
     _QueryReturn,
     _QueryOptions,
-    GenerativeReturn,
-    GroupByReturn,
-    QueryReturn,
     ReturnProperties,
+    ReturnReferences,
+    References,
+    TReferences,
+    WeaviateReferences,
 )
 from weaviate.collections.classes.types import (
     Properties,
@@ -55,28 +55,28 @@ from weaviate.exceptions import WeaviateGrpcUnavailable, WeaviateQueryException
 from weaviate.util import file_encoder_b64, parse_version_string, _datetime_from_weaviate_str
 from weaviate.proto.v1 import search_get_pb2, properties_pb2
 
-T = TypeVar("T")
-
 
 class _WeaviateUUID(uuid_lib.UUID):
     def __init__(self, hex_: str) -> None:
         object.__setattr__(self, "int", int(hex_.replace("-", ""), 16))
 
 
-class _Grpc(Generic[Properties]):
+class _BaseQuery(Generic[Properties, References]):
     def __init__(
         self,
         connection: Connection,
         name: str,
         consistency_level: Optional[ConsistencyLevel],
         tenant: Optional[str],
-        type_: Optional[Type[Properties]],
+        properties: Optional[Type[Properties]],
+        references: Optional[Type[References]],
     ):
         self.__connection = connection
         self.__name = name
         self.__tenant = tenant
         self.__consistency_level = consistency_level
-        self._type = type_
+        self._properties = properties
+        self._references = references
         self.__support_byte_vectors = (
             parse_version_string(self.__connection.server_version) > parse_version_string("1.22")
             if self.__connection.server_version != ""
@@ -144,7 +144,6 @@ class _Grpc(Generic[Properties]):
         return add_props.generative if add_props.generative_present else None
 
     def __deserialize_non_ref_prop(self, value: properties_pb2.Value) -> Any:
-        print(value)
         if value.HasField("uuid_value"):
             return uuid_lib.UUID(value.uuid_value)
         if value.HasField("date_value"):
@@ -174,14 +173,14 @@ class _Grpc(Generic[Properties]):
 
     def __parse_ref_properties_result(
         self, properties: RepeatedCompositeFieldContainer[search_get_pb2.RefPropertiesResult]
-    ) -> dict:
+    ) -> Optional[dict]:
         if len(properties) == 0:
-            return {}
+            return None
         return {
             ref_prop.prop_name: _Reference._from(
                 [
                     self.__result_to_query_object(
-                        prop, prop.metadata, Dict[str, Any], _QueryOptions(True, True, True)
+                        prop, prop.metadata, _QueryOptions(True, True, True, True)
                     )
                     for prop in ref_prop.properties
                 ]
@@ -189,26 +188,20 @@ class _Grpc(Generic[Properties]):
             for ref_prop in properties
         }
 
-    def __parse_result(
-        self,
-        properties: search_get_pb2.PropertiesResult,
-    ) -> dict:
-        nonref_result = self.__parse_nonref_properties_result(properties.non_ref_props)
-        ref_result = self.__parse_ref_properties_result(properties.ref_props)
-        return {**nonref_result, **ref_result}
-
     def __result_to_query_object(
         self,
         props: search_get_pb2.PropertiesResult,
         meta: search_get_pb2.MetadataResult,
-        type_: Optional[
-            Type[T]
-        ],  # required until 3.12 is minimum supported version to use new generics syntax
         options: _QueryOptions,
-    ) -> _Object[T]:
-        return _Object[T](
-            properties=cast(T, self.__parse_result(props) if options.include_properties else {}),
+    ) -> _Object[Any, Any]:
+        return _Object(
+            properties=self.__parse_nonref_properties_result(props.non_ref_props)
+            if options.include_properties
+            else {},
             metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else None,
+            references=self.__parse_ref_properties_result(props.ref_props)
+            if options.include_references
+            else None,
             uuid=self.__extract_id_for_object(meta),
             vector=self.__extract_vector_for_object(meta) if options.include_vector else None,
         )
@@ -217,14 +210,16 @@ class _Grpc(Generic[Properties]):
         self,
         props: search_get_pb2.PropertiesResult,
         meta: search_get_pb2.MetadataResult,
-        type_: Optional[
-            Type[T]
-        ],  # required until 3.12 is minimum supported version to use new generics syntax
         options: _QueryOptions,
-    ) -> _GenerativeObject[T]:
-        return _GenerativeObject[T](
-            properties=cast(T, self.__parse_result(props) if options.include_properties else {}),
+    ) -> _GenerativeObject[Any, Any]:
+        return _GenerativeObject(
+            properties=self.__parse_nonref_properties_result(props.non_ref_props)
+            if options.include_properties
+            else {},
             metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else None,
+            references=self.__parse_ref_properties_result(props.ref_props)
+            if options.include_references
+            else None,
             uuid=self.__extract_id_for_object(meta),
             vector=self.__extract_vector_for_object(meta) if options.include_vector else None,
             generated=self.__extract_generated_for_object(meta),
@@ -233,14 +228,11 @@ class _Grpc(Generic[Properties]):
     def __result_to_group(
         self,
         res: GroupByResult,
-        type_: Optional[
-            Type[T]
-        ],  # required until 3.12 is minimum supported version to use new generics syntax
         options: _QueryOptions,
-    ) -> _GroupByResult[T]:
-        return _GroupByResult[T](
+    ) -> _GroupByResult[Any, Any]:
+        return _GroupByResult(
             objects=[
-                self.__result_to_query_object(obj.properties, obj.metadata, type_, options)
+                self.__result_to_query_object(obj.properties, obj.metadata, options)
                 for obj in res.objects
             ],
             name=res.name,
@@ -252,102 +244,97 @@ class _Grpc(Generic[Properties]):
     def _result_to_query_return(
         self,
         res: SearchResponse,
-        type_: Optional[
+        options: _QueryOptions,
+        properties: Optional[
             ReturnProperties[TProperties]
         ],  # required until 3.12 is minimum supported version to use new generics syntax
-        options: _QueryOptions,
-    ) -> QueryReturn[Properties, TProperties]:
-        if is_typeddict(type_):
-            type_ = cast(Type[TProperties], type_)  # we know it's a typeddict
-            return _QueryReturn[TProperties](
-                objects=[
-                    self.__result_to_query_object(obj.properties, obj.metadata, type_, options)
-                    for obj in res.results
-                ]
-            )
-        else:
-            return _QueryReturn[Properties](
-                objects=[
-                    self.__result_to_query_object(obj.properties, obj.metadata, self._type, options)
-                    for obj in res.results
-                ]
-            )
+        references: Optional[
+            ReturnReferences[TReferences]
+        ],  # required until 3.12 is minimum supported version to use new generics syntax
+    ) -> Union[
+        _QueryReturn[Properties, References],
+        _QueryReturn[Properties, WeaviateReferences],
+        _QueryReturn[Properties, TReferences],
+        _QueryReturn[TProperties, References],
+        _QueryReturn[TProperties, WeaviateReferences],
+        _QueryReturn[TProperties, TReferences],
+    ]:
+        return _QueryReturn(
+            objects=[
+                self.__result_to_query_object(obj.properties, obj.metadata, options)
+                for obj in res.results
+            ]
+        )
 
     def _result_to_generative_return(
         self,
         res: SearchResponse,
-        type_: Optional[
+        options: _QueryOptions,
+        properties: Optional[
             ReturnProperties[TProperties]
         ],  # required until 3.12 is minimum supported version to use new generics syntax
-        options: _QueryOptions,
-    ) -> GenerativeReturn[Properties, TProperties]:
-        if is_typeddict(type_):
-            type_ = cast(Type[TProperties], type_)  # we know it's a typeddict
-            return _GenerativeReturn[TProperties](
-                objects=[
-                    self.__result_to_generative_object(obj.properties, obj.metadata, type_, options)
-                    for obj in res.results
-                ],
-                generated=res.generative_grouped_result
-                if res.generative_grouped_result != ""
-                else None,
-            )
-        else:
-            return _GenerativeReturn[Properties](
-                objects=[
-                    self.__result_to_generative_object(
-                        obj.properties, obj.metadata, self._type, options
-                    )
-                    for obj in res.results
-                ],
-                generated=res.generative_grouped_result
-                if res.generative_grouped_result != ""
-                else None,
-            )
+        references: Optional[
+            ReturnReferences[TReferences]
+        ],  # required until 3.12 is minimum supported version to use new generics syntax
+    ) -> Union[
+        _GenerativeReturn[Properties, References],
+        _GenerativeReturn[Properties, WeaviateReferences],
+        _GenerativeReturn[Properties, TReferences],
+        _GenerativeReturn[TProperties, References],
+        _GenerativeReturn[TProperties, WeaviateReferences],
+        _GenerativeReturn[TProperties, TReferences],
+    ]:
+        return _GenerativeReturn(
+            objects=[
+                self.__result_to_generative_object(obj.properties, obj.metadata, options)
+                for obj in res.results
+            ],
+            generated=res.generative_grouped_result
+            if res.generative_grouped_result != ""
+            else None,
+        )
 
     def _result_to_groupby_return(
         self,
         res: SearchResponse,
-        type_: Optional[
+        options: _QueryOptions,
+        properties: Optional[
             ReturnProperties[TProperties]
         ],  # required until 3.12 is minimum supported version to use new generics syntax
-        options: _QueryOptions,
-    ) -> GroupByReturn[Properties, TProperties]:
-        if is_typeddict(type_):
-            type_ = cast(Type[TProperties], type_)  # we know it's a typeddict
-            groups = {
-                group.name: self.__result_to_group(group, type_, options)
-                for group in res.group_by_results
-            }
-            objects_group_by = [
-                _GroupByObject[TProperties](
-                    properties=obj.properties,
-                    metadata=obj.metadata,
-                    belongs_to_group=group.name,
-                    uuid=obj.uuid,
-                    vector=obj.vector,
-                )
-                for group in groups.values()
-                for obj in group.objects
-            ]
-            return _GroupByReturn[TProperties](objects=objects_group_by, groups=groups)
-        else:
-            groupss = {
-                group.name: self.__result_to_group(group, self._type, options)
-                for group in res.group_by_results
-            }
-            objects_group_byy = [
-                _GroupByObject[Properties](
-                    properties=obj.properties,
-                    metadata=obj.metadata,
-                    belongs_to_group=group.name,
-                    uuid=obj.uuid,
-                    vector=obj.vector,
-                )
-                for group in groupss.values()
-                for obj in group.objects
-            ]
-            return _GroupByReturn[Properties](objects=objects_group_byy, groups=groupss)
+        references: Optional[
+            ReturnReferences[TReferences]
+        ],  # required until 3.12 is minimum supported version to use new generics syntax
+    ) -> Union[
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, WeaviateReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, WeaviateReferences],
+        _GroupByReturn[TProperties, TReferences],
+    ]:
+        groups = {
+            group.name: self.__result_to_group(group, options) for group in res.group_by_results
+        }
+        objects_group_by: List[_GroupByObject] = [
+            _GroupByObject(
+                properties=obj.properties,
+                references=obj.references,
+                metadata=obj.metadata,
+                belongs_to_group=group.name,
+                uuid=obj.uuid,
+                vector=obj.vector,
+            )
+            for group in groups.values()
+            for obj in group.objects
+        ]
+        return_ = _GroupByReturn(objects=objects_group_by, groups=groups)
+        return cast(
+            Union[
+                _GroupByReturn[Properties, TReferences],
+                _GroupByReturn[TProperties, TReferences],
+            ],
+            return_,
+        )
 
     def __parse_generic_properties(
         self, generic_properties: Type[TProperties]
@@ -358,23 +345,27 @@ class _Grpc(Generic[Properties]):
             )
         return _extract_properties_from_data_model(generic_properties)
 
-    def __parse_properties(self, return_properties: Optional[PROPERTIES]) -> Optional[PROPERTIES]:
-        return _PropertiesParser().parse(return_properties)
+    # def __parse_properties(self, return_properties: Optional[PROPERTIES]) -> Optional[PROPERTIES]:
+    #     return _PropertiesParser().parse(return_properties)
 
     def _parse_return_properties(
-        self, return_properties: Optional[ReturnProperties[TProperties]]
+        self,
+        return_properties: Optional[ReturnProperties[TProperties]],
     ) -> Optional[PROPERTIES]:
         if (
             isinstance(return_properties, list)
             or isinstance(return_properties, str)
-            or isinstance(return_properties, FromReference)
             or isinstance(return_properties, FromNested)
-            or (return_properties is None and self._type is None)
+            or (return_properties is None and self._properties is None)
         ):
             # return self.__parse_properties(return_properties)
-            return cast(Optional[PROPERTIES], return_properties)
-        elif return_properties is None and self._type is not None:
-            return self.__parse_generic_properties(self._type)
+            return cast(Optional[PROPERTIES], return_properties)  # is not sourced from any generic
+        elif return_properties is None and self._properties is not None:
+            if not is_typeddict(self._properties):
+                return return_properties
+            return _extract_properties_from_data_model(
+                self._properties
+            )  # is sourced from collection-specific generic
         else:
             assert return_properties is not None
             return self.__parse_generic_properties(return_properties)
@@ -390,6 +381,24 @@ class _Grpc(Generic[Properties]):
             ret_md = return_metadata
         return _MetadataQuery.from_public(ret_md, include_vector)
 
+    def _parse_return_references(
+        self, return_references: Optional[ReturnReferences[TReferences]]
+    ) -> Optional[REFERENCES]:
+        if (
+            isinstance(return_references, list)
+            or isinstance(return_references, FromReference)
+            or (return_references is None and self._references is None)
+        ):
+            return return_references
+        elif return_references is None and self._references is not None:
+            if not is_typeddict(self._references):
+                return return_references
+            refs = _extract_references_from_data_model(self._references)
+            return refs
+        else:
+            assert return_references is not None
+            return _extract_references_from_data_model(return_references)
+
     @staticmethod
     def _parse_media(media: Union[str, pathlib.Path, io.BufferedReader]) -> str:
         if isinstance(media, str):  # if already encoded by user
@@ -398,103 +407,103 @@ class _Grpc(Generic[Properties]):
             return file_encoder_b64(media)
 
 
-class _PropertiesParser:
-    def __init__(self) -> None:
-        self.__from_references_by_prop_name: Dict[str, FromReference] = {}
-        self.__non_ref_properties: List[str] = []
+# class _PropertiesParser:
+#     def __init__(self) -> None:
+#         self.__from_references_by_prop_name: Dict[str, FromReference] = {}
+#         self.__non_ref_properties: List[str] = []
 
-    def parse(self, properties: Optional[PROPERTIES]) -> Optional[PROPERTIES]:
-        if (
-            properties is None
-            or isinstance(properties, str)
-            or isinstance(properties, FromReference)
-            or isinstance(properties, FromNested)
-        ):
-            if isinstance(properties, str) and properties.startswith("__"):
-                self.__parse_reference_property_string(properties)
-                # if the user has not specified any return metadata for a reference, we want to return all
-                from_references: List[FromReference] = []
-                for ref in self.__from_references_by_prop_name.values():
-                    if ref.return_metadata is None:
-                        ref.return_metadata = MetadataQuery._full()
-                    from_references.append(ref)
-                return cast(PROPERTIES, from_references)
-            else:
-                return properties
-        elif isinstance(properties, list):
-            for prop in properties:
-                if prop is None:
-                    continue
-                if isinstance(prop, str):
-                    if prop.startswith("__"):
-                        self.__parse_reference_property_string(prop)
-                    else:
-                        self.__non_ref_properties.append(prop)
-                elif isinstance(prop, FromReference):
-                    self.__from_references_by_prop_name[prop.link_on] = prop
-            # if the user has not specified any return metadata for a reference, we want to return all
-            from_references = []
-            for ref in self.__from_references_by_prop_name.values():
-                if ref.return_metadata is None:
-                    ref.return_metadata = MetadataQuery._full()
-                from_references.append(ref)
-            return [*self.__non_ref_properties, *from_references]
-        else:
-            raise TypeError(
-                f"return_properties must be a list of strings and/or FromReferences, a string, or a FromReference but is {type(properties)}"
-            )
+#     def parse(self, properties: Optional[PROPERTIES]) -> Optional[PROPERTIES]:
+#         if (
+#             properties is None
+#             or isinstance(properties, str)
+#             or isinstance(properties, FromReference)
+#             or isinstance(properties, FromNested)
+#         ):
+#             if isinstance(properties, str) and properties.startswith("__"):
+#                 self.__parse_reference_property_string(properties)
+#                 # if the user has not specified any return metadata for a reference, we want to return all
+#                 from_references: List[FromReference] = []
+#                 for ref in self.__from_references_by_prop_name.values():
+#                     if ref.return_metadata is None:
+#                         ref.return_metadata = MetadataQuery._full()
+#                     from_references.append(ref)
+#                 return cast(PROPERTIES, from_references)
+#             else:
+#                 return properties
+#         elif isinstance(properties, list):
+#             for prop in properties:
+#                 if prop is None:
+#                     continue
+#                 if isinstance(prop, str):
+#                     if prop.startswith("__"):
+#                         self.__parse_reference_property_string(prop)
+#                     else:
+#                         self.__non_ref_properties.append(prop)
+#                 elif isinstance(prop, FromReference):
+#                     self.__from_references_by_prop_name[prop.link_on] = prop
+#             # if the user has not specified any return metadata for a reference, we want to return all
+#             from_references = []
+#             for ref in self.__from_references_by_prop_name.values():
+#                 if ref.return_metadata is None:
+#                     ref.return_metadata = MetadataQuery._full()
+#                 from_references.append(ref)
+#             return [*self.__non_ref_properties, *from_references]
+#         else:
+#             raise TypeError(
+#                 f"return_properties must be a list of strings and/or FromReferences, a string, or a FromReference but is {type(properties)}"
+#             )
 
-    def __parse_reference_property_string_without_options(self, ref_prop: str) -> None:
-        match = re.search(r"__([^_]+)", ref_prop)
-        if match is None:
-            raise ValueError(
-                f"return reference property {ref_prop} must be in the format __{{prop_name}} or __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
-            )
-        else:
-            prop_name = match.group(1)
-            existing_from_reference = self.__from_references_by_prop_name.get(prop_name)
-            if existing_from_reference is None:
-                self.__from_references_by_prop_name[prop_name] = FromReference(
-                    link_on=prop_name, return_properties=None, return_metadata=None
-                )
+#     def __parse_reference_property_string_without_options(self, ref_prop: str) -> None:
+#         match = re.search(r"__([^_]+)", ref_prop)
+#         if match is None:
+#             raise ValueError(
+#                 f"return reference property {ref_prop} must be in the format __{{prop_name}} or __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
+#             )
+#         else:
+#             prop_name = match.group(1)
+#             existing_from_reference = self.__from_references_by_prop_name.get(prop_name)
+#             if existing_from_reference is None:
+#                 self.__from_references_by_prop_name[prop_name] = FromReference(
+#                     link_on=prop_name, return_properties=None, return_metadata=None
+#                 )
 
-    def __parse_reference_property_string(self, ref_prop: str) -> None:
-        match_ = re.search(r"__([^_]+)__([^_]+)__([\w_]+)", ref_prop)
-        if match_ is None:
-            self.__parse_reference_property_string_without_options(ref_prop)
-            return
+#     def __parse_reference_property_string(self, ref_prop: str) -> None:
+#         match_ = re.search(r"__([^_]+)__([^_]+)__([\w_]+)", ref_prop)
+#         if match_ is None:
+#             self.__parse_reference_property_string_without_options(ref_prop)
+#             return
 
-        prop_name = match_.group(1)
-        existing_from_reference = self.__from_references_by_prop_name.get(prop_name)
-        properties_or_metadata = match_.group(2)
-        if properties_or_metadata not in ["properties", "metadata"]:
-            raise ValueError(
-                f"return reference property {ref_prop} must be in the format __{{prop_name}} or __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
-            )
-        nested_prop_name = match_.group(3)
-        if existing_from_reference is None:
-            self.__from_references_by_prop_name[prop_name] = FromReference(
-                link_on=prop_name,
-                return_properties=[nested_prop_name]
-                if properties_or_metadata == "properties"
-                else None,
-                return_metadata=MetadataQuery(**{nested_prop_name: True})
-                if properties_or_metadata == "metadata"
-                else None,
-            )
-        else:
-            if properties_or_metadata == "properties":
-                if existing_from_reference.return_properties is None:
-                    self.__from_references_by_prop_name[prop_name].return_properties = [
-                        nested_prop_name
-                    ]
-                else:
-                    assert isinstance(existing_from_reference.return_properties, list)
-                    existing_from_reference.return_properties.append(nested_prop_name)
-            else:
-                if existing_from_reference.return_metadata is None:
-                    metadata = MetadataQuery()
-                else:
-                    metadata = existing_from_reference.return_metadata
-                setattr(metadata, nested_prop_name, True)
-                self.__from_references_by_prop_name[prop_name].return_metadata = metadata
+#         prop_name = match_.group(1)
+#         existing_from_reference = self.__from_references_by_prop_name.get(prop_name)
+#         properties_or_metadata = match_.group(2)
+#         if properties_or_metadata not in ["properties", "metadata"]:
+#             raise ValueError(
+#                 f"return reference property {ref_prop} must be in the format __{{prop_name}} or __{{prop_name}}__{{properties|metadata}}_{{nested_prop_name}} when using string syntax"
+#             )
+#         nested_prop_name = match_.group(3)
+#         if existing_from_reference is None:
+#             self.__from_references_by_prop_name[prop_name] = FromReference(
+#                 link_on=prop_name,
+#                 return_properties=[nested_prop_name]
+#                 if properties_or_metadata == "properties"
+#                 else None,
+#                 return_metadata=MetadataQuery(**{nested_prop_name: True})
+#                 if properties_or_metadata == "metadata"
+#                 else None,
+#             )
+#         else:
+#             if properties_or_metadata == "properties":
+#                 if existing_from_reference.return_properties is None:
+#                     self.__from_references_by_prop_name[prop_name].return_properties = [
+#                         nested_prop_name
+#                     ]
+#                 else:
+#                     assert isinstance(existing_from_reference.return_properties, list)
+#                     existing_from_reference.return_properties.append(nested_prop_name)
+#             else:
+#                 if existing_from_reference.return_metadata is None:
+#                     metadata = MetadataQuery()
+#                 else:
+#                     metadata = existing_from_reference.return_metadata
+#                 setattr(metadata, nested_prop_name, True)
+#                 self.__from_references_by_prop_name[prop_name].return_metadata = metadata

--- a/weaviate/collections/queries/hybrid.py
+++ b/weaviate/collections/queries/hybrid.py
@@ -1,23 +1,25 @@
-from typing import Generic, List, Optional, Type, overload
+from typing import Generic, List, Literal, Optional, Type, Union, overload
 
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES, HybridFusion
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, HybridFusion
 from weaviate.collections.classes.internal import (
     _GenerativeReturn,
     _QueryReturn,
     _Generative,
-    GenerativeReturn,
-    QueryReturn,
     ReturnProperties,
+    ReturnReferences,
     _QueryOptions,
+    References,
+    TReferences,
+    WeaviateReferences,
 )
 from weaviate.collections.classes.types import Properties, TProperties
-from weaviate.collections.queries.base import _Grpc
+from weaviate.collections.queries.base import _BaseQuery
 
 
-class _HybridQuery(Generic[Properties], _Grpc[Properties]):
+class _HybridQuery(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def hybrid(
         self,
@@ -31,8 +33,48 @@ class _HybridQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _QueryReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[Properties, References]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _QueryReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -50,7 +92,46 @@ class _HybridQuery(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _QueryReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[TProperties, References]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _QueryReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
     def hybrid(
@@ -65,8 +146,17 @@ class _HybridQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> QueryReturn[Properties, TProperties]:
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _QueryReturn[Properties, References],
+        _QueryReturn[Properties, WeaviateReferences],
+        _QueryReturn[Properties, TReferences],
+        _QueryReturn[TProperties, References],
+        _QueryReturn[TProperties, WeaviateReferences],
+        _QueryReturn[TProperties, TReferences],
+    ]:
         """Search for objects in this collection using the hybrid algorithm blending keyword-based BM25 and vector-based similarity.
 
         See the [docs](https://weaviate.io/developers/weaviate/search/hybrid) for a more detailed explanation.
@@ -94,10 +184,13 @@ class _HybridQuery(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all non-reference properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_QueryReturn` object that includes the searched objects.
@@ -117,15 +210,23 @@ class _HybridQuery(Generic[Properties], _Grpc[Properties]):
             filters=filters,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_query_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )
 
 
-class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
+class _HybridGenerate(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def hybrid(
         self,
@@ -142,8 +243,54 @@ class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _GenerativeReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[Properties, References]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -164,7 +311,52 @@ class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _GenerativeReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[TProperties, References]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def hybrid(
+        self,
+        query: str,
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        alpha: float = 0.5,
+        vector: Optional[List[float]] = None,
+        query_properties: Optional[List[str]] = None,
+        fusion_type: Optional[HybridFusion] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[TProperties, TReferences]:
         ...
 
     def hybrid(
@@ -182,8 +374,17 @@ class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> GenerativeReturn[Properties, TProperties]:
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _GenerativeReturn[Properties, References],
+        _GenerativeReturn[Properties, WeaviateReferences],
+        _GenerativeReturn[Properties, TReferences],
+        _GenerativeReturn[TProperties, References],
+        _GenerativeReturn[TProperties, WeaviateReferences],
+        _GenerativeReturn[TProperties, TReferences],
+    ]:
         """Perform retrieval-augmented generation (RaG) on the results of an object search in this collection using the hybrid algorithm blending keyword-based BM25 and vector-based similarity.
 
         See the [docs](https://weaviate.io/developers/weaviate/search/hybrid) for a more detailed explanation.
@@ -217,10 +418,13 @@ class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all non-reference properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_GenerativeReturn` object that includes the searched objects with per-object generated results and group generated results.
@@ -240,6 +444,7 @@ class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
             filters=filters,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
             generative=_Generative(
                 single=single_prompt,
                 grouped=grouped_task,
@@ -248,6 +453,13 @@ class _HybridGenerate(Generic[Properties], _Grpc[Properties]):
         )
         return self._result_to_generative_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )

--- a/weaviate/collections/queries/near_audio.py
+++ b/weaviate/collections/queries/near_audio.py
@@ -1,34 +1,32 @@
 from io import BufferedReader
 from pathlib import Path
-from typing import Generic, List, Optional, Type, Union, overload
+from typing import Generic, List, Literal, Optional, Type, Union, overload
 
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import (
-    METADATA,
-    PROPERTIES,
-)
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
     _QueryReturn,
-    GenerativeReturn,
-    GroupByReturn,
-    QueryReturn,
     ReturnProperties,
+    ReturnReferences,
     _QueryOptions,
+    References,
+    WeaviateReferences,
+    TReferences,
 )
 from weaviate.collections.classes.types import (
     Properties,
     TProperties,
 )
-from weaviate.collections.queries.base import _Grpc
+from weaviate.collections.queries.base import _BaseQuery
 
 
-class _NearAudioQuery(Generic[Properties], _Grpc[Properties]):
+class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_audio(
         self,
@@ -40,8 +38,44 @@ class _NearAudioQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _QueryReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _QueryReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -57,7 +91,42 @@ class _NearAudioQuery(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _QueryReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _QueryReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
     def near_audio(
@@ -70,8 +139,17 @@ class _NearAudioQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> QueryReturn[Properties, TProperties]:
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _QueryReturn[Properties, References],
+        _QueryReturn[Properties, WeaviateReferences],
+        _QueryReturn[Properties, TReferences],
+        _QueryReturn[TProperties, References],
+        _QueryReturn[TProperties, WeaviateReferences],
+        _QueryReturn[TProperties, TReferences],
+    ]:
         """Search for objects by audio in this collection using an audio-capable vectorisation module and vector-based similarity search.
 
         See the [docs](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for a more detailed explanation.
@@ -98,10 +176,13 @@ class _NearAudioQuery(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all non-reference properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_QueryReturn` object that includes the searched objects.
@@ -119,15 +200,23 @@ class _NearAudioQuery(Generic[Properties], _Grpc[Properties]):
             autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_query_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )
 
 
-class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
+class _NearAudioGenerate(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_audio(
         self,
@@ -142,8 +231,50 @@ class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _GenerativeReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -162,7 +293,48 @@ class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _GenerativeReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[TProperties, TReferences]:
         ...
 
     def near_audio(
@@ -178,8 +350,17 @@ class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> GenerativeReturn[Properties, TProperties]:
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _GenerativeReturn[Properties, References],
+        _GenerativeReturn[Properties, WeaviateReferences],
+        _GenerativeReturn[Properties, TReferences],
+        _GenerativeReturn[TProperties, References],
+        _GenerativeReturn[TProperties, WeaviateReferences],
+        _GenerativeReturn[TProperties, TReferences],
+    ]:
         """Perform retrieval-augmented generation (RaG) on the results of a by-audio object search in this collection using an audio-capable vectorisation module and vector-based similarity search.
 
         See the [docs](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for a more detailed explanation.
@@ -206,10 +387,13 @@ class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_GenerativeReturn` object that includes the searched objects with per-object generated results and group generated results.
@@ -232,15 +416,23 @@ class _NearAudioGenerate(Generic[Properties], _Grpc[Properties]):
             autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_generative_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )
 
 
-class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
+class _NearAudioGroupBy(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_audio(
         self,
@@ -255,8 +447,50 @@ class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _GroupByReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -275,7 +509,48 @@ class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _GroupByReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
     def near_audio(
@@ -291,8 +566,17 @@ class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> GroupByReturn[Properties, TProperties]:
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, WeaviateReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, WeaviateReferences],
+        _GroupByReturn[TProperties, TReferences],
+    ]:
         """Group the results of a by-audio object search in this collection using an audio-capable vectorisation module and vector-based similarity search.
 
         See the [docs](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for a more detailed explanation.
@@ -325,10 +609,13 @@ class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_GroupByReturn` object that includes the searched objects grouped by the specified property.
@@ -351,9 +638,17 @@ class _NearAudioGroupBy(Generic[Properties], _Grpc[Properties]):
             autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_groupby_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )

--- a/weaviate/collections/queries/near_vector.py
+++ b/weaviate/collections/queries/near_vector.py
@@ -1,32 +1,30 @@
-from typing import Generic, List, Optional, Type, overload
+from typing import Generic, List, Literal, Optional, Type, Union, overload
 
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import (
-    METADATA,
-    PROPERTIES,
-)
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
     _QueryReturn,
-    GenerativeReturn,
-    GroupByReturn,
-    QueryReturn,
     ReturnProperties,
+    ReturnReferences,
     _QueryOptions,
+    References,
+    WeaviateReferences,
+    TReferences,
 )
 from weaviate.collections.classes.types import (
     Properties,
     TProperties,
 )
-from weaviate.collections.queries.base import _Grpc
+from weaviate.collections.queries.base import _BaseQuery
 
 
-class _NearVectorQuery(Generic[Properties], _Grpc[Properties]):
+class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_vector(
         self,
@@ -38,8 +36,44 @@ class _NearVectorQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _QueryReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _QueryReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -55,7 +89,42 @@ class _NearVectorQuery(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _QueryReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _QueryReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
     def near_vector(
@@ -68,15 +137,24 @@ class _NearVectorQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> QueryReturn[Properties, TProperties]:
-        """Search for objects in this collection by a vector using vector-based similarity search.
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _QueryReturn[Properties, References],
+        _QueryReturn[Properties, WeaviateReferences],
+        _QueryReturn[Properties, TReferences],
+        _QueryReturn[TProperties, References],
+        _QueryReturn[TProperties, WeaviateReferences],
+        _QueryReturn[TProperties, TReferences],
+    ]:
+        """Search for objects by vector in this collection using and vector-based similarity search.
 
-        See the [docs](https://weaviate.io/developers/weaviate/api/graphql/search-operators#nearvector) for a more detailed explanation.
+        See the [docs](https://weaviate.io/developers/weaviate/search/similarity) for a more detailed explanation.
 
         Arguments:
             `near_vector`
-                The vector to search on, REQUIRED.
+                The vector to search on, REQUIRED. This can be a base64 encoded string of the binary, a path to the file, or a file-like object.
             `certainty`
                 The minimum similarity score to return. If not specified, the default certainty specified by the server is used.
             `distance`
@@ -93,10 +171,13 @@ class _NearVectorQuery(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all non-reference properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_QueryReturn` object that includes the searched objects.
@@ -109,20 +190,28 @@ class _NearVectorQuery(Generic[Properties], _Grpc[Properties]):
             near_vector=near_vector,
             certainty=certainty,
             distance=distance,
+            filters=filters,
             limit=limit,
             autocut=auto_limit,
-            filters=filters,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_query_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )
 
 
-class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
+class _NearVectorGenerate(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_vector(
         self,
@@ -137,8 +226,50 @@ class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _GenerativeReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -157,7 +288,48 @@ class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _GenerativeReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[TProperties, TReferences]:
         ...
 
     def near_vector(
@@ -173,21 +345,24 @@ class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> GenerativeReturn[Properties, TProperties]:
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _GenerativeReturn[Properties, References],
+        _GenerativeReturn[Properties, WeaviateReferences],
+        _GenerativeReturn[Properties, TReferences],
+        _GenerativeReturn[TProperties, References],
+        _GenerativeReturn[TProperties, WeaviateReferences],
+        _GenerativeReturn[TProperties, TReferences],
+    ]:
         """Perform retrieval-augmented generation (RaG) on the results of a by-vector object search in this collection using vector-based similarity search.
 
-        See the [docs](https://weaviate.io/developers/weaviate/api/graphql/search-operators#nearvector) for a more detailed explanation.
+        See the [docs](https://weaviate.io/developers/weaviate/search/similarity) for a more detailed explanation.
 
         Arguments:
             `near_vector`
-                The vector to search on, REQUIRED.
-            `single_prompt`
-                The prompt to use for single-prompt generation.
-            `grouped_task`
-                The task to use for grouped generation.
-            `grouped_properties`
-                The properties to group on.
+                The vector to search on, REQUIRED. This can be a base64 encoded string of the binary, a path to the file, or a file-like object.
             `certainty`
                 The minimum similarity score to return. If not specified, the default certainty specified by the server is used.
             `distance`
@@ -204,10 +379,13 @@ class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_GenerativeReturn` object that includes the searched objects with per-object generated results and group generated results.
@@ -220,25 +398,33 @@ class _NearVectorGenerate(Generic[Properties], _Grpc[Properties]):
             near_vector=near_vector,
             certainty=certainty,
             distance=distance,
-            limit=limit,
-            autocut=auto_limit,
             filters=filters,
             generative=_Generative(
                 single=single_prompt,
                 grouped=grouped_task,
                 grouped_properties=grouped_properties,
             ),
+            limit=limit,
+            autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_generative_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )
 
 
-class _NearVectorGroupBy(Generic[Properties], _Grpc[Properties]):
+class _NearVectorGroupBy(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_vector(
         self,
@@ -253,8 +439,50 @@ class _NearVectorGroupBy(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _GroupByReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -273,7 +501,48 @@ class _NearVectorGroupBy(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _GroupByReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
     def near_vector(
@@ -289,66 +558,86 @@ class _NearVectorGroupBy(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> GroupByReturn[Properties, TProperties]:
-        """Group the results of a by-vector object search in this collection using vector-based similarity search.
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, WeaviateReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, WeaviateReferences],
+        _GroupByReturn[TProperties, TReferences],
+    ]:
+        """Group the results of a by-vector object search in this collection using a vector-based similarity search.
 
-        See the [docs](https://weaviate.io/developers/weaviate/api/graphql/search-operators#nearvector) for a more detailed explanation.
+        #         See the [docs](https://weaviate.io/developers/weaviate/api/graphql/search-operators#nearobject) for a more detailed explanation.
 
-        Arguments:
-            `near_vector`
-                The vector to search on, REQUIRED.
-            `group_by_property`
-                The property to group on.
-            `number_of_groups`
-                The number of groups to return.
-            `objects_per_group`
-                The number of objects per group to return.
-            `certainty`
-                The minimum similarity score to return. If not specified, the default certainty specified by the server is used.
-            `distance`
-                The maximum distance to search. If not specified, the default distance specified by the server is used.
-            `limit`
-                The maximum number of results to return. If not specified, the default limit specified by the server is returned.
-            `auto_limit`
-                The maximum number of [autocut](https://weaviate.io/developers/weaviate/api/graphql/additional-operators#autocut) results to return. If not specified, no limit is applied.
-            `filters`
-                The filters to apply to the search.
-            `include_vector`
-                Whether to include the vector in the results. If not specified, this is set to False.
-            `return_metadata`
-                The metadata to return for each object, defaults to `None`.
-            `return_properties`
-                The properties to return for each object.
+                Arguments:
+                    `near_vector`
+                        The vector to search on, REQUIRED. This can be a base64 encoded string of the binary, a path to the file, or a file-like object.
+                    `group_by_property`
+                        The property to group by, REQUIRED.
+                    `number_of_groups`
+                        The number of groups to return, REQUIRED.
+                    `objects_per_group`
+                        The number of objects to return per group, REQUIRED.
+                    `certainty`
+                        The minimum similarity score to return. If not specified, the default certainty specified by the server is used.
+                    `distance`
+                        The maximum distance to search. If not specified, the default distance specified by the server is used.
+                    `limit`
+                        The maximum number of results to return. If not specified, the default limit specified by the server is returned.
+                    `auto_limit`
+                        The maximum number of [autocut](https://weaviate.io/developers/weaviate/api/graphql/additional-operators#autocut) results to return. If not specified, no limit is applied.
+                    `filters`
+                        The filters to apply to the search.
+                    `include_vector`
+                        Whether to include the vector in the results. If not specified, this is set to False.
+                    `return_metadata`
+                        The metadata to return for each object, defaults to `None`.
+                    `return_properties`
+                        The properties to return for each object.
+                    `return_references`
+                        The references to return for each object.
 
-        NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
-            If `return_metadata` is not provided then no metadata is provided.
+                NOTE:
+                    If `return_properties` is not provided then all properties are returned including nested properties.
+                    If `return_metadata` is not provided then no metadata is provided.
+                    If `return_references` is not provided then no references are provided.
 
-        Returns:
-            A `_GroupByReturn` object that includes the searched objects grouped by the specified property.
+                Returns:
+                    A `_GroupByReturn` object that includes the searched objects grouped by the specified property.
 
-        Raises:
-            `weaviate.exceptions.WeaviateQueryException`:
-                If the request to the Weaviate server fails.
+                Raises:
+                    `weaviate.exceptions.WeaviateQueryException`:
+                        If the request to the Weaviate server fails.
         """
         res = self._query().near_vector(
             near_vector=near_vector,
             certainty=certainty,
             distance=distance,
-            limit=limit,
-            autocut=auto_limit,
             filters=filters,
             group_by=_GroupBy(
                 prop=group_by_property,
                 number_of_groups=number_of_groups,
                 objects_per_group=objects_per_group,
             ),
+            limit=limit,
+            autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_groupby_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )

--- a/weaviate/collections/queries/near_video.py
+++ b/weaviate/collections/queries/near_video.py
@@ -1,31 +1,32 @@
 from io import BufferedReader
 from pathlib import Path
-from typing import Generic, List, Optional, Type, Union, overload
+from typing import Generic, List, Literal, Optional, Type, Union, overload
 
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import (
-    METADATA,
-    PROPERTIES,
-)
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
     _GroupBy,
     _GroupByReturn,
     _QueryReturn,
-    QueryReturn,
-    GenerativeReturn,
-    GroupByReturn,
     ReturnProperties,
+    ReturnReferences,
     _QueryOptions,
+    References,
+    WeaviateReferences,
+    TReferences,
 )
-from weaviate.collections.classes.types import Properties, TProperties
-from weaviate.collections.queries.base import _Grpc
+from weaviate.collections.classes.types import (
+    Properties,
+    TProperties,
+)
+from weaviate.collections.queries.base import _BaseQuery
 
 
-class _NearVideoQuery(Generic[Properties], _Grpc[Properties]):
+class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_video(
         self,
@@ -37,8 +38,44 @@ class _NearVideoQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _QueryReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _QueryReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -54,7 +91,42 @@ class _NearVideoQuery(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _QueryReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _QueryReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _QueryReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
     def near_video(
@@ -67,14 +139,23 @@ class _NearVideoQuery(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> QueryReturn[Properties, TProperties]:
-        """Search for objects by video in this collection using a video-capable vectorisation module and vector-based similarity search.
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _QueryReturn[Properties, References],
+        _QueryReturn[Properties, WeaviateReferences],
+        _QueryReturn[Properties, TReferences],
+        _QueryReturn[TProperties, References],
+        _QueryReturn[TProperties, WeaviateReferences],
+        _QueryReturn[TProperties, TReferences],
+    ]:
+        """Search for objects by video in this collection using an video-capable vectorisation module and vector-based similarity search.
 
         See the [docs](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for a more detailed explanation.
 
         NOTE:
-            You must have a video-capable vectorisation module installed in order to use this method, e.g. `multi2vec-bind`.
+            You must have an video-capable vectorisation module installed in order to use this method, e.g. `multi2vec-bind`.
 
         Arguments:
             `near_video`
@@ -89,14 +170,19 @@ class _NearVideoQuery(Generic[Properties], _Grpc[Properties]):
                 The maximum number of [autocut](https://weaviate.io/developers/weaviate/api/graphql/additional-operators#autocut) results to return. If not specified, no limit is applied.
             `filters`
                 The filters to apply to the search.
+            `include_vector`
+                Whether to include the vector in the results. If not specified, this is set to False.
             `return_metadata`
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all non-reference properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_QueryReturn` object that includes the searched objects.
@@ -114,15 +200,23 @@ class _NearVideoQuery(Generic[Properties], _Grpc[Properties]):
             autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_query_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )
 
 
-class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
+class _NearVideoGenerate(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_video(
         self,
@@ -137,8 +231,50 @@ class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _GenerativeReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -157,7 +293,48 @@ class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _GenerativeReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _GenerativeReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GenerativeReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        single_prompt: Optional[str] = None,
+        grouped_task: Optional[str] = None,
+        grouped_properties: Optional[List[str]] = None,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GenerativeReturn[TProperties, TReferences]:
         ...
 
     def near_video(
@@ -173,21 +350,27 @@ class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> GenerativeReturn[Properties, TProperties]:
-        """Perform retrieval-augmented generation (RaG) on the results of a by-video object search in this collection using the video-capable vectorisation module and vector-based similarity search.
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _GenerativeReturn[Properties, References],
+        _GenerativeReturn[Properties, WeaviateReferences],
+        _GenerativeReturn[Properties, TReferences],
+        _GenerativeReturn[TProperties, References],
+        _GenerativeReturn[TProperties, WeaviateReferences],
+        _GenerativeReturn[TProperties, TReferences],
+    ]:
+        """Perform retrieval-augmented generation (RaG) on the results of a by-video object search in this collection using an video-capable vectorisation module and vector-based similarity search.
 
         See the [docs](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for a more detailed explanation.
+
+        NOTE:
+            You must have an video-capable vectorisation module installed in order to use this method, e.g. `multi2vec-bind`.
 
         Arguments:
             `near_video`
                 The video file to search on, REQUIRED. This can be a base64 encoded string of the binary, a path to the file, or a file-like object.
-            `single_prompt`
-                A single prompt to use for all objects.
-            `grouped_task`
-                A task to perform on the grouped objects.
-            `grouped_properties`
-                The properties to group on.
             `certainty`
                 The minimum similarity score to return. If not specified, the default certainty specified by the server is used.
             `distance`
@@ -204,10 +387,13 @@ class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_GenerativeReturn` object that includes the searched objects with per-object generated results and group generated results.
@@ -230,15 +416,23 @@ class _NearVideoGenerate(Generic[Properties], _Grpc[Properties]):
             autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_generative_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )
 
 
-class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
+class _NearVideoGroupBy(Generic[Properties, References], _BaseQuery[Properties, References]):
     @overload
     def near_video(
         self,
@@ -253,8 +447,50 @@ class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[PROPERTIES] = None,
-    ) -> _GroupByReturn[Properties]:
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
         ...
 
     @overload
@@ -273,7 +509,48 @@ class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
         return_metadata: Optional[METADATA] = None,
         *,
         return_properties: Type[TProperties],
-    ) -> _GroupByReturn[TProperties]:
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, WeaviateReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        group_by_property: str,
+        number_of_groups: int,
+        objects_per_group: int,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        *,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
     def near_video(
@@ -289,21 +566,33 @@ class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
         filters: Optional[_Filters] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        *,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
-    ) -> GroupByReturn[Properties, TProperties]:
-        """Group the results of a by-video object search in this collection using the video-capable vectorisation module and vector-based similarity search.
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Union[
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, WeaviateReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, WeaviateReferences],
+        _GroupByReturn[TProperties, TReferences],
+    ]:
+        """Group the results of a by-video object search in this collection using an video-capable vectorisation module and vector-based similarity search.
 
         See the [docs](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for a more detailed explanation.
+
+        NOTE:
+            You must have an video-capable vectorisation module installed in order to use this method, e.g. `multi2vec-bind`.
 
         Arguments:
             `near_video`
                 The video file to search on, REQUIRED. This can be a base64 encoded string of the binary, a path to the file, or a file-like object.
             `group_by_property`
-                The property to group on.
+                The property to group by, REQUIRED.
             `number_of_groups`
-                The number of groups to return.
+                The number of groups to return, REQUIRED.
             `objects_per_group`
-                The number of objects per group to return.
+                The number of objects to return per group, REQUIRED.
             `certainty`
                 The minimum similarity score to return. If not specified, the default certainty specified by the server is used.
             `distance`
@@ -320,10 +609,13 @@ class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
                 The metadata to return for each object, defaults to `None`.
             `return_properties`
                 The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         NOTE:
-            If `return_properties` is not provided then all properties are returned except for any cross reference properties.
+            If `return_properties` is not provided then all properties are returned including nested properties.
             If `return_metadata` is not provided then no metadata is provided.
+            If `return_references` is not provided then no references are provided.
 
         Returns:
             A `_GroupByReturn` object that includes the searched objects grouped by the specified property.
@@ -346,9 +638,17 @@ class _NearVideoGroupBy(Generic[Properties], _Grpc[Properties]):
             autocut=auto_limit,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
+            return_references=self._parse_return_references(return_references),
         )
         return self._result_to_groupby_return(
             res,
+            _QueryOptions.from_input(
+                return_metadata,
+                return_properties,
+                include_vector,
+                self._references,
+                return_references,
+            ),
             return_properties,
-            _QueryOptions.from_input(return_metadata, return_properties, include_vector),
+            return_references,
         )

--- a/weaviate/collections/query.py
+++ b/weaviate/collections/query.py
@@ -6,7 +6,7 @@ from typing import (
 
 from weaviate.collections.classes.config import ConsistencyLevel
 
-from weaviate.collections.classes.internal import _Object
+from weaviate.collections.classes.internal import _Object, References
 from weaviate.collections.classes.types import TProperties
 
 from weaviate.collections.data import _DataCollection
@@ -50,16 +50,16 @@ from weaviate.types import UUID
 
 
 class _QueryCollection(
-    Generic[TProperties],
-    _BM25Query[TProperties],
-    _FetchObjectsQuery[TProperties],
-    _HybridQuery,
-    _NearAudioQuery,
-    _NearImageQuery,
-    _NearObjectQuery,
-    _NearTextQuery,
-    _NearVectorQuery,
-    _NearVideoQuery,
+    Generic[TProperties, References],
+    _BM25Query[TProperties, References],
+    _FetchObjectsQuery[TProperties, References],
+    _HybridQuery[TProperties, References],
+    _NearAudioQuery[TProperties, References],
+    _NearImageQuery[TProperties, References],
+    _NearObjectQuery[TProperties, References],
+    _NearTextQuery[TProperties, References],
+    _NearVectorQuery[TProperties, References],
+    _NearVideoQuery[TProperties, References],
 ):
     def __init__(
         self,
@@ -69,13 +69,14 @@ class _QueryCollection(
         consistency_level: Optional[ConsistencyLevel],
         tenant: Optional[str],
         type_: Optional[Type[TProperties]],
+        references: Optional[Type[References]],
     ):
-        super().__init__(connection, name, consistency_level, tenant, type_)
+        super().__init__(connection, name, consistency_level, tenant, type_, references)
         self.__data = rest_query
 
     def fetch_object_by_id(
         self, uuid: UUID, include_vector: bool = False
-    ) -> Optional[_Object[TProperties]]:
+    ) -> Optional[_Object[TProperties, dict]]:
         """Retrieve an object from the server by its UUID.
 
         Arguments:
@@ -97,31 +98,33 @@ class _QueryCollection(
 
 
 class _GenerateCollection(
-    _BM25Generate,
-    _FetchObjectsGenerate,
-    _HybridGenerate,
-    _NearAudioGenerate,
-    _NearImageGenerate,
-    _NearObjectGenerate,
-    _NearTextGenerate,
-    _NearVectorGenerate,
-    _NearVideoGenerate,
+    Generic[TProperties, References],
+    _BM25Generate[TProperties, References],
+    _FetchObjectsGenerate[TProperties, References],
+    _HybridGenerate[TProperties, References],
+    _NearAudioGenerate[TProperties, References],
+    _NearImageGenerate[TProperties, References],
+    _NearObjectGenerate[TProperties, References],
+    _NearTextGenerate[TProperties, References],
+    _NearVectorGenerate[TProperties, References],
+    _NearVideoGenerate[TProperties, References],
 ):
     pass
 
 
 class _GroupByCollection(
-    _NearAudioGroupBy,
-    _NearImageGroupBy,
-    _NearObjectGroupBy,
-    _NearTextGroupBy,
-    _NearVectorGroupBy,
-    _NearVideoGroupBy,
+    Generic[TProperties, References],
+    _NearAudioGroupBy[TProperties, References],
+    _NearImageGroupBy[TProperties, References],
+    _NearObjectGroupBy[TProperties, References],
+    _NearTextGroupBy[TProperties, References],
+    _NearVectorGroupBy[TProperties, References],
+    _NearVideoGroupBy[TProperties, References],
 ):
     pass
 
 
-# class _GrpcCollectionModel(Generic[Model], _Grpc[Any]):
+# class _GrpcCollectionModel(Generic[Model], _BaseQuery[Any]):
 #     def __init__(
 #         self,
 #         connection: Connection,

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -144,8 +144,8 @@ class AdditionalPropertiesException(WeaviateBaseError):
 class InvalidDataModelException(WeaviateBaseError):
     """Is raised when the user provides a generic that is not supported"""
 
-    def __init__(self) -> None:
-        msg = """data_model can only be a dict type, e.g. Dict[str, str], or a class that inherits from TypedDict"""
+    def __init__(self, type_: str) -> None:
+        msg = f"""{type_} can only be a dict type, e.g. Dict[str, Any], or a class that inherits from TypedDict"""
         super().__init__(msg)
 
 

--- a/weaviate/types.py
+++ b/weaviate/types.py
@@ -2,6 +2,7 @@ import datetime
 import uuid as uuid_package
 from typing import Dict, Union, List, Tuple
 
+DATE = datetime.datetime
 UUID = Union[str, uuid_package.UUID]
 UUIDS = Union[List[UUID], UUID]
 NUMBER = Union[int, float]
@@ -29,4 +30,4 @@ DATATYPE_TO_PYTHON_TYPE = {
 PYTHON_TYPE_TO_DATATYPE = {val: key for key, val in DATATYPE_TO_PYTHON_TYPE.items()}
 TIME = datetime.datetime
 
-WeaviateField = Union[str, bool, int, float, UUID, GEO_COORDINATES, List["WeaviateField"]]
+WeaviateField = Union[str, bool, int, float, DATE, UUID, GEO_COORDINATES, List["WeaviateField"]]


### PR DESCRIPTION
This PR marks a significant refactoring of the API surface to split `properties` and `references` out to become independent entities within the client. It does this so that references are more easily accessed both by non-generic and generic users