### PR TITLE
Fully support new API surface with `<1.23` Weaviate

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,9 +91,6 @@ jobs:
           { py: "3.12", weaviate: "1.23.0-rc.0-b454247"}
         ]
         optional_dependencies: [false]
-        include:
-          - version: "3.11"
-            optional_dependencies: true
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -107,7 +107,7 @@ jobs:
           pip install -r requirements-devel.txt
           pip install .
       - name: start weaviate
-        run: /bin/bash ci/start_weaviate.sh ${{ matrix.versions.weaviate }}
+        run: export WEAVIATE_VERSION=${{ matrix.versions.weaviate }} & /bin/bash ci/start_weaviate.sh
       - name: Run integration tests with auth secrets
         if: ${{ !github.event.pull_request.head.repo.fork }}
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -178,6 +178,13 @@ jobs:
   test-package:
     needs: [build-package]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server: [
+          "1.22.6",
+          "1.23.0-rc.0-b454247",
+        ]
     steps:
       - name: Download build artifact to append to release
         uses: actions/download-artifact@v3
@@ -192,7 +199,7 @@ jobs:
           fetch-depth: 0
       - run: rm -r weaviate
       - name: start weaviate
-        run: /bin/bash ci/start_weaviate.sh
+        run: /bin/bash ci/start_weaviate.sh ${{ matrix.server }}
       - name: Run integration tests with auth secrets
         if: ${{ !github.event.pull_request.head.repo.fork }}
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -107,7 +107,7 @@ jobs:
           pip install -r requirements-devel.txt
           pip install .
       - name: start weaviate
-        run: export WEAVIATE_VERSION=${{ matrix.versions.weaviate }} & /bin/bash ci/start_weaviate.sh
+        run: /bin/bash ci/start_weaviate.sh ${{ matrix.versions.weaviate }}
       - name: Run integration tests with auth secrets
         if: ${{ !github.event.pull_request.head.repo.fork }}
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -82,7 +82,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "3.8", "3.9", "3.10", "3.11"]
+        versions: [
+          { py: "3.8", weaviate: "1.23.0-rc.0-b454247"},
+          { py: "3.9", weaviate: "1.23.0-rc.0-b454247"},
+          { py: "3.10", weaviate: "1.23.0-rc.0-b454247"},
+          { py: "3.11", weaviate: "1.23.0-rc.0-b454247"},
+          { py: "3.11", weaviate: "1.22.6"},
+          { py: "3.12", weaviate: "1.23.0-rc.0-b454247"}
+        ]
         optional_dependencies: [false]
         include:
           - version: "3.11"
@@ -94,13 +101,13 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.version }}
+          python-version: ${{ matrix.versions.py }}
           cache: 'pip' # caching pip dependencies
       - run: |
           pip install -r requirements-devel.txt
           pip install .
       - name: start weaviate
-        run: /bin/bash ci/start_weaviate.sh
+        run: /bin/bash ci/start_weaviate.sh ${{ matrix.versions.weaviate }}
       - name: Run integration tests with auth secrets
         if: ${{ !github.event.pull_request.head.repo.fork }}
         env:
@@ -114,7 +121,7 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.fork }}
         run: pytest -v --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage-integration.xml integration
       - name: Archive code coverage results
-        if: matrix.version == '3.10' && (github.ref_name != 'main')
+        if: matrix.versions.py == '3.10' && (github.ref_name != 'main')
         uses: actions/upload-artifact@v3
         with:
           name: coverage-report-integration

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,10 @@ on:
       - publishing.md
   pull_request:
 
+env:
+  OLD_WEAVIATE_VERSION: 1.22.6
+  NEW_WEAVIATE_VERSION: 1.23.0-rc.0-1db42dc
+
 jobs:
   lint-and-format:
     name: Run Linter and Formatter
@@ -83,12 +87,12 @@ jobs:
       fail-fast: false
       matrix:
         versions: [
-          { py: "3.8", weaviate: "1.23.0-rc.0-1db42dc"},
-          { py: "3.9", weaviate: "1.23.0-rc.0-1db42dc"},
-          { py: "3.10", weaviate: "1.23.0-rc.0-1db42dc"},
-          { py: "3.11", weaviate: "1.23.0-rc.0-1db42dc"},
-          { py: "3.11", weaviate: "1.22.6"},
-          { py: "3.12", weaviate: "1.23.0-rc.0-1db42dc"}
+          { py: "3.8", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.9", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.10", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.11", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.11", weaviate: $OLD_WEAVIATE_VERSION},
+          { py: "3.12", weaviate: $NEW_WEAVIATE_VERSION}
         ]
         optional_dependencies: [false]
     steps:
@@ -182,8 +186,8 @@ jobs:
       fail-fast: false
       matrix:
         server: [
-          "1.22.6",
-          "1.23.0-rc.0-b454247",
+          $OLD_WEAVIATE_VERSION,
+          $NEW_WEAVIATE_VERSION,
         ]
     steps:
       - name: Download build artifact to append to release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,12 +83,12 @@ jobs:
       fail-fast: false
       matrix:
         versions: [
-          { py: "3.8", weaviate: "1.23.0-rc.0-b454247"},
-          { py: "3.9", weaviate: "1.23.0-rc.0-b454247"},
-          { py: "3.10", weaviate: "1.23.0-rc.0-b454247"},
-          { py: "3.11", weaviate: "1.23.0-rc.0-b454247"},
+          { py: "3.8", weaviate: "1.23.0-rc.0-1db42dc"},
+          { py: "3.9", weaviate: "1.23.0-rc.0-1db42dc"},
+          { py: "3.10", weaviate: "1.23.0-rc.0-1db42dc"},
+          { py: "3.11", weaviate: "1.23.0-rc.0-1db42dc"},
           { py: "3.11", weaviate: "1.22.6"},
-          { py: "3.12", weaviate: "1.23.0-rc.0-b454247"}
+          { py: "3.12", weaviate: "1.23.0-rc.0-1db42dc"}
         ]
         optional_dependencies: [false]
     steps:

--- a/ci/docker-compose-async.yml
+++ b/ci/docker-compose-async.yml
@@ -9,7 +9,7 @@ services:
       - '8090'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - "8090:8090"
       - "50060:50051"

--- a/ci/docker-compose-azure.yml
+++ b/ci/docker-compose-azure.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -26,7 +26,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8088:8080
       - "50059:50051"

--- a/ci/docker-compose-generative.yml
+++ b/ci/docker-compose-generative.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8086:8086
       - "50057:50051"

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.0-b454247
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - "8080:8080"
       - "50051:50051"

--- a/ci/start_weaviate.sh
+++ b/ci/start_weaviate.sh
@@ -2,6 +2,8 @@
 
 set -eou pipefail
 
+export WEAVIATE_VERSION=$1
+
 echo "Run Docker compose"
 nohup docker-compose -f ci/docker-compose.yml up -d
 nohup docker-compose -f ci/docker-compose-async.yml up -d

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -4,8 +4,6 @@ import pytest
 
 import weaviate
 
-# GIT_HASH = "b454247"
-# SERVER_VERSION = "1.23.0-rc.0"
 NODE_NAME = "node1"
 NUM_OBJECT = 10
 
@@ -36,13 +34,13 @@ def test_get_nodes_status_without_data(client: weaviate.Client):
     """get nodes status without data"""
     resp = client.cluster.get_nodes_status(output="verbose")
     assert len(resp) == 1
-    # assert resp[0]["gitHash"] == GIT_HASH
+    assert "gitHash" in resp[0]
     assert resp[0]["name"] == NODE_NAME
     assert resp[0]["shards"] is None  # no class given
     assert resp[0]["stats"]["objectCount"] == 0
     assert resp[0]["stats"]["shardCount"] == 0
     assert resp[0]["status"] == "HEALTHY"
-    # assert resp[0]["version"] == SERVER_VERSION
+    assert "version" in resp[0]
 
 
 def test_get_nodes_status_with_data(client: weaviate.Client):
@@ -59,15 +57,15 @@ def test_get_nodes_status_with_data(client: weaviate.Client):
         client.data_object.create({"stringProp": f"object-{i}", "intProp": i}, class_name2)
 
     resp = client.cluster.get_nodes_status(output="verbose")
-    print(resp)
+
     assert len(resp) == 1
-    # assert resp[0]["gitHash"] == GIT_HASH
+    assert "gitHash" in resp[0]
     assert resp[0]["name"] == NODE_NAME
     assert len(resp[0]["shards"]) == 2
     assert resp[0]["stats"]["objectCount"] == NUM_OBJECT * 3
     assert resp[0]["stats"]["shardCount"] == 2
     assert resp[0]["status"] == "HEALTHY"
-    # assert resp[0]["version"] == SERVER_VERSION
+    assert "version" in resp[0]
 
     shards = sorted(resp[0]["shards"], key=lambda x: x["class"])
     assert shards[0]["class"] == class_name1
@@ -77,12 +75,12 @@ def test_get_nodes_status_with_data(client: weaviate.Client):
 
     resp = client.cluster.get_nodes_status(class_name1, output="verbose")
     assert len(resp) == 1
-    # assert resp[0]["gitHash"] == GIT_HASH
+    assert "gitHash" in resp[0]
     assert resp[0]["name"] == NODE_NAME
     assert len(resp[0]["shards"]) == 1
     assert resp[0]["stats"]["shardCount"] == 1
     assert resp[0]["status"] == "HEALTHY"
-    # assert resp[0]["version"] == SERVER_VERSION
+    assert "version" in resp[0]
 
     assert shards[0]["class"] == class_name1
     assert shards[0]["objectCount"] == NUM_OBJECT
@@ -90,12 +88,12 @@ def test_get_nodes_status_with_data(client: weaviate.Client):
 
     resp = client.cluster.get_nodes_status(uncap_class_name1, output="verbose")
     assert len(resp) == 1
-    # assert resp[0]["gitHash"] == GIT_HASH
+    assert "gitHash" in resp[0]
     assert resp[0]["name"] == NODE_NAME
     assert len(resp[0]["shards"]) == 1
     assert resp[0]["stats"]["shardCount"] == 1
     assert resp[0]["status"] == "HEALTHY"
-    # assert resp[0]["version"] == SERVER_VERSION
+    assert "version" in resp[0]
 
     assert shards[0]["class"] == class_name1
     assert shards[0]["objectCount"] == NUM_OBJECT

--- a/integration/test_cluster.py
+++ b/integration/test_cluster.py
@@ -4,8 +4,8 @@ import pytest
 
 import weaviate
 
-GIT_HASH = "b454247"
-SERVER_VERSION = "1.23.0-rc.0"
+# GIT_HASH = "b454247"
+# SERVER_VERSION = "1.23.0-rc.0"
 NODE_NAME = "node1"
 NUM_OBJECT = 10
 
@@ -36,13 +36,13 @@ def test_get_nodes_status_without_data(client: weaviate.Client):
     """get nodes status without data"""
     resp = client.cluster.get_nodes_status(output="verbose")
     assert len(resp) == 1
-    assert resp[0]["gitHash"] == GIT_HASH
+    # assert resp[0]["gitHash"] == GIT_HASH
     assert resp[0]["name"] == NODE_NAME
     assert resp[0]["shards"] is None  # no class given
     assert resp[0]["stats"]["objectCount"] == 0
     assert resp[0]["stats"]["shardCount"] == 0
     assert resp[0]["status"] == "HEALTHY"
-    assert resp[0]["version"] == SERVER_VERSION
+    # assert resp[0]["version"] == SERVER_VERSION
 
 
 def test_get_nodes_status_with_data(client: weaviate.Client):
@@ -61,13 +61,13 @@ def test_get_nodes_status_with_data(client: weaviate.Client):
     resp = client.cluster.get_nodes_status(output="verbose")
     print(resp)
     assert len(resp) == 1
-    assert resp[0]["gitHash"] == GIT_HASH
+    # assert resp[0]["gitHash"] == GIT_HASH
     assert resp[0]["name"] == NODE_NAME
     assert len(resp[0]["shards"]) == 2
     assert resp[0]["stats"]["objectCount"] == NUM_OBJECT * 3
     assert resp[0]["stats"]["shardCount"] == 2
     assert resp[0]["status"] == "HEALTHY"
-    assert resp[0]["version"] == SERVER_VERSION
+    # assert resp[0]["version"] == SERVER_VERSION
 
     shards = sorted(resp[0]["shards"], key=lambda x: x["class"])
     assert shards[0]["class"] == class_name1
@@ -77,12 +77,12 @@ def test_get_nodes_status_with_data(client: weaviate.Client):
 
     resp = client.cluster.get_nodes_status(class_name1, output="verbose")
     assert len(resp) == 1
-    assert resp[0]["gitHash"] == GIT_HASH
+    # assert resp[0]["gitHash"] == GIT_HASH
     assert resp[0]["name"] == NODE_NAME
     assert len(resp[0]["shards"]) == 1
     assert resp[0]["stats"]["shardCount"] == 1
     assert resp[0]["status"] == "HEALTHY"
-    assert resp[0]["version"] == SERVER_VERSION
+    # assert resp[0]["version"] == SERVER_VERSION
 
     assert shards[0]["class"] == class_name1
     assert shards[0]["objectCount"] == NUM_OBJECT
@@ -90,12 +90,12 @@ def test_get_nodes_status_with_data(client: weaviate.Client):
 
     resp = client.cluster.get_nodes_status(uncap_class_name1, output="verbose")
     assert len(resp) == 1
-    assert resp[0]["gitHash"] == GIT_HASH
+    # assert resp[0]["gitHash"] == GIT_HASH
     assert resp[0]["name"] == NODE_NAME
     assert len(resp[0]["shards"]) == 1
     assert resp[0]["stats"]["shardCount"] == 1
     assert resp[0]["status"] == "HEALTHY"
-    assert resp[0]["version"] == SERVER_VERSION
+    # assert resp[0]["version"] == SERVER_VERSION
 
     assert shards[0]["class"] == class_name1
     assert shards[0]["objectCount"] == NUM_OBJECT

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -21,6 +21,7 @@ from weaviate.collections.classes.config import (
     GenerativeSearches,
 )
 from weaviate.collections.classes.tenants import Tenant
+from weaviate.util import parse_version_string
 
 
 @pytest.fixture(scope="module")
@@ -453,6 +454,8 @@ def test_collection_config_update(client: weaviate.WeaviateClient) -> None:
 
 
 def test_update_flat(client: weaviate.WeaviateClient) -> None:
+    if parse_version_string(client._connection._server_version) < parse_version_string("1.23"):
+        pytest.skip("flat index is not supported in this version")
     collection = client.collections.create(
         name="TestCollectionConfigUpdateFlat",
         vector_index_config=Configure.VectorIndex.flat(
@@ -524,6 +527,8 @@ def test_collection_config_get_shards_multi_tenancy(client: weaviate.WeaviateCli
 
 def test_config_vector_index_flat_and_quantitizer_bq() -> None:
     client = weaviate.connect_to_local()
+    if parse_version_string(client._connection._server_version) < parse_version_string("1.23"):
+        pytest.skip("flat index is not supported in this version")
     client.collections.delete("TestCollectionCVectorIndexAndQuantitizer")
     collection = client.collections.create(
         name="TestCollectionCVectorIndexAndQuantitizer",

--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -23,6 +23,7 @@ from weaviate.collections.classes.filters import (
 )
 from weaviate.collections.classes.grpc import MetadataQuery
 from weaviate.collections.classes.internal import Reference
+from weaviate.util import parse_version_string
 
 NOW = datetime.datetime.now(datetime.timezone.utc)
 LATER = NOW + datetime.timedelta(hours=1)
@@ -216,6 +217,10 @@ def test_filters_comparison(
 def test_filters_contains(
     client: weaviate.WeaviateClient, weaviate_filter: _FilterValue, results: List[int]
 ) -> None:
+    if parse_version_string(client._connection._server_version) < parse_version_string(
+        "1.23"
+    ) and weaviate_filter.path == ["_id"]:
+        pytest.skip("filter by id is not supported in this version")
     client.collections.delete("TestFilterContains")
     collection = client.collections.create(
         name="TestFilterContains",
@@ -321,6 +326,10 @@ def test_filters_contains(
 def test_ref_filters(
     client: weaviate.WeaviateClient, weaviate_filter: _FilterValue, results: List[int]
 ) -> None:
+    if parse_version_string(client._connection._server_version) < parse_version_string(
+        "1.23"
+    ) and weaviate_filter.path == ["ref", "TestFilterRef2", "_id"]:
+        pytest.skip("filter by id is not supported in this version")
     client.collections.delete("TestFilterRef")
     client.collections.delete("TestFilterRef2")
     to_collection = client.collections.create(
@@ -851,6 +860,8 @@ def test_delete_many_return(client: weaviate.WeaviateClient) -> None:
     ],
 )
 def test_filter_id(client: weaviate.WeaviateClient, weav_filter: _FilterValue) -> None:
+    if parse_version_string(client._connection._server_version) < parse_version_string("1.23"):
+        pytest.skip("filter by id is not supported in this version")
     FilterMetadata.ById.contains_any
     name = "TestFilterMetadata"
     client.collections.delete(name)
@@ -876,6 +887,8 @@ def test_filter_id(client: weaviate.WeaviateClient, weav_filter: _FilterValue) -
 
 @pytest.mark.parametrize("path", ["_creationTimeUnix", "_lastUpdateTimeUnix"])
 def test_filter_timestamp_direct_path(client: weaviate.WeaviateClient, path: str) -> None:
+    if parse_version_string(client._connection._server_version) < parse_version_string("1.23"):
+        pytest.skip("filter by id is not supported in this version")
     name = "TestFilterMetadataTime"
     client.collections.delete(name)
     collection = client.collections.create(
@@ -907,6 +920,8 @@ def test_filter_timestamp_direct_path(client: weaviate.WeaviateClient, path: str
     "filter_type", [FilterMetadata.ByCreationTime, FilterMetadata.ByUpdateTime]
 )
 def test_filter_timestamp_class(client: weaviate.WeaviateClient, filter_type: _FilterTime) -> None:
+    if parse_version_string(client._connection._server_version) < parse_version_string("1.23"):
+        pytest.skip("filter by id is not supported in this version")
     name = "TestFilterMetadataTime"
     client.collections.delete(name)
     collection = client.collections.create(
@@ -965,6 +980,8 @@ def test_filter_timestamp_class(client: weaviate.WeaviateClient, filter_type: _F
 
 
 def test_time_update_and_creation_time(client: weaviate.WeaviateClient) -> None:
+    if parse_version_string(client._connection._server_version) < parse_version_string("1.23"):
+        pytest.skip("filter by id is not supported in this version")
     name = "TestFilterMetadataTime"
     client.collections.delete(name)
     collection = client.collections.create(

--- a/integration/test_collection_nested.py
+++ b/integration/test_collection_nested.py
@@ -323,6 +323,9 @@ def test_nested_return_all_properties(
     result = collection.query.fetch_objects()
     assert result.objects[0].properties["nested"] == object_
 
+    res = collection.query.fetch_object_by_id(res.uuids[0])
+    assert res.properties["nested"] == object_
+
 
 @pytest.mark.parametrize(
     "return_properties,expected",
@@ -508,6 +511,8 @@ def test_nested_return_specific_properties(
     assert res.has_errors is False
     result = collection.query.fetch_objects(return_properties=return_properties)
     assert result.objects[0].properties["nested"] == expected
+    res = collection.query.fetch_object_by_id(res.uuids[0], return_properties=return_properties)
+    assert res.properties["nested"] == expected
 
 
 def test_nested_return_generic_properties(

--- a/weaviate/collections/classes/types.py
+++ b/weaviate/collections/classes/types.py
@@ -4,8 +4,9 @@ from typing_extensions import TypeAlias, TypeVar, is_typeddict
 from pydantic import BaseModel, ConfigDict
 
 from weaviate.exceptions import InvalidDataModelException
+from weaviate.types import WeaviateField
 
-WeaviateProperties: TypeAlias = Dict[str, "WeaviateProperties"]
+WeaviateProperties: TypeAlias = Dict[str, WeaviateField]
 
 Properties = TypeVar("Properties", bound=Mapping[str, Any], default=WeaviateProperties)
 """`Properties` is used wherever a single generic type is needed for properties"""

--- a/weaviate/collections/classes/types.py
+++ b/weaviate/collections/classes/types.py
@@ -4,9 +4,8 @@ from typing_extensions import TypeAlias, TypeVar, is_typeddict
 from pydantic import BaseModel, ConfigDict
 
 from weaviate.exceptions import InvalidDataModelException
-from weaviate.types import WeaviateField
 
-WeaviateProperties: TypeAlias = Dict[str, WeaviateField]
+WeaviateProperties: TypeAlias = Dict[str, "WeaviateProperties"]
 
 Properties = TypeVar("Properties", bound=Mapping[str, Any], default=WeaviateProperties)
 """`Properties` is used wherever a single generic type is needed for properties"""

--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -1,16 +1,6 @@
 import datetime
 import uuid as uuid_package
-from typing import (
-    Dict,
-    Any,
-    Optional,
-    List,
-    Tuple,
-    Generic,
-    Type,
-    Union,
-    cast,
-)
+from typing import Dict, Any, Optional, List, Tuple, Generic, Type, Union, cast
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 

--- a/weaviate/collections/queries/fetch_object_by_id.py
+++ b/weaviate/collections/queries/fetch_object_by_id.py
@@ -1,4 +1,18 @@
-from typing import Generic, Literal, Optional, Union, Type, cast, overload
+import datetime
+import uuid as uuid_lib
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Union,
+    Type,
+    TypedDict,
+    cast,
+    overload,
+)
 
 from weaviate.collections.classes.filters import (
     FilterMetadata,
@@ -14,9 +28,13 @@ from weaviate.collections.classes.internal import (
     References,
     WeaviateReferences,
     TReferences,
+    WeaviateProperties,
+    FromNested,
+    _Reference,
 )
 from weaviate.collections.classes.types import Properties, TProperties
 from weaviate.collections.queries.base import _BaseQuery
+from weaviate.util import _datetime_from_weaviate_str
 from weaviate.types import UUID
 
 
@@ -108,10 +126,12 @@ class _FetchObjectByIDQuery(Generic[Properties, References], _BaseQuery[Properti
         Arguments:
             `uuid`
                 The UUID of the object to retrieve, REQUIRED.
-            `return_properties`
-                The properties to return for each object.
             `include_vector`
                 Whether to include the vector in the returned object.
+            `return_properties`
+                The properties to return for each object.
+            `return_references`
+                The references to return for each object.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -119,56 +139,201 @@ class _FetchObjectByIDQuery(Generic[Properties, References], _BaseQuery[Properti
             `weaviate.exceptions.WeaviateInsertInvalidPropertyError`:
                 If a property is invalid. I.e., has name `id` or `vector`, which are reserved.
         """
-        return_metadata = MetadataQuery(
-            creation_time_unix=True, last_update_time_unix=True, is_consistent=True
-        )
-        res = self._query().get(
-            limit=1,
-            filters=FilterMetadata.ById.equal(uuid),
-            return_metadata=self._parse_return_metadata(return_metadata, include_vector),
-            return_properties=self._parse_return_properties(return_properties),
-            return_references=self._parse_return_references(return_references),
-        )
-        objects = self._result_to_query_return(
-            res,
-            _QueryOptions.from_input(
-                return_metadata,
-                return_properties,
-                include_vector,
-                self._references,
-                return_references,
-            ),
-            return_properties,
-            None,
-        )
-
-        if len(objects.objects) == 0:
-            return None
-
-        obj = objects.objects[0]
-        assert obj.metadata is not None
-        assert obj.metadata.creation_time_unix is not None
-        assert obj.metadata.last_update_time_unix is not None
-
-        return cast(
-            Union[
-                None,
-                _ObjectSingleReturn[Properties, References],
-                _ObjectSingleReturn[Properties, WeaviateReferences],
-                _ObjectSingleReturn[Properties, TReferences],
-                _ObjectSingleReturn[TProperties, References],
-                _ObjectSingleReturn[TProperties, WeaviateReferences],
-                _ObjectSingleReturn[TProperties, TReferences],
-            ],
-            _ObjectSingleReturn(
-                uuid=obj.uuid,
-                vector=obj.vector,
-                properties=obj.properties,
-                metadata=_MetadataSingleObjectReturn(
-                    creation_time_unix=obj.metadata.creation_time_unix,
-                    last_update_time_unix=obj.metadata.last_update_time_unix,
-                    is_consistent=obj.metadata.is_consistent,
+        if self._is_weaviate_version_123:
+            return_metadata = MetadataQuery(
+                creation_time_unix=True, last_update_time_unix=True, is_consistent=True
+            )
+            res = self._query().get(
+                limit=1,
+                filters=FilterMetadata.ById.equal(uuid),
+                return_metadata=self._parse_return_metadata(return_metadata, include_vector),
+                return_properties=self._parse_return_properties(return_properties),
+                return_references=self._parse_return_references(return_references),
+            )
+            objects = self._result_to_query_return(
+                res,
+                _QueryOptions.from_input(
+                    return_metadata,
+                    return_properties,
+                    include_vector,
+                    self._references,
+                    return_references,
                 ),
-                references=obj.references,
-            ),
+                return_properties,
+                None,
+            )
+
+            if len(objects.objects) == 0:
+                return None
+
+            obj = objects.objects[0]
+            assert obj.metadata is not None
+            assert obj.metadata.creation_time_unix is not None
+            assert obj.metadata.last_update_time_unix is not None
+
+            return cast(
+                Union[
+                    None,
+                    _ObjectSingleReturn[Properties, References],
+                    _ObjectSingleReturn[Properties, WeaviateReferences],
+                    _ObjectSingleReturn[Properties, TReferences],
+                    _ObjectSingleReturn[TProperties, References],
+                    _ObjectSingleReturn[TProperties, WeaviateReferences],
+                    _ObjectSingleReturn[TProperties, TReferences],
+                ],
+                _ObjectSingleReturn(
+                    uuid=obj.uuid,
+                    vector=obj.vector,
+                    properties=obj.properties,
+                    metadata=_MetadataSingleObjectReturn(
+                        creation_time_unix=obj.metadata.creation_time_unix,
+                        last_update_time_unix=obj.metadata.last_update_time_unix,
+                        is_consistent=obj.metadata.is_consistent,
+                    ),
+                    references=obj.references,
+                ),
+            )
+        else:
+            return cast(
+                Union[
+                    None,
+                    _ObjectSingleReturn[Properties, References],
+                    _ObjectSingleReturn[Properties, WeaviateReferences],
+                    _ObjectSingleReturn[Properties, TReferences],
+                    _ObjectSingleReturn[TProperties, References],
+                    _ObjectSingleReturn[TProperties, WeaviateReferences],
+                    _ObjectSingleReturn[TProperties, TReferences],
+                ],
+                self._get_with_rest(
+                    self._name, uuid, include_vector, return_properties, return_references
+                ),
+            )
+
+    def _get_with_rest(
+        self,
+        collection: str,
+        uuid: UUID,
+        include_vector: bool = False,
+        return_properties: Optional[ReturnProperties[TProperties]] = None,
+        return_references: Optional[ReturnReferences[TReferences]] = None,
+    ) -> Optional[_ObjectSingleReturn[Any, Any]]:
+        res = self._get_by_id_rest(collection, uuid, include_vector)
+        if res is None:
+            return None
+        else:
+            obj_rest = cast(_RestPayload, res)
+
+        parsed_props = self._parse_return_properties(return_properties)
+        ret_props = (
+            parsed_props
+            if isinstance(parsed_props, list) or parsed_props is None
+            else [parsed_props]
         )
+        props = {}
+
+        def parse_value(value: Any) -> Any:
+            if isinstance(value, list):
+                return [parse_value(val) for val in value]
+            if isinstance(value, str):
+                try:
+                    return _datetime_from_weaviate_str(value)
+                except ValueError:
+                    pass
+                try:
+                    return uuid_lib.UUID(value)
+                except ValueError:
+                    pass
+            return value
+
+        def resolve_nested(obj: Dict[str, WeaviateProperties], prop: FromNested) -> dict:
+            nested_props = (
+                prop.properties if isinstance(prop.properties, list) else [prop.properties]
+            )
+            nested = {}
+            for nested_prop in nested_props:
+                if isinstance(nested_prop, FromNested):
+                    return resolve_nested(obj[nested_prop.name], nested_prop)
+                else:
+                    nested[nested_prop] = parse_value(obj[nested_prop])
+            return nested
+
+        if ret_props is not None:
+            for prop in ret_props:
+                if isinstance(prop, FromNested):
+                    props[prop.name] = resolve_nested(obj_rest["properties"], prop)
+                else:
+                    props[prop] = parse_value(obj_rest["properties"][prop])
+        else:
+            for key, value in obj_rest["properties"].items():
+                if (
+                    isinstance(value, list)
+                    and len(value) > 0
+                    and isinstance(value[0], dict)
+                    and "beacon" in value[0]
+                ):
+                    continue
+                else:
+                    props[key] = parse_value(value)
+
+        parsed_refs = self._parse_return_references(return_references)
+        ret_refs = (
+            parsed_refs if isinstance(parsed_refs, list) or parsed_refs is None else [parsed_refs]
+        )
+        if ret_refs is not None:
+            refs = {
+                ret_ref.link_on: _Reference._from(
+                    [
+                        self._get_with_rest(
+                            rest_ref["beacon"].split("/")[-2],
+                            uuid_lib.UUID(rest_ref["beacon"].split("/")[-1]),
+                            ret_ref.include_vector,
+                            ret_ref.return_properties,
+                            ret_ref.return_references,
+                        )  # type: ignore # incompatability between _Object and _ObjectSingleReturn but will remove this anyway in 1.24 and Py GA
+                        for rest_ref in cast(
+                            List[_RestReference], obj_rest["properties"][ret_ref.link_on]
+                        )
+                    ]
+                )
+                for ret_ref in ret_refs
+            }
+        else:
+            refs = None
+
+        return _ObjectSingleReturn(
+            uuid=uuid_lib.UUID(obj_rest["id"]),
+            vector=obj_rest.get("vector", None),
+            properties=props,
+            metadata=_MetadataSingleObjectReturn(
+                creation_time_unix=datetime.datetime.fromtimestamp(
+                    obj_rest["creationTimeUnix"] / 1000, tz=datetime.timezone.utc
+                ),
+                last_update_time_unix=datetime.datetime.fromtimestamp(
+                    obj_rest["lastUpdateTimeUnix"] / 1000, tz=datetime.timezone.utc
+                ),
+                is_consistent=None,
+            ),
+            references=refs,
+        )
+
+
+_RestPayload = TypedDict(
+    "_RestPayload",
+    {
+        "class": str,
+        "creationTimeUnix": int,
+        "id": str,
+        "lastUpdateTimeUnix": int,
+        "properties": Dict[str, WeaviateProperties],
+        "vectorWeights": Optional[List[float]],
+        "vector": Optional[List[float]],
+    },
+)
+
+_RestReference = TypedDict(
+    "_RestReference",
+    {
+        "beacon": str,
+        "href": str,
+    },
+)

--- a/weaviate/collections/query.py
+++ b/weaviate/collections/query.py
@@ -1,6 +1,4 @@
-from typing import (
-    Generic,
-)
+from typing import Generic
 
 from weaviate.collections.classes.internal import References
 from weaviate.collections.classes.types import TProperties

--- a/weaviate/types.py
+++ b/weaviate/types.py
@@ -30,4 +30,14 @@ DATATYPE_TO_PYTHON_TYPE = {
 PYTHON_TYPE_TO_DATATYPE = {val: key for key, val in DATATYPE_TO_PYTHON_TYPE.items()}
 TIME = datetime.datetime
 
-WeaviateField = Union[str, bool, int, float, DATE, UUID, GEO_COORDINATES, List["WeaviateField"]]
+WeaviateField = Union[
+    str,
+    bool,
+    int,
+    float,
+    DATE,
+    UUID,
+    GEO_COORDINATES,
+    List["WeaviateField"],
+    Dict[str, "WeaviateField"],
+]


### PR DESCRIPTION
This PR adds back functionality for the new API surface to allow for its use with `<1.23` Weaviate so as to minimise user pain-points associated with breaking changes between versions

Much of the patching code is quite hack-y and will be removed in the future once the previous functionality is deprecated

It also refactors the CI pipeline to accept CI-defined variables for the Weaviate versions to be tested rather than specifying this in the Docker compose files themselves