### PR TITLE
Introduce `FilterReference` class to ease reference filtering

### DIFF
--- a/integration/test_collection_filter.py
+++ b/integration/test_collection_filter.py
@@ -22,6 +22,7 @@ from weaviate.collections.classes.filters import (
     _Filters,
     _FilterValue,
     FilterMetadata,
+    FilterReference,
 )
 from weaviate.collections.classes.grpc import MetadataQuery
 from weaviate.collections.classes.internal import Reference
@@ -397,6 +398,9 @@ def test_filters_contains(
         (Filter(path=["ref", "target", "int"]).greater_than(3), [1]),
         (Filter(path=["ref", "target", "text"], length=True).less_than(6), [0]),
         (Filter(path=["ref", "target", "_id"]).equal(UUID2), [1]),
+        (Filter(FilterReference("ref", "target", "int")).greater_than(3), [1]),
+        (Filter(FilterReference("ref", "target", "text"), length=True).less_than(6), [0]),
+        (Filter(FilterReference("ref", "target", "_id")).equal(UUID2), [1]),
     ],
 )
 def test_ref_filters(

--- a/weaviate/classes/query.py
+++ b/weaviate/classes/query.py
@@ -1,4 +1,4 @@
-from weaviate.collections.classes.filters import Filter, FilterMetadata
+from weaviate.collections.classes.filters import Filter, FilterMetadata, FilterReference
 from weaviate.collections.classes.grpc import (
     HybridFusion,
     FromNested,
@@ -16,6 +16,7 @@ from weaviate.collections.classes.grpc import (
 __all__ = [
     "Filter",
     "FilterMetadata",
+    "FilterReference",
     "FromNested",
     "FromReference",
     "FromReferenceMultiTarget",

--- a/weaviate/collections/classes/filters.py
+++ b/weaviate/collections/classes/filters.py
@@ -100,6 +100,25 @@ FilterValues = Union[
 ]
 
 
+class FilterReference:
+    """Define a filter on a property within a referenced collection."""
+
+    def __init__(self, link_on: str, target_collection: str, prop: str):
+        """Initialise the reference filter.
+
+        Arguments:
+            `link_on`
+                The name of the property on the object that links to the referenced collection.
+            `target_collection`
+                The name of the referenced collection.
+            `prop`
+                The name of the property to be filtered on within the referenced collection.
+        """
+        self.link_on = link_on
+        self.target_collection = target_collection
+        self.prop = prop
+
+
 class _FilterValue(_WeaviateInput, _Filters):
     path: Union[str, List[str]]
     value: FilterValues
@@ -118,7 +137,7 @@ class Filter:
     See [the docs](https://weaviate.io/developers/weaviate/search/filters) for more details!
     """
 
-    def __init__(self, path: Union[str, List[str]], length: bool = False):
+    def __init__(self, path: Union[str, List[str], FilterReference], length: bool = False):
         """Initialise the filter.
 
         Arguments:
@@ -131,6 +150,8 @@ class Filter:
         """
         if isinstance(path, str):
             path = [path]
+        elif isinstance(path, FilterReference):
+            path = [path.link_on, path.target_collection, path.prop]
         if length:
             path[-1] = "len(" + path[-1] + ")"
         self.__internal_path = path


### PR DESCRIPTION
This PR adds the `FilterReference` class for use instead of the `path=["ref", "target", "prop"]` syntax