### PR TITLE
UI improvements

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -928,7 +928,7 @@ def test_tenants(client: weaviate.WeaviateClient):
     client.collections.delete("Tenants")
 
 
-def test_multi_searches(client: weaviate.WeaviateClient):
+def test_multi_searches(client: weaviate.WeaviateClient) -> None:
     collection = client.collections.create(
         name="TestMultiSearches",
         properties=[Property(name="name", data_type=DataType.TEXT)],
@@ -949,12 +949,12 @@ def test_multi_searches(client: weaviate.WeaviateClient):
     objects = collection.query.bm25(query="other").objects
     assert "name" in objects[0].properties
     assert objects[0].uuid is not None
-    assert objects[0].metadata is None
+    assert objects[0].metadata._is_empty()
 
     objects = collection.query.bm25(query="other", return_properties=[]).objects
     assert "name" not in objects[0].properties
     assert objects[0].uuid is not None
-    assert objects[0].metadata is None
+    assert objects[0].metadata._is_empty()
 
     client.collections.delete("TestMultiSearches")
 
@@ -1118,7 +1118,7 @@ def test_return_properties_and_return_metadata_combos(
     return_properties: Optional[PROPERTIES],
     return_metadata: Optional[MetadataQuery],
     include_vector: bool,
-):
+) -> None:
     client.collections.delete("TestReturnEverything")
     collection = client.collections.create(
         name="TestReturnEverything",
@@ -1159,7 +1159,7 @@ def test_return_properties_and_return_metadata_combos(
         or return_metadata == MetadataQuery()
         or (isinstance(return_metadata, list) and len(return_metadata) == 0)
     ):
-        assert objects[0].metadata is None
+        assert objects[0].metadata._is_empty()
     else:
         assert objects[0].metadata.last_update_time_unix is not None
         assert objects[0].metadata.creation_time_unix is not None
@@ -1733,7 +1733,7 @@ def test_iterator_arguments(
     include_vector: bool,
     return_metadata: Optional[METADATA],
     return_properties: Optional[Union[PROPERTIES, Type[Properties]]],
-):
+) -> None:
     name = "TestIteratorTypedDict"
     client.collections.delete(name)
 
@@ -1782,7 +1782,7 @@ def test_iterator_arguments(
             assert all(obj.metadata.creation_time_unix is not None for obj in iter_)
             assert all(obj.metadata.score is not None for obj in iter_)
         else:
-            assert all(obj.metadata is None for obj in iter_)
+            assert all(obj.metadata._is_empty() for obj in iter_)
     # Expect specified properties and no vector
     elif not include_vector and return_properties is not None:
         all_data: list[int] = sorted([int(obj.properties["data"]) for obj in iter_])
@@ -1793,7 +1793,7 @@ def test_iterator_arguments(
             assert all(obj.metadata.creation_time_unix is not None for obj in iter_)
             assert all(obj.metadata.score is not None for obj in iter_)
         else:
-            assert all(obj.metadata is None for obj in iter_)
+            assert all(obj.metadata._is_empty() for obj in iter_)
 
 
 def test_iterator_dict_hint(client: weaviate.WeaviateClient) -> None:

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -882,11 +882,7 @@ def test_filter_timestamp_direct_path(client: weaviate.WeaviateClient, path: str
     assert obj2.metadata is not None
     assert obj2.metadata.creation_time_unix is not None
 
-    date = datetime.datetime.fromtimestamp(
-        obj2.metadata.creation_time_unix / 1000, tz=datetime.timezone.utc
-    )
-
-    filters = Filter(path=[path]).less_than(date)
+    filters = Filter(path=[path]).less_than(obj2.metadata.creation_time_unix)
     objects = collection.query.fetch_objects(
         filters=filters, return_metadata=MetadataQuery(creation_time_unix=True)
     ).objects

--- a/weaviate/collections/classes/filters.py
+++ b/weaviate/collections/classes/filters.py
@@ -1,13 +1,11 @@
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Union
 
 from weaviate.types import UUID
 from weaviate.proto.v1 import search_get_pb2
 from weaviate.util import get_valid_uuid
-
-DATE = Union[datetime, int]
 
 
 class _Operator(str, Enum):
@@ -224,73 +222,66 @@ class _FilterId:
 
 class _FilterTime:
     @staticmethod
-    def contains_any(dates: List[DATE], on_reference_path: List[str]) -> _FilterValue:
+    def contains_any(dates: List[datetime], on_reference_path: List[str]) -> _FilterValue:
         return _FilterValue(
             path=on_reference_path,
-            value=[_FilterTime._convert_date(date) for date in dates],
+            value=dates,
             operator=_Operator.CONTAINS_ANY,
         )
 
     @staticmethod
-    def equal(date: DATE, on_reference_path: List[str]) -> _FilterValue:
+    def equal(date: datetime, on_reference_path: List[str]) -> _FilterValue:
         return _FilterValue(
             path=on_reference_path,
-            value=_FilterTime._convert_date(date),
+            value=date,
             operator=_Operator.EQUAL,
         )
 
     @staticmethod
-    def not_equal(date: DATE, on_reference_path: List[str]) -> _FilterValue:
+    def not_equal(date: datetime, on_reference_path: List[str]) -> _FilterValue:
         return _FilterValue(
             path=on_reference_path,
-            value=_FilterTime._convert_date(date),
+            value=date,
             operator=_Operator.NOT_EQUAL,
         )
 
     @staticmethod
-    def less_than(date: DATE, on_reference_path: List[str]) -> _FilterValue:
+    def less_than(date: datetime, on_reference_path: List[str]) -> _FilterValue:
         return _FilterValue(
             path=on_reference_path,
-            value=_FilterTime._convert_date(date),
+            value=date,
             operator=_Operator.LESS_THAN,
         )
 
     @staticmethod
-    def less_or_equal(date: DATE, on_reference_path: List[str]) -> _FilterValue:
+    def less_or_equal(date: datetime, on_reference_path: List[str]) -> _FilterValue:
         return _FilterValue(
             path=on_reference_path,
-            value=_FilterTime._convert_date(date),
+            value=date,
             operator=_Operator.LESS_THAN_EQUAL,
         )
 
     @staticmethod
-    def greater_than(date: DATE, on_reference_path: List[str]) -> _FilterValue:
+    def greater_than(date: datetime, on_reference_path: List[str]) -> _FilterValue:
         return _FilterValue(
             path=on_reference_path,
-            value=_FilterTime._convert_date(date),
+            value=date,
             operator=_Operator.GREATER_THAN,
         )
 
     @staticmethod
-    def greater_or_equal(date: DATE, on_reference_path: List[str]) -> _FilterValue:
+    def greater_or_equal(date: datetime, on_reference_path: List[str]) -> _FilterValue:
         return _FilterValue(
             path=on_reference_path,
-            value=_FilterTime._convert_date(date),
+            value=date,
             operator=_Operator.GREATER_THAN_EQUAL,
         )
-
-    @staticmethod
-    def _convert_date(date: DATE) -> datetime:
-        if isinstance(date, datetime):
-            return date
-        # weaviate returns a different timestamp format
-        return datetime.fromtimestamp(date / 1000, tz=timezone.utc)
 
 
 class _FilterCreationTime(_FilterTime):
     @staticmethod
     def contains_any(
-        dates: List[DATE], on_reference_path: Optional[List[str]] = None
+        dates: List[datetime], on_reference_path: Optional[List[str]] = None
     ) -> _FilterValue:
         """Filter for objects that have been created at the given time.
 
@@ -303,7 +294,7 @@ class _FilterCreationTime(_FilterTime):
         return _FilterTime.contains_any(dates, _FilterCreationTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def equal(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the creation time is equal to the given time.
 
         Arguments:
@@ -315,7 +306,7 @@ class _FilterCreationTime(_FilterTime):
         return _FilterTime.equal(date, _FilterCreationTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def not_equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def not_equal(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the creation time is not equal to the given time.
 
         Arguments:
@@ -327,7 +318,7 @@ class _FilterCreationTime(_FilterTime):
         return _FilterTime.not_equal(date, _FilterCreationTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def less_than(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def less_than(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the creation time is less than the given time.
 
         Arguments:
@@ -339,7 +330,9 @@ class _FilterCreationTime(_FilterTime):
         return _FilterTime.less_than(date, _FilterCreationTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def less_or_equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def less_or_equal(
+        date: datetime, on_reference_path: Optional[List[str]] = None
+    ) -> _FilterValue:
         """Filter on whether the creation time is less than or equal to the given time.
 
         Arguments:
@@ -351,7 +344,7 @@ class _FilterCreationTime(_FilterTime):
         return _FilterTime.less_or_equal(date, _FilterCreationTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def greater_than(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def greater_than(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the creation time is greater than the given time.
 
         Arguments:
@@ -363,7 +356,9 @@ class _FilterCreationTime(_FilterTime):
         return _FilterTime.greater_than(date, _FilterCreationTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def greater_or_equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def greater_or_equal(
+        date: datetime, on_reference_path: Optional[List[str]] = None
+    ) -> _FilterValue:
         """Filter on whether the creation time is greater than or equal to the given time.
 
         Arguments:
@@ -384,7 +379,7 @@ class _FilterCreationTime(_FilterTime):
 class _FilterUpdateTime:
     @staticmethod
     def contains_any(
-        dates: List[DATE], on_reference_path: Optional[List[str]] = None
+        dates: List[datetime], on_reference_path: Optional[List[str]] = None
     ) -> _FilterValue:
         """Filter for objects that have been last update at the given time.
 
@@ -397,7 +392,7 @@ class _FilterUpdateTime:
         return _FilterTime.contains_any(dates, _FilterUpdateTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def equal(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the last update time is equal to the given time.
 
         Arguments:
@@ -409,7 +404,7 @@ class _FilterUpdateTime:
         return _FilterTime.equal(date, _FilterUpdateTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def not_equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def not_equal(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the last update time is not equal to the given time.
 
         Arguments:
@@ -421,7 +416,7 @@ class _FilterUpdateTime:
         return _FilterTime.not_equal(date, _FilterUpdateTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def less_than(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def less_than(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the last update time is less than the given time.
 
         Arguments:
@@ -433,7 +428,9 @@ class _FilterUpdateTime:
         return _FilterTime.less_than(date, _FilterUpdateTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def less_or_equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def less_or_equal(
+        date: datetime, on_reference_path: Optional[List[str]] = None
+    ) -> _FilterValue:
         """Filter on whether the last update time is less than or equal to the given time.
 
         Arguments:
@@ -445,7 +442,7 @@ class _FilterUpdateTime:
         return _FilterTime.less_or_equal(date, _FilterUpdateTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def greater_than(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def greater_than(date: datetime, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
         """Filter on whether the last update time is greater than the given time.
 
         Arguments:
@@ -457,7 +454,9 @@ class _FilterUpdateTime:
         return _FilterTime.greater_than(date, _FilterUpdateTime._prepare_path(on_reference_path))
 
     @staticmethod
-    def greater_or_equal(date: DATE, on_reference_path: Optional[List[str]] = None) -> _FilterValue:
+    def greater_or_equal(
+        date: datetime, on_reference_path: Optional[List[str]] = None
+    ) -> _FilterValue:
         """Filter on whether the last update time is greater than or equal to the given time.
 
         Arguments:

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -65,13 +65,13 @@ def _metadata_from_dict(
 
 @dataclass
 class _MetadataReturn:
-    creation_time_unix: Optional[int]
-    last_update_time_unix: Optional[int]
-    distance: Optional[float]
-    certainty: Optional[float]
-    score: Optional[float]
-    explain_score: Optional[str]
-    is_consistent: Optional[bool]
+    creation_time_unix: Optional[int] = None
+    last_update_time_unix: Optional[int] = None
+    distance: Optional[float] = None
+    certainty: Optional[float] = None
+    score: Optional[float] = None
+    explain_score: Optional[str] = None
+    is_consistent: Optional[bool] = None
 
     def _is_empty(self) -> bool:
         return all(

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -1,3 +1,4 @@
+import datetime
 import sys
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union, cast
@@ -65,8 +66,8 @@ def _metadata_from_dict(
 
 @dataclass
 class _MetadataReturn:
-    creation_time_unix: Optional[int] = None
-    last_update_time_unix: Optional[int] = None
+    creation_time_unix: Optional[datetime.datetime] = None
+    last_update_time_unix: Optional[datetime.datetime] = None
     distance: Optional[float] = None
     certainty: Optional[float] = None
     score: Optional[float] = None
@@ -97,8 +98,8 @@ class _Object(Generic[P]):
 
 @dataclass
 class _MetadataSingleObjectReturn:
-    creation_time_unix: int
-    last_update_time_unix: int
+    creation_time_unix: datetime.datetime
+    last_update_time_unix: datetime.datetime
     is_consistent: Optional[bool]
 
 

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -91,7 +91,7 @@ class _MetadataReturn:
 @dataclass
 class _Object(Generic[P]):
     uuid: uuid_package.UUID
-    metadata: Optional[_MetadataReturn]
+    metadata: _MetadataReturn
     properties: P
     vector: Optional[List[float]]
 

--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -10,8 +10,6 @@ from typing import (
     Type,
     Union,
     cast,
-    get_type_hints,
-    get_origin,
 )
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -309,27 +307,6 @@ class _DataCollection(Generic[Properties], _Data):
         _check_data_model(data_model)
         return _DataCollection[TProperties](
             self._connection, self.name, self._consistency_level, self._tenant, data_model
-        )
-
-    def __deserialize_properties(self, data: Dict[str, Any]) -> Properties:
-        hints = (
-            get_type_hints(self.__type)
-            if self.__type and not get_origin(self.__type) == dict
-            else {}
-        )
-        return cast(
-            Properties,
-            {key: self._deserialize_primitive(val, hints.get(key)) for key, val in data.items()},
-        )
-
-    def _json_to_object(self, obj: Dict[str, Any]) -> _Object[Properties]:
-        props = self.__deserialize_properties(obj["properties"])
-        uuid, vector, metadata = _metadata_from_dict(obj)
-        return _Object[Properties](
-            metadata=metadata,
-            properties=cast(Properties, props),
-            uuid=uuid,
-            vector=vector,
         )
 
     def insert(

--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -326,7 +326,7 @@ class _DataCollection(Generic[Properties], _Data):
         props = self.__deserialize_properties(obj["properties"])
         uuid, vector, metadata = _metadata_from_dict(obj)
         return _Object[Properties](
-            metadata=None if metadata._is_empty() else metadata,
+            metadata=metadata,
             properties=cast(Properties, props),
             uuid=uuid,
             vector=vector,

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import pathlib
 import re
@@ -211,7 +212,9 @@ class _Grpc(Generic[Properties]):
     ) -> _Object[T]:
         return _Object[T](
             properties=cast(T, self.__parse_result(props) if options.include_properties else {}),
-            metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else _MetadataReturn(),
+            metadata=self.__extract_metadata_for_object(meta)
+            if options.include_metadata
+            else _MetadataReturn(),
             uuid=self.__extract_id_for_object(meta),
             vector=self.__extract_vector_for_object(meta) if options.include_vector else None,
         )
@@ -227,7 +230,9 @@ class _Grpc(Generic[Properties]):
     ) -> _GenerativeObject[T]:
         return _GenerativeObject[T](
             properties=cast(T, self.__parse_result(props) if options.include_properties else {}),
-            metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else _MetadataReturn(),
+            metadata=self.__extract_metadata_for_object(meta)
+            if options.include_metadata
+            else _MetadataReturn(),
             uuid=self.__extract_id_for_object(meta),
             vector=self.__extract_vector_for_object(meta) if options.include_vector else None,
             generated=self.__extract_generated_for_object(meta),

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -97,21 +97,25 @@ class _Grpc(Generic[Properties]):
     def __extract_metadata_for_object(
         self,
         add_props: "search_get_pb2.MetadataResult",
-    ) -> Optional[_MetadataReturn]:
+    ) -> _MetadataReturn:
         meta = _MetadataReturn(
             distance=add_props.distance if add_props.distance_present else None,
             certainty=add_props.certainty if add_props.certainty_present else None,
-            creation_time_unix=add_props.creation_time_unix
+            creation_time_unix=datetime.datetime.fromtimestamp(
+                add_props.creation_time_unix / 1000, tz=datetime.timezone.utc
+            )
             if add_props.creation_time_unix_present
             else None,
-            last_update_time_unix=add_props.last_update_time_unix
+            last_update_time_unix=datetime.datetime.fromtimestamp(
+                add_props.last_update_time_unix / 1000, tz=datetime.timezone.utc
+            )
             if add_props.last_update_time_unix_present
             else None,
             score=add_props.score if add_props.score_present else None,
             explain_score=add_props.explain_score if add_props.explain_score_present else None,
             is_consistent=add_props.is_consistent if add_props.is_consistent_present else None,
         )
-        return None if meta._is_empty() else meta
+        return meta
 
     def __extract_id_for_object(
         self,
@@ -223,7 +227,7 @@ class _Grpc(Generic[Properties]):
     ) -> _GenerativeObject[T]:
         return _GenerativeObject[T](
             properties=cast(T, self.__parse_result(props) if options.include_properties else {}),
-            metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else None,
+            metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else _MetadataReturn(),
             uuid=self.__extract_id_for_object(meta),
             vector=self.__extract_vector_for_object(meta) if options.include_vector else None,
             generated=self.__extract_generated_for_object(meta),

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -207,7 +207,7 @@ class _Grpc(Generic[Properties]):
     ) -> _Object[T]:
         return _Object[T](
             properties=cast(T, self.__parse_result(props) if options.include_properties else {}),
-            metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else None,
+            metadata=self.__extract_metadata_for_object(meta) if options.include_metadata else _MetadataReturn(),
             uuid=self.__extract_id_for_object(meta),
             vector=self.__extract_vector_for_object(meta) if options.include_vector else None,
         )


### PR DESCRIPTION
- make Metadate non-optional. Each entry is already optional and that saves users (and us) from doing
```
assert obj is not None
assert obj.metadata is not None. <= this can go away
assert obj.metadata.XXX is not None
```
- return creation and update time as datetimes. Before they were returned as unixtime stamps integers, however their format is not what datetime.fromtimestamp expects/.totimestamp outputs.
- remove support for ints from metadata filter. This was only added to support filtering by a time that was taken from obejct metadata. Now that this is changed to datettime, it is not necessary anymore

Removing the code needed to make the metadata optional also slightly speeds up vector search queries