### PR TITLE
Beta/add BC for reranking functionality

### DIFF
--- a/test/test_server_version.py
+++ b/test/test_server_version.py
@@ -1,0 +1,89 @@
+import pytest
+
+from weaviate.util import _ServerVersion
+
+
+@pytest.mark.parametrize(
+    "version_string,expected",
+    [
+        ("1.2.3.a", _ServerVersion(1, 2, 3)),
+        ("1.2.3.4", _ServerVersion(1, 2, 3)),
+        ("v1.2.3.4", _ServerVersion(1, 2, 3)),
+        ("1.2.3", _ServerVersion(1, 2, 3)),
+        ("v1.2.3", _ServerVersion(1, 2, 3)),
+        ("1.2", _ServerVersion(1, 2, 0)),
+        ("v1.2", _ServerVersion(1, 2, 0)),
+        ("1", _ServerVersion(1, 0, 0)),
+        ("v1", _ServerVersion(1, 0, 0)),
+        ("", _ServerVersion(0, 0, 0)),
+    ],
+)
+def test_server_version_successful_parsing(version_string: str, expected: _ServerVersion) -> None:
+    assert _ServerVersion.from_string(version_string) == expected
+
+
+@pytest.mark.parametrize(
+    "version_string",
+    [
+        "v",
+        "1.v2.3",
+        "1.2.b3",
+    ],
+)
+def test_server_version_unsuccessful_parsing(version_string: str) -> None:
+    with pytest.raises(ValueError):
+        _ServerVersion.from_string(version_string)
+
+
+@pytest.mark.parametrize(
+    "is_valid",
+    [
+        _ServerVersion(1, 2, 3).is_at_least(1, 2, 3),
+        _ServerVersion(1, 2, 3).is_at_least(1, 2, 2),
+        _ServerVersion(1, 2, 3).is_at_least(1, 1, 3),
+        _ServerVersion(1, 2, 3).is_at_least(1, 1, 2),
+        _ServerVersion(1, 2, 3).is_at_least(0, 2, 3),
+        _ServerVersion(1, 2, 3).is_at_least(0, 2, 2),
+        _ServerVersion(1, 2, 3).is_at_least(0, 1, 3),
+        _ServerVersion(1, 2, 3).is_at_least(0, 1, 2),
+        not _ServerVersion(1, 2, 3).is_at_least(1, 2, 4),
+        not _ServerVersion(1, 2, 3).is_at_least(1, 3, 3),
+        not _ServerVersion(1, 2, 3).is_at_least(1, 3, 4),
+        not _ServerVersion(1, 2, 3).is_at_least(2, 2, 3),
+        not _ServerVersion(1, 2, 3).is_at_least(2, 2, 4),
+        not _ServerVersion(1, 2, 3).is_at_least(2, 3, 3),
+        not _ServerVersion(1, 2, 3).is_at_least(2, 3, 4),
+        not _ServerVersion(0, 0, 0).is_at_least(0, 0, 1),
+    ],
+)
+def test_server_version_is_at_least(is_valid: bool) -> None:
+    assert is_valid
+
+
+def test_server_version_magic_methods() -> None:
+    # Test __eq__
+    assert _ServerVersion(1, 2, 3) == _ServerVersion(1, 2, 3)
+    # Test __neq__
+    assert _ServerVersion(1, 2, 3) != _ServerVersion(1, 2, 2)
+
+    # Test __lt__
+    assert _ServerVersion(1, 2, 2) < _ServerVersion(1, 2, 3)
+    assert _ServerVersion(1, 1, 3) < _ServerVersion(1, 2, 3)
+    assert _ServerVersion(0, 2, 3) < _ServerVersion(1, 2, 3)
+
+    # Test __le__
+    assert _ServerVersion(1, 2, 3) <= _ServerVersion(1, 2, 3)
+    assert _ServerVersion(1, 2, 2) <= _ServerVersion(1, 2, 3)
+    assert _ServerVersion(1, 1, 3) <= _ServerVersion(1, 2, 3)
+    assert _ServerVersion(0, 2, 3) <= _ServerVersion(1, 2, 3)
+
+    # Test __gt__
+    assert _ServerVersion(1, 2, 4) > _ServerVersion(1, 2, 3)
+    assert _ServerVersion(1, 3, 3) > _ServerVersion(1, 2, 3)
+    assert _ServerVersion(2, 2, 3) > _ServerVersion(1, 2, 3)
+
+    # Test __ge__
+    assert _ServerVersion(1, 2, 3) >= _ServerVersion(1, 2, 3)
+    assert _ServerVersion(1, 2, 4) >= _ServerVersion(1, 2, 3)
+    assert _ServerVersion(1, 3, 3) >= _ServerVersion(1, 2, 3)
+    assert _ServerVersion(2, 2, 3) >= _ServerVersion(1, 2, 3)

--- a/weaviate/collections/batch/grpc.py
+++ b/weaviate/collections/batch/grpc.py
@@ -22,7 +22,7 @@ from weaviate.exceptions import (
     WeaviateInsertInvalidPropertyError,
     WeaviateInsertManyAllFailedError,
 )
-from weaviate.util import _datetime_to_string, get_vector, parse_version_string
+from weaviate.util import _datetime_to_string, get_vector
 from weaviate.proto.v1 import batch_pb2, base_pb2
 
 
@@ -34,11 +34,7 @@ class _BatchGRPC(_BaseGRPC):
     """
 
     def __init__(self, connection: Connection, consistency_level: Optional[ConsistencyLevel]):
-        is_weaviate_version_123 = (
-            parse_version_string(connection.server_version) > parse_version_string("1.22")
-            if connection.server_version != ""
-            else True
-        )
+        is_weaviate_version_123 = connection._weaviate_version.is_at_least(1, 23, 0)
 
         super().__init__(connection, consistency_level, is_weaviate_version_123)
 

--- a/weaviate/connect/connection.py
+++ b/weaviate/connect/connection.py
@@ -36,6 +36,7 @@ from weaviate.util import (
     is_weaviate_client_too_old,
     PYPI_PACKAGE_URL,
     _decode_json_response_dict,
+    _ServerVersion,
 )
 from weaviate.warnings import _Warnings
 
@@ -297,6 +298,7 @@ class Connection:
                 pass  # ignore any errors related to requests, it is a best-effort warning
         else:
             self._server_version = ""
+        self._weaviate_version = _ServerVersion.from_string(self._server_version)
 
     def _create_sessions(self, auth_client_secret: Optional[AuthCredentials]) -> None:
         """Creates a async httpx session and a sync request session.

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -710,10 +710,6 @@ def parse_version_string(ver_str: str) -> tuple:
 
 
 class _ServerVersion:
-    major: int
-    minor: int
-    patch: int
-
     def __init__(self, major: int, minor: int, patch: int) -> None:
         self.major = major
         self.minor = minor

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -720,6 +720,9 @@ class _ServerVersion:
             return NotImplemented
         return self.major == other.major and self.minor == other.minor and self.patch == other.patch
 
+    def __neq__(self, other: object) -> bool:
+        return not self.__eq__(other)
+
     def __gt__(self, other: "_ServerVersion") -> bool:
         if self.major > other.major:
             return True

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -751,6 +751,7 @@ class _ServerVersion:
 
     @classmethod
     def from_string(cls, version: str) -> "_ServerVersion":
+        initial = version
         if version == "":
             version = "0"
         if version.count(".") == 0:
@@ -766,7 +767,7 @@ class _ServerVersion:
             return cls(major=ver_tup[0], minor=ver_tup[1], patch=ver_tup[2])
         else:
             raise ValueError(
-                f"Unable to parse a version from the input string: {version}. Is it in the format '(v)x.y.z' (e.g. 'v1.18.2' or '1.18.0')?"
+                f"Unable to parse a version from the input string: {initial}. Is it in the format '(v)x.y.z' (e.g. 'v1.18.2' or '1.18.0')?"
             )
 
 

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -210,3 +210,12 @@ class _Warnings:
             category=UserWarning,
             stacklevel=1,
         )
+
+    @staticmethod
+    def reranking_not_enabled() -> None:
+        warnings.warn(
+            message="""Grpc001: Reranking is not in the gRPC API for this Weaviate version. You must update to the latest Weaviate server version to use this new functionality.
+            This query will execute without reranking.""",
+            category=UserWarning,
+            stacklevel=1,
+        )


### PR DESCRIPTION
This PR warns users if they attempt to use the `rerank` option with a Weaviate server version that does not contain that functionality. It does this by introducing the `_ServerVersion` class that handles all comparisons in an abstracted way