### PR TITLE
Beta/more splitting props and refs

### DIFF
--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -265,6 +265,8 @@ def test_collection_config_full(client: weaviate.WeaviateClient) -> None:
             Property(name="booleans", data_type=DataType.BOOL_ARRAY),
             Property(name="geo", data_type=DataType.GEO_COORDINATES),
             Property(name="phone", data_type=DataType.PHONE_NUMBER),
+        ],
+        references=[
             ReferenceProperty(name="self", target_collection="TestCollectionConfigFull"),
         ],
         inverted_index_config=Configure.inverted_index(

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -11,6 +11,7 @@ from weaviate.collections.classes.config import (
     Configure,
     Reconfigure,
     Property,
+    ReferenceProperty,
     DataType,
     PQEncoderType,
     PQEncoderDistribution,
@@ -264,6 +265,7 @@ def test_collection_config_full(client: weaviate.WeaviateClient) -> None:
             Property(name="booleans", data_type=DataType.BOOL_ARRAY),
             Property(name="geo", data_type=DataType.GEO_COORDINATES),
             Property(name="phone", data_type=DataType.PHONE_NUMBER),
+            ReferenceProperty(name="self", target_collection="TestCollectionConfigFull"),
         ],
         inverted_index_config=Configure.inverted_index(
             bm25_b=0.8,
@@ -331,6 +333,9 @@ def test_collection_config_full(client: weaviate.WeaviateClient) -> None:
     assert config.properties[10].data_type == DataType.GEO_COORDINATES
     assert config.properties[11].name == "phone"
     assert config.properties[11].data_type == DataType.PHONE_NUMBER
+
+    assert config.references[0].name == "self"
+    assert config.references[0].target_collections == ["TestCollectionConfigFull"]
 
     assert config.inverted_index_config.bm25.b == 0.8
     assert config.inverted_index_config.bm25.k1 == 1.3

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -482,7 +482,6 @@ def test_insert_many_with_refs(client: weaviate.WeaviateClient):
         if obj.properties["name"] in ["A", "B"]:
             assert obj.references is None
         else:
-            print(obj)
             assert obj.references is not None
 
 

--- a/weaviate/collections/batch/grpc.py
+++ b/weaviate/collections/batch/grpc.py
@@ -69,7 +69,10 @@ class _BatchGRPC(_BaseGRPC):
                 if obj.vector is not None and self._support_byte_vectors
                 else None,
                 uuid=str(obj.uuid) if obj.uuid is not None else str(uuid_package.uuid4()),
-                properties=self.__translate_properties_from_python_to_grpc(obj.properties, False)
+                properties=self.__translate_properties_from_python_to_grpc(
+                    {**obj.properties, **(obj.references if obj.references is not None else {})},
+                    False,
+                )
                 if obj.properties is not None
                 else None,
                 tenant=obj.tenant,

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
 from pydantic import BaseModel, Field, field_validator
 
+from weaviate.collections.classes.internal import WeaviateReferences
 from weaviate.util import _capitalize_first_letter, get_valid_uuid, get_vector
 from weaviate.types import BEACON, UUID, WeaviateField
 
@@ -15,6 +16,7 @@ class _BatchObject:
     uuid: Optional[UUID]
     properties: Optional[Dict[str, WeaviateField]]
     tenant: Optional[str]
+    references: Optional[WeaviateReferences]
 
 
 @dataclass
@@ -37,6 +39,7 @@ class BatchObject(BaseModel):
     uuid: Optional[UUID] = Field(default=None)
     vector: Optional[Sequence] = Field(default=None)
     tenant: Optional[str] = Field(default=None)
+    references: Optional[WeaviateReferences] = Field(default=None)
 
     def __init__(self, **data: Any) -> None:
         data["vector"] = get_vector(v) if (v := data.get("vector")) is not None else None
@@ -52,6 +55,7 @@ class BatchObject(BaseModel):
             uuid=self.uuid,
             properties=self.properties,
             tenant=self.tenant,
+            references=self.references,
         )
 
     @field_validator("collection")

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -39,7 +39,6 @@ class BatchObject(BaseModel):
     uuid: Optional[UUID] = Field(default=None)
     vector: Optional[Sequence] = Field(default=None)
     tenant: Optional[str] = Field(default=None)
-    references: Optional[WeaviateReferences] = Field(default=None)
 
     def __init__(self, **data: Any) -> None:
         data["vector"] = get_vector(v) if (v := data.get("vector")) is not None else None
@@ -55,7 +54,7 @@ class BatchObject(BaseModel):
             uuid=self.uuid,
             properties=self.properties,
             tenant=self.tenant,
-            references=self.references,
+            references=None,
         )
 
     @field_validator("collection")

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1569,7 +1569,7 @@ class _Property(_PropertyBase):
 
     def _to_dict(self) -> Dict[str, Any]:
         out = super()._to_dict()
-        out["dataType"] = self.data_type.value
+        out["dataType"] = [self.data_type.value]
         return out
 
 
@@ -1691,6 +1691,7 @@ class _CollectionConfig(_ConfigBase):
             *[prop._to_dict() for prop in self.properties],
             *[prop._to_dict() for prop in self.references],
         ]
+        out.pop("references")
         return out
 
 

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -27,6 +27,7 @@ from weaviate.collections.classes.config import (
     _VectorizerConfig,
     _GenerativeConfig,
     GenerativeSearches,
+    DataType,
 )
 
 
@@ -197,7 +198,7 @@ def _properties_from_config(schema: Dict[str, Any]) -> List[_Property]:
             continue
         props.append(
             _Property(
-                data_type=prop["dataType"][0],
+                data_type=DataType(prop["dataType"][0]),
                 description=prop.get("description"),
                 index_filterable=prop["indexFilterable"],
                 index_searchable=prop["indexSearchable"],

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -6,14 +6,12 @@ from weaviate.collections.classes.config import (
     _CollectionConfigSimple,
     _PQConfig,
     _VectorIndexConfigFlat,
-    DataType,
     _InvertedIndexConfig,
     _BM25Config,
     _StopwordsConfig,
     _MultiTenancyConfig,
     _Property,
-    _ReferenceDataType,
-    _ReferenceDataTypeMultiTarget,
+    _ReferenceProperty,
     _ReplicationConfig,
     _ShardingConfig,
     _VectorIndexConfigHNSW,
@@ -34,18 +32,6 @@ from weaviate.collections.classes.config import (
 
 def _is_primitive(d_type: str) -> bool:
     return d_type[0][0].lower() == d_type[0][0]
-
-
-def _property_data_type_from_weaviate_data_type(
-    data_type: List[str],
-) -> Union[DataType, _ReferenceDataType, _ReferenceDataTypeMultiTarget]:
-    if len(data_type) == 1 and _is_primitive(data_type[0]):
-        return DataType(data_type[0])
-
-    if len(data_type) == 1:
-        return _ReferenceDataType(target_collection=data_type[0])
-
-    return _ReferenceDataTypeMultiTarget(target_collections=data_type)
 
 
 def _collection_config_simple_from_json(schema: Dict[str, Any]) -> _CollectionConfigSimple:
@@ -73,30 +59,8 @@ def _collection_config_simple_from_json(schema: Dict[str, Any]) -> _CollectionCo
         name=schema["class"],
         description=schema.get("description"),
         generative_config=generative_config,
-        properties=[
-            _Property(
-                data_type=_property_data_type_from_weaviate_data_type(prop["dataType"]),
-                description=prop.get("description"),
-                index_filterable=prop["indexFilterable"],
-                index_searchable=prop["indexSearchable"],
-                name=prop["name"],
-                tokenization=Tokenization(prop["tokenization"])
-                if prop.get("tokenization") is not None
-                else None,
-                vectorizer_config=_PropertyVectorizerConfig(
-                    skip=prop["moduleConfig"][schema["vectorizer"]]["skip"],
-                    vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]][
-                        "vectorizePropertyName"
-                    ],
-                )
-                if schema["vectorizer"] != "none"
-                else None,
-                vectorizer=schema["vectorizer"],
-            )
-            for prop in schema["properties"]
-        ]
-        if schema.get("properties") is not None
-        else [],
+        properties=_properties_from_config(schema) if schema.get("properties") is not None else [],
+        references=_references_from_config(schema) if schema.get("properties") is not None else [],
         vectorizer_config=vectorizer_config,
         vectorizer=Vectorizer(schema["vectorizer"]),
     )
@@ -194,30 +158,8 @@ def _collection_config_from_json(schema: Dict[str, Any]) -> _CollectionConfig:
             ),
         ),
         multi_tenancy_config=_MultiTenancyConfig(enabled=schema["multiTenancyConfig"]["enabled"]),
-        properties=[
-            _Property(
-                data_type=_property_data_type_from_weaviate_data_type(prop["dataType"]),
-                description=prop.get("description"),
-                index_filterable=prop["indexFilterable"],
-                index_searchable=prop["indexSearchable"],
-                name=prop["name"],
-                tokenization=Tokenization(prop["tokenization"])
-                if prop.get("tokenization") is not None
-                else None,
-                vectorizer_config=_PropertyVectorizerConfig(
-                    skip=prop["moduleConfig"][schema["vectorizer"]]["skip"],
-                    vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]][
-                        "vectorizePropertyName"
-                    ],
-                )
-                if schema["vectorizer"] != "none"
-                else None,
-                vectorizer=schema["vectorizer"],
-            )
-            for prop in schema["properties"]
-        ]
-        if schema.get("properties") is not None
-        else [],
+        properties=_properties_from_config(schema) if schema.get("properties") is not None else [],
+        references=_references_from_config(schema) if schema.get("properties") is not None else [],
         replication_config=_ReplicationConfig(factor=schema["replicationConfig"]["factor"]),
         sharding_config=_ShardingConfig(
             virtual_per_physical=schema["shardingConfig"]["virtualPerPhysical"],
@@ -246,3 +188,61 @@ def _collection_configs_simple_from_json(
     return {
         schema["class"]: _collection_config_simple_from_json(schema) for schema in schema["classes"]
     }
+
+
+def _properties_from_config(schema: Dict[str, Any]) -> List[_Property]:
+    props: List[_Property] = []
+    for prop in schema["properties"]:
+        if not _is_primitive(prop["dataType"]):
+            continue
+        props.append(
+            _Property(
+                data_type=prop["dataType"][0],
+                description=prop.get("description"),
+                index_filterable=prop["indexFilterable"],
+                index_searchable=prop["indexSearchable"],
+                name=prop["name"],
+                tokenization=Tokenization(prop["tokenization"])
+                if prop.get("tokenization") is not None
+                else None,
+                vectorizer_config=_PropertyVectorizerConfig(
+                    skip=prop["moduleConfig"][schema["vectorizer"]]["skip"],
+                    vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]][
+                        "vectorizePropertyName"
+                    ],
+                )
+                if schema["vectorizer"] != "none"
+                else None,
+                vectorizer=schema["vectorizer"],
+            )
+        )
+    return props
+
+
+def _references_from_config(schema: Dict[str, Any]) -> List[_ReferenceProperty]:
+    refs: List[_ReferenceProperty] = []
+    for prop in schema["properties"]:
+        if _is_primitive(prop["dataType"]):
+            continue
+        refs.append(
+            _ReferenceProperty(
+                target_collections=prop["dataType"],
+                description=prop.get("description"),
+                index_filterable=prop["indexFilterable"],
+                index_searchable=prop["indexSearchable"],
+                name=prop["name"],
+                tokenization=Tokenization(prop["tokenization"])
+                if prop.get("tokenization") is not None
+                else None,
+                vectorizer_config=_PropertyVectorizerConfig(
+                    skip=prop["moduleConfig"][schema["vectorizer"]]["skip"],
+                    vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]][
+                        "vectorizePropertyName"
+                    ],
+                )
+                if schema["vectorizer"] != "none"
+                else None,
+                vectorizer=schema["vectorizer"],
+            )
+        )
+    return refs

--- a/weaviate/collections/classes/data.py
+++ b/weaviate/collections/classes/data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Generic
-from weaviate.collections.classes.internal import P
+from weaviate.collections.classes.internal import P, R
 from weaviate.collections.classes.types import _WeaviateInput
 from weaviate.types import UUID
 
@@ -22,12 +22,13 @@ class RefError:
 
 
 @dataclass
-class DataObject(Generic[P]):
+class DataObject(Generic[P, R]):
     """This class represents an entire object within a collection to be used when batching."""
 
     properties: Optional[P] = None
     uuid: Optional[UUID] = None
     vector: Optional[List[float]] = None
+    references: Optional[R] = None
 
 
 @dataclass

--- a/weaviate/collections/config.py
+++ b/weaviate/collections/config.py
@@ -193,10 +193,10 @@ class _ConfigCollection(_ConfigBase):
         self._add_property(prop)
 
     def add_reference(self, ref: Union[ReferenceProperty, ReferencePropertyMultiTarget]) -> None:
-        """Add a reference property to the collection in Weaviate.
+        """Add a reference to the collection in Weaviate.
 
         Arguments:
-            ref : The reference property to add to the collection.
+            ref : The reference to add to the collection.
 
         Raises:
             `requests.ConnectionError`:

--- a/weaviate/collections/config.py
+++ b/weaviate/collections/config.py
@@ -8,6 +8,9 @@ from weaviate.collections.classes.config import (
     _ReplicationConfigUpdate,
     _VectorIndexConfigFlatUpdate,
     PropertyType,
+    Property,
+    ReferenceProperty,
+    ReferencePropertyMultiTarget,
     _VectorIndexConfigHNSWUpdate,
     _CollectionConfig,
     _CollectionConfigSimple,
@@ -169,11 +172,11 @@ class _ConfigBase:
 
 
 class _ConfigCollection(_ConfigBase):
-    def add_property(self, additional_property: PropertyType) -> None:
+    def add_property(self, prop: Property) -> None:
         """Add a property to the collection in Weaviate.
 
         Arguments:
-            additional_property : The property to add to the collection.
+            prop : The property to add to the collection.
 
         Raises:
             `requests.ConnectionError`:
@@ -183,11 +186,31 @@ class _ConfigCollection(_ConfigBase):
             `weaviate.ObjectAlreadyExistsException`:
                 If the property already exists in the collection.
         """
-        if self._get_property_by_name(additional_property.name) is not None:
+        if self._get_property_by_name(prop.name) is not None:
             raise ObjectAlreadyExistsException(
-                f"Property with name '{additional_property.name}' already exists in collection '{self._name}'."
+                f"Property with name '{prop.name}' already exists in collection '{self._name}'."
             )
-        self._add_property(additional_property)
+        self._add_property(prop)
+
+    def add_reference(self, ref: Union[ReferenceProperty, ReferencePropertyMultiTarget]) -> None:
+        """Add a reference property to the collection in Weaviate.
+
+        Arguments:
+            ref : The reference property to add to the collection.
+
+        Raises:
+            `requests.ConnectionError`:
+                If the network connection to Weaviate fails.
+            `weaviate.UnexpectedStatusCodeException`:
+                If Weaviate reports a non-OK status.
+            `weaviate.ObjectAlreadyExistsException`:
+                If the reference already exists in the collection.
+        """
+        if self._get_property_by_name(ref.name) is not None:
+            raise ObjectAlreadyExistsException(
+                f"Reference with name '{ref.name}' already exists in collection '{self._name}'."
+            )
+        self._add_property(ref)
 
 
 class _ConfigCollectionModel(_ConfigBase):

--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -295,15 +295,15 @@ class _DataCollection(Generic[Properties], _Data):
 
     def insert_many(
         self,
-        objects: List[Union[Properties, DataObject[Properties]]],
+        objects: List[Union[Properties, DataObject[Properties, WeaviateReferences]]],
     ) -> BatchObjectReturn:
         """Insert multiple objects into the collection.
 
         Arguments:
             `objects`
-                The objects to insert. This can be either a list of `Properties` or `DataObject[Properties]`
+                The objects to insert. This can be either a list of `Properties` or `DataObject[Properties, WeaviateReferences]`
                     If you didn't set `data_model` then `Properties` will be `Data[str, Any]` in which case you can insert simple dictionaries here.
-                        If you want to insert vectors and UUIDs alongside your properties, you will have to use `DataObject` instead.
+                        If you want to insert references, vectors, or UUIDs alongside your properties, you will have to use `DataObject` instead.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -321,6 +321,7 @@ class _DataCollection(Generic[Properties], _Data):
                     uuid=obj.uuid,
                     properties=cast(dict, obj.properties),
                     tenant=self._tenant,
+                    references=obj.references,
                 )
                 if isinstance(obj, DataObject)
                 else _BatchObject(
@@ -329,6 +330,7 @@ class _DataCollection(Generic[Properties], _Data):
                     uuid=None,
                     properties=cast(dict, obj),
                     tenant=None,
+                    references=None,
                 )
                 for obj in objects
             ]
@@ -544,6 +546,7 @@ class _DataCollectionModel(Generic[Model], _Data):
                 tenant=self._tenant,
                 uuid=obj.uuid,
                 vector=obj.vector,
+                references=None,
             )
             for obj in objects
         ]

--- a/weaviate/collections/queries/fetch_object_by_id.py
+++ b/weaviate/collections/queries/fetch_object_by_id.py
@@ -286,6 +286,7 @@ class _FetchObjectByIDQuery(Generic[Properties, References], _BaseQuery[Properti
         ret_refs = (
             parsed_refs if isinstance(parsed_refs, list) or parsed_refs is None else [parsed_refs]
         )
+        refs: Optional[dict] = None
         if ret_refs is not None:
             refs = {
                 ret_ref.link_on: _Reference._from(
@@ -302,10 +303,12 @@ class _FetchObjectByIDQuery(Generic[Properties, References], _BaseQuery[Properti
                         )
                     ]
                 )
+                if obj_rest["properties"].get(ret_ref.link_on) is not None
+                else None
                 for ret_ref in ret_refs
             }
-        else:
-            refs = None
+            if all(ref is None for ref in refs.values()):
+                refs = None
 
         return _ObjectSingleReturn(
             uuid=uuid_lib.UUID(obj_rest["id"]),


### PR DESCRIPTION
This PR continues the splitting of `properties` and `references` out within the _beta_ API

It was decided that `batch.add_object` should not have a `references` argument so as not to confuse the API in relation to the `batch.add_reference` function. When users do batching, they should be adding all the objects first and then using the returned UUIDs to create the references anyway as the happy path