### PR TITLE
Beta/add groupby arg to near queries

### DIFF
--- a/integration/test_collection.py
+++ b/integration/test_collection.py
@@ -24,6 +24,7 @@ from weaviate.collections.classes.grpc import (
     FromReferenceMultiTarget,
     HybridFusion,
     FromReference,
+    GroupBy,
     MetadataQuery,
     Move,
     Sort,
@@ -632,7 +633,7 @@ def test_near_vector(collection_factory: CollectionFactory) -> None:
     assert len(objects_distance) == 3
 
 
-def test_near_vector_group_by(collection_factory: CollectionFactory) -> None:
+def test_near_vector_group_by_namespace(collection_factory: CollectionFactory) -> None:
     collection = collection_factory(
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
@@ -650,11 +651,47 @@ def test_near_vector_group_by(collection_factory: CollectionFactory) -> None:
     banana1 = collection.query.fetch_object_by_id(uuid_banana1, include_vector=True)
 
     assert banana1.vector is not None
-    ret = collection.query_group_by.near_vector(
+    with pytest.warns(DeprecationWarning):
+        ret = collection.query_group_by.near_vector(
+            banana1.vector,
+            group_by_property="name",
+            number_of_groups=4,
+            objects_per_group=10,
+            return_metadata=MetadataQuery(distance=True, certainty=True),
+        )
+
+    assert len(ret.objects) == 4
+    assert ret.objects[0].belongs_to_group == "Banana"
+    assert ret.objects[1].belongs_to_group == "Banana"
+    assert ret.objects[2].belongs_to_group == "car"
+    assert ret.objects[3].belongs_to_group == "Mountain"
+
+
+def test_near_vector_group_by_argument(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[
+            Property(name="Name", data_type=DataType.TEXT),
+            Property(name="Count", data_type=DataType.INT),
+        ],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana1 = collection.data.insert({"Name": "Banana", "Count": 51})
+    collection.data.insert({"Name": "Banana", "Count": 72})
+    collection.data.insert({"Name": "car", "Count": 12})
+    collection.data.insert({"Name": "Mountain", "Count": 1})
+
+    banana1 = collection.query.fetch_object_by_id(uuid_banana1, include_vector=True)
+
+    assert banana1.vector is not None
+    ret = collection.query.near_vector(
         banana1.vector,
-        group_by_property="name",
-        number_of_groups=4,
-        objects_per_group=10,
+        group_by=GroupBy(
+            prop="name",
+            number_of_groups=4,
+            objects_per_group=10,
+        ),
         return_metadata=MetadataQuery(distance=True, certainty=True),
     )
 
@@ -693,7 +730,7 @@ def test_near_object(collection_factory: CollectionFactory) -> None:
     assert len(objects_certainty) == 3
 
 
-def test_near_object_group_by(collection_factory: CollectionFactory) -> None:
+def test_near_object_group_by_namespace(collection_factory: CollectionFactory) -> None:
     collection = collection_factory(
         properties=[
             Property(name="Name", data_type=DataType.TEXT),
@@ -708,11 +745,44 @@ def test_near_object_group_by(collection_factory: CollectionFactory) -> None:
     collection.data.insert({"Name": "car", "Count": 12})
     collection.data.insert({"Name": "Mountain", "Count": 1})
 
-    ret = collection.query_group_by.near_object(
+    with pytest.warns(DeprecationWarning):
+        ret = collection.query_group_by.near_object(
+            uuid_banana1,
+            group_by_property="name",
+            number_of_groups=4,
+            objects_per_group=10,
+            return_metadata=MetadataQuery(distance=True, certainty=True),
+        )
+
+    assert len(ret.objects) == 4
+    assert ret.objects[0].belongs_to_group == "Banana"
+    assert ret.objects[1].belongs_to_group == "Banana"
+    assert ret.objects[2].belongs_to_group == "car"
+    assert ret.objects[3].belongs_to_group == "Mountain"
+
+
+def test_near_object_group_by_argument(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[
+            Property(name="Name", data_type=DataType.TEXT),
+            Property(name="Count", data_type=DataType.INT),
+        ],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana1 = collection.data.insert({"Name": "Banana", "Count": 51})
+    collection.data.insert({"Name": "Banana", "Count": 72})
+    collection.data.insert({"Name": "car", "Count": 12})
+    collection.data.insert({"Name": "Mountain", "Count": 1})
+
+    ret = collection.query.near_object(
         uuid_banana1,
-        group_by_property="name",
-        number_of_groups=4,
-        objects_per_group=10,
+        group_by=GroupBy(
+            prop="name",
+            number_of_groups=4,
+            objects_per_group=10,
+        ),
         return_metadata=MetadataQuery(distance=True, certainty=True),
     )
 
@@ -1161,7 +1231,7 @@ def test_near_text_error(collection_factory: CollectionFactory) -> None:
         collection.query.near_text(query="test", move_to=Move(force=1.0))
 
 
-def test_near_text_group_by(collection_factory: CollectionFactory) -> None:
+def test_near_text_group_by_namespace(collection_factory: CollectionFactory) -> None:
     collection = collection_factory(
         vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
             vectorize_collection_name=False
@@ -1178,11 +1248,49 @@ def test_near_text_group_by(collection_factory: CollectionFactory) -> None:
         ]
     )
 
-    ret = collection.query_group_by.near_text(
+    with pytest.warns(DeprecationWarning):
+        ret = collection.query_group_by.near_text(
+            query="cake",
+            group_by_property="value",
+            number_of_groups=2,
+            objects_per_group=100,
+            include_vector=True,
+            return_properties=["value"],
+        )
+
+    assert len(ret.objects) == 2
+    assert ret.objects[0].uuid == batch_return.uuids[3]
+    assert ret.objects[0].vector is not None
+    assert ret.objects[0].belongs_to_group == "cake"
+    assert ret.objects[1].uuid == batch_return.uuids[2]
+    assert ret.objects[1].vector is not None
+    assert ret.objects[1].belongs_to_group == "apple cake"
+
+
+def test_near_text_group_by_argument(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+        properties=[Property(name="value", data_type=DataType.TEXT)],
+    )
+
+    batch_return = collection.data.insert_many(
+        [
+            DataObject(properties={"value": "Apple"}, uuid=UUID1),
+            DataObject(properties={"value": "Mountain climbing"}),
+            DataObject(properties={"value": "apple cake"}),
+            DataObject(properties={"value": "cake"}),
+        ]
+    )
+
+    ret = collection.query.near_text(
         query="cake",
-        group_by_property="value",
-        number_of_groups=2,
-        objects_per_group=100,
+        group_by=GroupBy(
+            prop="value",
+            number_of_groups=2,
+            objects_per_group=100,
+        ),
         include_vector=True,
         return_properties=["value"],
     )

--- a/integration/test_collection_rerank.py
+++ b/integration/test_collection_rerank.py
@@ -4,6 +4,7 @@ import pytest
 
 import weaviate
 import weaviate.classes as wvc
+from weaviate.util import _ServerVersion
 
 from .conftest import CollectionFactory
 
@@ -39,7 +40,8 @@ def test_queries_with_rerank() -> None:
         ),
         additional_headers={"X-OpenAI-Api-Key": api_key},
     )
-    client._connection._server_version = "1.23.1"
+    if client._connection._weaviate_version < _ServerVersion(1, 23, 1):
+        pytest.skip("Reranking requires Weaviate 1.23.1 or higher")
 
     collection = client.collections.create(
         name="Test_test_queries_with_rerank",
@@ -100,7 +102,8 @@ def test_queries_with_rerank_and_generative(collection_factory: CollectionFactor
         ),
         additional_headers={"X-OpenAI-Api-Key": api_key},
     )
-    client._connection._server_version = "1.23.1"
+    if client._connection._weaviate_version < _ServerVersion(1, 23, 1):
+        pytest.skip("Generative reranking requires Weaviate 1.23.1 or higher")
 
     collection = client.collections.create(
         name="Test_test_queries_with_rerank_and_generative",

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -5,6 +5,7 @@ grpcio>=1.57.0,<2.0.0
 grpcio-tools>=1.57.0,<2.0.0
 grpcio-health-checking>=1.57.0,<2.0.0
 pydantic>=2.1.1<3.0.0
+deprecated>=1.2.14<2.0.0
 
 build
 twine
@@ -25,6 +26,7 @@ pytest-httpserver>=1.0.8
 mypy>=1.5.1<2.0.0
 mypy-extensions==1.0.0
 tomli>=2.0.1<3.0.0
+types-Deprecated>=1.2.9.3<2.0.0
 types-protobuf>=4.24.0.1<5.0.0
 types-requests>=2.31.0.2<3.0.0
 types-urllib3>=1.26.25.14<2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ packages =
 platforms = any
 include_package_data = True
 install_requires =
+    deprecated>=1.2.14,<2.0.0
     requests>=2.30.0,<3.0.0
     validators>=0.21.2,<1.0.0
     authlib>=1.2.1,<2.0.0

--- a/weaviate/collections/aggregations/near_image.py
+++ b/weaviate/collections/aggregations/near_image.py
@@ -114,8 +114,8 @@ class _NearImage(_Aggregate):
 
 class _NearImageGroupBy(_Aggregate):
     @deprecated(
-        version="4.4b6",
-        reason="Use `aggregate.near_image` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `aggregate.near_image` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in the final release.",
     )
     def near_image(
         self,

--- a/weaviate/collections/aggregations/near_image.py
+++ b/weaviate/collections/aggregations/near_image.py
@@ -1,28 +1,65 @@
 from io import BufferedReader
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union, overload
+
+from deprecated import deprecated
 
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
     _AggregateReturn,
     _AggregateGroupByReturn,
+    _AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 
 
 class _NearImage(_Aggregate):
+    @overload
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> _AggregateReturn:
+        ...
+
+    @overload
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        object_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: str,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> _AggregateGroupByReturn:
+        ...
+
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        object_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[str] = None,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
         """Aggregate metrics over the objects returned by a near image vector search on this collection.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -40,6 +77,8 @@ class _NearImage(_Aggregate):
                 The maximum number of objects to return from the image search prior to the aggregation.
             `filters`
                 The filters to apply to the search.
+            `group_by`
+                The property name to group the aggregation by.
             `limit`
                 The maximum number of aggregated objects to return.
             `total_count`
@@ -48,7 +87,7 @@ class _NearImage(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateReturn` object that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -60,12 +99,24 @@ class _NearImage(_Aggregate):
             else [return_metrics]
         )
         builder = self._base(return_metrics, filters, limit, total_count)
+        if group_by is not None:
+            builder = builder.with_group_by_filter([group_by]).with_fields(
+                " groupedBy { path value } "
+            )
         builder = self._add_near_image(builder, near_image, certainty, distance, object_limit)
         res = self._do(builder)
-        return self._to_aggregate_result(res, return_metrics)
+        return (
+            self._to_aggregate_result(res, return_metrics)
+            if group_by is None
+            else self._to_group_by_result(res, return_metrics)
+        )
 
 
 class _NearImageGroupBy(_Aggregate):
+    @deprecated(
+        version="4.4b6",
+        reason="Use `aggregate.near_image` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+    )
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
@@ -77,7 +128,7 @@ class _NearImageGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroupByReturn]:
+    ) -> List[_AggregateGroup]:
         """Aggregate metrics over the objects returned by a near image vector search on this collection grouping the results by a property.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -105,7 +156,7 @@ class _NearImageGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateGroupByReturn` object that includes the aggregation objects.
+            A list of `_AggregateGroup` objects that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -123,4 +174,4 @@ class _NearImageGroupBy(_Aggregate):
         )
         builder = self._add_near_image(builder, near_image, certainty, distance, object_limit)
         res = self._do(builder)
-        return self._to_group_by_result(res, return_metrics)
+        return self._to_group_by_result(res, return_metrics).groups

--- a/weaviate/collections/aggregations/near_object.py
+++ b/weaviate/collections/aggregations/near_object.py
@@ -113,8 +113,8 @@ class _NearObject(_Aggregate):
 
 class _NearObjectGroupBy(_Aggregate):
     @deprecated(
-        version="4.4b6",
-        reason="Use `aggregate.near_object` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `aggregate.near_object` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in the final release.",
     )
     def near_object(
         self,

--- a/weaviate/collections/aggregations/near_text.py
+++ b/weaviate/collections/aggregations/near_text.py
@@ -124,8 +124,8 @@ class _NearText(_Aggregate):
 
 class _NearTextGroupBy(_Aggregate):
     @deprecated(
-        version="4.4b6",
-        reason="Use `aggregate.near_text` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `aggregate.near_text` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in the final release.",
     )
     def near_text(
         self,

--- a/weaviate/collections/aggregations/near_text.py
+++ b/weaviate/collections/aggregations/near_text.py
@@ -1,29 +1,70 @@
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union, overload
+
+from deprecated import deprecated
 
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
     _AggregateReturn,
     _AggregateGroupByReturn,
+    _AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 from weaviate.collections.classes.grpc import Move
 
 
 class _NearText(_Aggregate):
+    @overload
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
         move_away: Optional[Move] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> _AggregateReturn:
+        ...
+
+    @overload
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        object_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: str,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> _AggregateGroupByReturn:
+        ...
+
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        object_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[str] = None,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
         """Aggregate metrics over the objects returned by a near text vector search on this collection.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -45,6 +86,8 @@ class _NearText(_Aggregate):
                 The maximum number of objects to return from the text search prior to the aggregation.
             `filters`
                 The filters to apply to the search.
+            `group_by`
+                The property name to group the aggregation by.
             `limit`
                 The maximum number of aggregated objects to return.
             `total_count`
@@ -53,7 +96,7 @@ class _NearText(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateReturn` object that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -65,14 +108,25 @@ class _NearText(_Aggregate):
             else [return_metrics]
         )
         builder = self._base(return_metrics, filters, limit, total_count)
+        if group_by is not None:
+            builder = builder.with_group_by_filter([group_by])
+            builder = builder.with_fields(" groupedBy { path value } ")
         builder = self._add_near_text(
             builder, query, certainty, distance, move_to, move_away, object_limit
         )
         res = self._do(builder)
-        return self._to_aggregate_result(res, return_metrics)
+        return (
+            self._to_aggregate_result(res, return_metrics)
+            if group_by is None
+            else self._to_group_by_result(res, return_metrics)
+        )
 
 
 class _NearTextGroupBy(_Aggregate):
+    @deprecated(
+        version="4.4b6",
+        reason="Use `aggregate.near_text` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+    )
     def near_text(
         self,
         query: Union[List[str], str],
@@ -86,7 +140,7 @@ class _NearTextGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroupByReturn]:
+    ) -> List[_AggregateGroup]:
         """Aggregate metrics over the objects returned by a near text search on this collection grouping the results by a property.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -118,7 +172,7 @@ class _NearTextGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateGroupByReturn` object that includes the aggregation objects.
+            A list of `_AggregateGroup` objects that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -138,4 +192,4 @@ class _NearTextGroupBy(_Aggregate):
             builder, query, certainty, distance, move_to, move_away, object_limit
         )
         res = self._do(builder)
-        return self._to_group_by_result(res, return_metrics)
+        return self._to_group_by_result(res, return_metrics).groups

--- a/weaviate/collections/aggregations/near_vector.py
+++ b/weaviate/collections/aggregations/near_vector.py
@@ -1,26 +1,63 @@
-from typing import List, Optional
+from typing import List, Literal, Optional, Union, overload
+
+from deprecated import deprecated
 
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
     _AggregateReturn,
     _AggregateGroupByReturn,
+    _AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 
 
 class _NearVector(_Aggregate):
+    @overload
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> _AggregateReturn:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        object_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: str,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> _AggregateGroupByReturn:
+        ...
+
+    def near_vector(
+        self,
+        near_vector: List[float],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        object_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[str] = None,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
         """Aggregate metrics over the objects returned by a near vector search on this collection.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -38,6 +75,8 @@ class _NearVector(_Aggregate):
                 The maximum number of objects to return from the vector search prior to the aggregation.
             `filters`
                 The filters to apply to the search.
+            `group_by`
+                The property name to group the aggregation by.
             `limit`
                 The maximum number of aggregated objects to return.
             `total_count`
@@ -46,7 +85,7 @@ class _NearVector(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateReturn` object that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -58,12 +97,23 @@ class _NearVector(_Aggregate):
             else [return_metrics]
         )
         builder = self._base(return_metrics, filters, limit, total_count)
+        if group_by is not None:
+            builder = builder.with_group_by_filter([group_by])
+            builder = builder.with_fields(" groupedBy { path value } ")
         builder = self._add_near_vector(builder, near_vector, certainty, distance, object_limit)
         res = self._do(builder)
-        return self._to_aggregate_result(res, return_metrics)
+        return (
+            self._to_aggregate_result(res, return_metrics)
+            if group_by is None
+            else self._to_group_by_result(res, return_metrics)
+        )
 
 
 class _NearVectorGroupBy(_Aggregate):
+    @deprecated(
+        version="4.4b6",
+        reason="Use `aggregate.near_text` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+    )
     def near_vector(
         self,
         near_vector: List[float],
@@ -75,7 +125,7 @@ class _NearVectorGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroupByReturn]:
+    ) -> List[_AggregateGroup]:
         """Aggregate metrics over the objects returned by a near vector search on this collection and grouping the results grouping the results by a property.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -103,7 +153,7 @@ class _NearVectorGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateGroupByReturn` object that includes the aggregation objects.
+            A list of `_AggregateGroup` object that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -121,4 +171,4 @@ class _NearVectorGroupBy(_Aggregate):
         )
         builder = self._add_near_vector(builder, near_vector, certainty, distance, object_limit)
         res = self._do(builder)
-        return self._to_group_by_result(res, return_metrics)
+        return self._to_group_by_result(res, return_metrics).groups

--- a/weaviate/collections/aggregations/near_vector.py
+++ b/weaviate/collections/aggregations/near_vector.py
@@ -111,8 +111,8 @@ class _NearVector(_Aggregate):
 
 class _NearVectorGroupBy(_Aggregate):
     @deprecated(
-        version="4.4b6",
-        reason="Use `aggregate.near_text` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `aggregate.near_text` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in the final release.",
     )
     def near_vector(
         self,

--- a/weaviate/collections/aggregations/over_all.py
+++ b/weaviate/collections/aggregations/over_all.py
@@ -87,8 +87,8 @@ class _OverAll(_Aggregate):
 
 class _OverAllGroupBy(_Aggregate):
     @deprecated(
-        version="4.4b6",
-        reason="Use `aggregate.over_all` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `aggregate.over_all` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in the final release.",
     )
     def over_all(
         self,

--- a/weaviate/collections/aggregations/over_all.py
+++ b/weaviate/collections/aggregations/over_all.py
@@ -1,27 +1,58 @@
-from typing import List, Optional
+from typing import List, Literal, Optional, Union, overload
+
+from deprecated import deprecated
 
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
     _AggregateReturn,
     _AggregateGroupByReturn,
+    _AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 
 
 class _OverAll(_Aggregate):
+    @overload
     def over_all(
         self,
+        *,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> _AggregateReturn:
+        ...
+
+    @overload
+    def over_all(
+        self,
+        *,
+        filters: Optional[_Filters] = None,
+        group_by: str,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> _AggregateGroupByReturn:
+        ...
+
+    def over_all(
+        self,
+        *,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[str] = None,
+        limit: Optional[int] = None,
+        total_count: bool = True,
+        return_metrics: Optional[PropertiesMetrics] = None,
+    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
         """Aggregate metrics over all the objects in this collection without any vector search.
 
         Arguments:
             `filters`
                 The filters to apply to the search.
+            `group_by`
+                The property name to group the aggregation by.
             `limit`
                 The maximum number of aggregated objects to return.
             `total_count`
@@ -30,7 +61,7 @@ class _OverAll(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateReturn` object that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -42,11 +73,23 @@ class _OverAll(_Aggregate):
             else [return_metrics]
         )
         builder = self._base(return_metrics, filters, limit, total_count)
+        if group_by is not None:
+            builder = builder.with_group_by_filter([group_by]).with_fields(
+                " groupedBy { path value } "
+            )
         res = self._do(builder)
-        return self._to_aggregate_result(res, return_metrics)
+        return (
+            self._to_aggregate_result(res, return_metrics)
+            if group_by is None
+            else self._to_group_by_result(res, return_metrics)
+        )
 
 
 class _OverAllGroupBy(_Aggregate):
+    @deprecated(
+        version="4.4b6",
+        reason="Use `aggregate.over_all` with the `group_by` argument instead. The `aggregate_group_by` namespace will be removed in GA.",
+    )
     def over_all(
         self,
         group_by: str,
@@ -54,7 +97,7 @@ class _OverAllGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroupByReturn]:
+    ) -> List[_AggregateGroup]:
         """Aggregate metrics over all the objects in this collection without any vector search grouping the results by a property.
 
         Arguments:
@@ -70,7 +113,7 @@ class _OverAllGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A `_AggregateGroupByReturn` object that includes the aggregation objects.
+            A list of `_AggregateGroup` objects that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -87,4 +130,4 @@ class _OverAllGroupBy(_Aggregate):
             .with_fields(" groupedBy { path value } ")
         )
         res = self._do(builder)
-        return self._to_group_by_result(res, return_metrics)
+        return self._to_group_by_result(res, return_metrics).groups

--- a/weaviate/collections/classes/aggregate.py
+++ b/weaviate/collections/classes/aggregate.py
@@ -108,10 +108,15 @@ class _GroupedBy:
 
 
 @dataclass
-class _AggregateGroupByReturn:
+class _AggregateGroup:
     grouped_by: _GroupedBy
     properties: AProperties
     total_count: Optional[int]
+
+
+@dataclass
+class _AggregateGroupByReturn:
+    groups: List[_AggregateGroup]
 
 
 class _MetricsBase(BaseModel):

--- a/weaviate/collections/classes/grpc.py
+++ b/weaviate/collections/classes/grpc.py
@@ -144,6 +144,14 @@ class Generate(_WeaviateInput):
     grouped_properties: Optional[List[str]] = Field(default=None)
 
 
+class GroupBy(_WeaviateInput):
+    """Define how the query's group-by operation should be performed."""
+
+    prop: str
+    objects_per_group: int
+    number_of_groups: int
+
+
 class Sort(_WeaviateInput):
     """Define how the query's sort operation should be performed."""
 

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -17,6 +17,7 @@ from weaviate.collections.classes.grpc import (
     FromReference,
     FromReferenceMultiTarget,
     Generate,
+    GroupBy,
     MetadataQuery,
     METADATA,
     PROPERTIES,
@@ -217,6 +218,18 @@ class _GroupBy:
             path=[self.prop],
             number_of_groups=self.number_of_groups,
             objects_per_group=self.objects_per_group,
+        )
+
+    @classmethod
+    def from_input(cls, group_by: Optional[GroupBy]) -> Optional["_GroupBy"]:
+        return (
+            cls(
+                prop=group_by.prop,
+                number_of_groups=group_by.number_of_groups,
+                objects_per_group=group_by.objects_per_group,
+            )
+            if group_by
+            else None
         )
 
 
@@ -528,6 +541,7 @@ class _QueryOptions(Generic[Properties, References, TReferences]):
     include_properties: bool
     include_references: bool
     include_vector: bool
+    is_group_by: bool
 
     @classmethod
     def from_input(
@@ -538,6 +552,7 @@ class _QueryOptions(Generic[Properties, References, TReferences]):
         collection_references: Optional[Type[References]],
         query_references: Optional[ReturnReferences[TReferences]],
         rerank: Optional[Rerank] = None,
+        group_by: Optional[GroupBy] = None,
     ) -> "_QueryOptions":
         return cls(
             include_metadata=return_metadata is not None or rerank is not None,
@@ -546,4 +561,5 @@ class _QueryOptions(Generic[Properties, References, TReferences]):
             ),
             include_references=collection_references is not None or query_references is not None,
             include_vector=include_vector,
+            is_group_by=group_by is not None,
         )

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -195,7 +195,7 @@ class _BaseQuery(Generic[Properties, References]):
             ref_prop.prop_name: _CrossReference._from(
                 [
                     self.__result_to_query_object(
-                        prop, prop.metadata, _QueryOptions(True, True, True, True)
+                        prop, prop.metadata, _QueryOptions(True, True, True, True, False)
                     )
                     for prop in ref_prop.properties
                 ]
@@ -272,7 +272,7 @@ class _BaseQuery(Generic[Properties, References]):
             ref_prop.prop_name: _CrossReference._from(
                 [
                     self.__result_to_query_object(
-                        prop, prop.metadata, _QueryOptions(True, True, True, True)
+                        prop, prop.metadata, _QueryOptions(True, True, True, True, False)
                     )
                     for prop in ref_prop.properties
                 ]
@@ -446,6 +446,36 @@ class _BaseQuery(Generic[Properties, References]):
                 _GroupByReturn[TProperties, TReferences],
             ],
             return_,
+        )
+
+    def _result_to_query_or_groupby_return(
+        self,
+        res: SearchResponse,
+        options: _QueryOptions,
+        properties: Optional[
+            ReturnProperties[TProperties]
+        ],  # required until 3.12 is minimum supported version to use new generics syntax
+        references: Optional[
+            ReturnReferences[TReferences]
+        ],  # required until 3.12 is minimum supported version to use new generics syntax
+    ) -> Union[
+        _QueryReturn[Properties, References],
+        _QueryReturn[Properties, CrossReferences],
+        _QueryReturn[Properties, TReferences],
+        _QueryReturn[TProperties, References],
+        _QueryReturn[TProperties, CrossReferences],
+        _QueryReturn[TProperties, TReferences],
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, CrossReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, CrossReferences],
+        _GroupByReturn[TProperties, TReferences],
+    ]:
+        return (
+            self._result_to_query_return(res, options, properties, references)
+            if not options.is_group_by
+            else self._result_to_groupby_return(res, options, properties, references)
         )
 
     def __parse_generic_properties(

--- a/weaviate/collections/queries/near_audio.py
+++ b/weaviate/collections/queries/near_audio.py
@@ -709,8 +709,8 @@ class _NearAudioGroupBy(Generic[Properties, References], _BaseQuery[Properties, 
         ...
 
     @deprecated(
-        version="4.4b6",
-        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in the final release.",
     )
     def near_audio(
         self,

--- a/weaviate/collections/queries/near_audio.py
+++ b/weaviate/collections/queries/near_audio.py
@@ -2,10 +2,12 @@ from io import BufferedReader
 from pathlib import Path
 from typing import Generic, List, Literal, Optional, Type, Union, overload
 
+from deprecated import deprecated
+
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, Rerank
+from weaviate.collections.classes.grpc import GroupBy, METADATA, PROPERTIES, REFERENCES, Rerank
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
@@ -31,15 +33,16 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Literal[None] = None,
     ) -> _QueryReturn[Properties, References]:
@@ -49,15 +52,16 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: REFERENCES,
     ) -> _QueryReturn[Properties, CrossReferences]:
@@ -67,15 +71,16 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Type[TReferences],
     ) -> _QueryReturn[Properties, TReferences]:
@@ -85,15 +90,16 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Literal[None] = None,
     ) -> _QueryReturn[TProperties, References]:
@@ -103,15 +109,16 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: REFERENCES,
     ) -> _QueryReturn[TProperties, CrossReferences]:
@@ -121,32 +128,150 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Type[TReferences],
     ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
+    ### GroupBy ###
+
+    @overload
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: GroupBy,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
         *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, CrossReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, CrossReferences]:
+        ...
+
+    @overload
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
+        ...
+
+    def near_audio(
+        self,
+        near_audio: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[GroupBy] = None,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
         return_references: Optional[ReturnReferences[TReferences]] = None,
     ) -> Union[
@@ -156,6 +281,12 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
         _QueryReturn[TProperties, References],
         _QueryReturn[TProperties, CrossReferences],
         _QueryReturn[TProperties, TReferences],
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, CrossReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, CrossReferences],
+        _GroupByReturn[TProperties, TReferences],
     ]:
         """Search for objects by audio in this collection using an audio-capable vectorisation module and vector-based similarity search.
 
@@ -194,7 +325,8 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
             - If `return_references` is not provided then no references are provided.
 
         Returns:
-            A `_QueryReturn` object that includes the searched objects.
+            A `_QueryReturn` or `_GroupByReturn` object that includes the searched objects.
+            If `group_by` is provided then a `_GroupByReturn` object is returned, otherwise a `_QueryReturn` object is returned.
 
         Raises:
             `weaviate.exceptions.WeaviateQueryException`:
@@ -204,15 +336,16 @@ class _NearAudioQuery(Generic[Properties, References], _BaseQuery[Properties, Re
             audio=self._parse_media(near_audio),
             certainty=certainty,
             distance=distance,
-            filters=filters,
             limit=limit,
             autocut=auto_limit,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
             rerank=rerank,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
             return_references=self._parse_return_references(return_references),
         )
-        return self._result_to_query_return(
+        return self._result_to_query_or_groupby_return(
             res,
             _QueryOptions.from_input(
                 return_metadata,
@@ -575,6 +708,10 @@ class _NearAudioGroupBy(Generic[Properties, References], _BaseQuery[Properties, 
     ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
+    @deprecated(
+        version="4.4b6",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+    )
     def near_audio(
         self,
         near_audio: Union[str, Path, BufferedReader],

--- a/weaviate/collections/queries/near_image.py
+++ b/weaviate/collections/queries/near_image.py
@@ -2,10 +2,12 @@ from io import BufferedReader
 from pathlib import Path
 from typing import Generic, List, Literal, Optional, Type, Union, overload
 
+from deprecated import deprecated
+
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, Rerank
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, GroupBy, Rerank
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
@@ -31,15 +33,16 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Literal[None] = None,
     ) -> _QueryReturn[Properties, References]:
@@ -49,15 +52,16 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: REFERENCES,
     ) -> _QueryReturn[Properties, CrossReferences]:
@@ -67,15 +71,16 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Type[TReferences],
     ) -> _QueryReturn[Properties, TReferences]:
@@ -85,15 +90,16 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Literal[None] = None,
     ) -> _QueryReturn[TProperties, References]:
@@ -103,15 +109,16 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: REFERENCES,
     ) -> _QueryReturn[TProperties, CrossReferences]:
@@ -121,32 +128,150 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Type[TReferences],
     ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
+    ### GroupBy ###
+
+    @overload
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: GroupBy,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
         *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, CrossReferences]:
+        ...
+
+    @overload
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
+        ...
+
+    @overload
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, CrossReferences]:
+        ...
+
+    @overload
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
+        ...
+
+    def near_image(
+        self,
+        near_image: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[GroupBy] = None,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
         return_references: Optional[ReturnReferences[TReferences]] = None,
     ) -> Union[
@@ -156,6 +281,12 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
         _QueryReturn[TProperties, References],
         _QueryReturn[TProperties, CrossReferences],
         _QueryReturn[TProperties, TReferences],
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, CrossReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, CrossReferences],
+        _GroupByReturn[TProperties, TReferences],
     ]:
         """Search for objects by image in this collection using an image-capable vectorisation module and vector-based similarity search.
 
@@ -204,15 +335,16 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
             image=self._parse_media(near_image),
             certainty=certainty,
             distance=distance,
-            filters=filters,
             limit=limit,
             autocut=auto_limit,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
             rerank=rerank,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
             return_references=self._parse_return_references(return_references),
         )
-        return self._result_to_query_return(
+        return self._result_to_query_or_groupby_return(
             res,
             _QueryOptions.from_input(
                 return_metadata,
@@ -221,6 +353,7 @@ class _NearImageQuery(Generic[Properties, References], _BaseQuery[Properties, Re
                 self._references,
                 return_references,
                 rerank,
+                group_by,
             ),
             return_properties,
             return_references,
@@ -575,6 +708,10 @@ class _NearImageGroupBy(Generic[Properties, References], _BaseQuery[Properties, 
     ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
+    @deprecated(
+        version="4.4b6",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+    )
     def near_image(
         self,
         near_image: Union[str, Path, BufferedReader],

--- a/weaviate/collections/queries/near_image.py
+++ b/weaviate/collections/queries/near_image.py
@@ -709,8 +709,8 @@ class _NearImageGroupBy(Generic[Properties, References], _BaseQuery[Properties, 
         ...
 
     @deprecated(
-        version="4.4b6",
-        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in the final release.",
     )
     def near_image(
         self,

--- a/weaviate/collections/queries/near_object.py
+++ b/weaviate/collections/queries/near_object.py
@@ -699,8 +699,8 @@ class _NearObjectGroupBy(Generic[Properties, References], _BaseQuery[Properties,
         ...
 
     @deprecated(
-        version="4.4b6",
-        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in the final release.",
     )
     def near_object(
         self,

--- a/weaviate/collections/queries/near_object.py
+++ b/weaviate/collections/queries/near_object.py
@@ -1,9 +1,11 @@
 from typing import Generic, List, Literal, Optional, Type, Union, overload
 
+from deprecated import deprecated
+
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, Rerank
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, GroupBy, Rerank
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
@@ -27,15 +29,16 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_object(
         self,
         near_object: UUID,
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Literal[None] = None,
     ) -> _QueryReturn[Properties, References]:
@@ -45,15 +48,16 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_object(
         self,
         near_object: UUID,
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: REFERENCES,
     ) -> _QueryReturn[Properties, CrossReferences]:
@@ -63,15 +67,16 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_object(
         self,
         near_object: UUID,
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Type[TReferences],
     ) -> _QueryReturn[Properties, TReferences]:
@@ -81,15 +86,16 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_object(
         self,
         near_object: UUID,
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Literal[None] = None,
     ) -> _QueryReturn[TProperties, References]:
@@ -99,15 +105,16 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_object(
         self,
         near_object: UUID,
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: REFERENCES,
     ) -> _QueryReturn[TProperties, CrossReferences]:
@@ -117,32 +124,150 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_object(
         self,
         near_object: UUID,
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Type[TReferences],
     ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
+    ### GroupBy ###
+
+    @overload
     def near_object(
         self,
         near_object: UUID,
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: GroupBy,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_object(
+        self,
+        near_object: UUID,
         *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, CrossReferences]:
+        ...
+
+    @overload
+    def near_object(
+        self,
+        near_object: UUID,
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
+        ...
+
+    @overload
+    def near_object(
+        self,
+        near_object: UUID,
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_object(
+        self,
+        near_object: UUID,
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, CrossReferences]:
+        ...
+
+    @overload
+    def near_object(
+        self,
+        near_object: UUID,
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
+        ...
+
+    def near_object(
+        self,
+        near_object: UUID,
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[GroupBy] = None,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
         return_references: Optional[ReturnReferences[TReferences]] = None,
     ) -> Union[
@@ -152,6 +277,12 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
         _QueryReturn[TProperties, References],
         _QueryReturn[TProperties, CrossReferences],
         _QueryReturn[TProperties, TReferences],
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, CrossReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, CrossReferences],
+        _GroupByReturn[TProperties, TReferences],
     ]:
         """Search for objects in this collection by another object using a vector-based similarity search.
 
@@ -200,12 +331,13 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
             limit=limit,
             autocut=auto_limit,
             filters=filters,
+            group_by=_GroupBy.from_input(group_by),
             rerank=rerank,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
             return_references=self._parse_return_references(return_references),
         )
-        return self._result_to_query_return(
+        return self._result_to_query_or_groupby_return(
             res,
             _QueryOptions.from_input(
                 return_metadata,
@@ -214,6 +346,7 @@ class _NearObjectQuery(Generic[Properties, References], _BaseQuery[Properties, R
                 self._references,
                 return_references,
                 rerank,
+                group_by,
             ),
             return_properties,
             return_references,
@@ -565,6 +698,10 @@ class _NearObjectGroupBy(Generic[Properties, References], _BaseQuery[Properties,
     ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
+    @deprecated(
+        version="4.4b6",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+    )
     def near_object(
         self,
         near_object: UUID,

--- a/weaviate/collections/queries/near_text.py
+++ b/weaviate/collections/queries/near_text.py
@@ -1,9 +1,18 @@
 from typing import Generic, List, Literal, Optional, Type, Union, overload
 
+from deprecated import deprecated
+
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, Move, Rerank
+from weaviate.collections.classes.grpc import (
+    METADATA,
+    PROPERTIES,
+    REFERENCES,
+    GroupBy,
+    Move,
+    Rerank,
+)
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
@@ -26,6 +35,7 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
@@ -33,10 +43,10 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Literal[None] = None,
     ) -> _QueryReturn[Properties, References]:
@@ -46,6 +56,7 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
@@ -53,10 +64,10 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: REFERENCES,
     ) -> _QueryReturn[Properties, CrossReferences]:
@@ -66,6 +77,7 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
@@ -73,10 +85,10 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Type[TReferences],
     ) -> _QueryReturn[Properties, TReferences]:
@@ -86,6 +98,7 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
@@ -93,10 +106,10 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Literal[None] = None,
     ) -> _QueryReturn[TProperties, References]:
@@ -106,6 +119,7 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
@@ -113,10 +127,10 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: REFERENCES,
     ) -> _QueryReturn[TProperties, CrossReferences]:
@@ -126,6 +140,7 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
@@ -133,18 +148,22 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Type[TReferences],
     ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
+    ### GroupBy ###
+
+    @overload
     def near_text(
         self,
         query: Union[List[str], str],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         move_to: Optional[Move] = None,
@@ -152,10 +171,135 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: GroupBy,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_text(
+        self,
+        query: Union[List[str], str],
         *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _QueryReturn[Properties, CrossReferences]:
+        ...
+
+    @overload
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
+        ...
+
+    @overload
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, CrossReferences]:
+        ...
+
+    @overload
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
+        ...
+
+    def near_text(
+        self,
+        query: Union[List[str], str],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        move_to: Optional[Move] = None,
+        move_away: Optional[Move] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[GroupBy] = None,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
         return_references: Optional[ReturnReferences[TReferences]] = None,
     ) -> Union[
@@ -165,6 +309,12 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
         _QueryReturn[TProperties, References],
         _QueryReturn[TProperties, CrossReferences],
         _QueryReturn[TProperties, TReferences],
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, CrossReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, CrossReferences],
+        _GroupByReturn[TProperties, TReferences],
     ]:
         """Search for objects in this collection by text using text-capable vectorisation module and vector-based similarity search.
 
@@ -218,12 +368,13 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
             limit=limit,
             autocut=auto_limit,
             filters=filters,
+            group_by=_GroupBy.from_input(group_by),
             rerank=rerank,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
             return_references=self._parse_return_references(return_references),
         )
-        return self._result_to_query_return(
+        return self._result_to_query_or_groupby_return(
             res,
             _QueryOptions.from_input(
                 return_metadata,
@@ -232,6 +383,7 @@ class _NearTextQuery(Generic[Properties, References], _BaseQuery[Properties, Ref
                 self._references,
                 return_references,
                 rerank,
+                group_by,
             ),
             return_properties,
             return_references,
@@ -614,6 +766,10 @@ class _NearTextGroupBy(Generic[Properties, References], _BaseQuery[Properties, R
     ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
+    @deprecated(
+        version="4.4b6",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+    )
     def near_text(
         self,
         query: Union[List[str], str],

--- a/weaviate/collections/queries/near_text.py
+++ b/weaviate/collections/queries/near_text.py
@@ -767,8 +767,8 @@ class _NearTextGroupBy(Generic[Properties, References], _BaseQuery[Properties, R
         ...
 
     @deprecated(
-        version="4.4b6",
-        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in the final release.",
     )
     def near_text(
         self,

--- a/weaviate/collections/queries/near_vector.py
+++ b/weaviate/collections/queries/near_vector.py
@@ -701,8 +701,8 @@ class _NearVectorGroupBy(Generic[Properties, References], _BaseQuery[Properties,
         ...
 
     @deprecated(
-        version="4.4b6",
-        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in the final release.",
     )
     def near_vector(
         self,

--- a/weaviate/collections/queries/near_vector.py
+++ b/weaviate/collections/queries/near_vector.py
@@ -1,9 +1,11 @@
 from typing import Generic, List, Literal, Optional, Type, Union, overload
 
+from deprecated import deprecated
+
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, Rerank
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, GroupBy, Rerank
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
@@ -29,15 +31,16 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Literal[None] = None,
     ) -> _QueryReturn[Properties, References]:
@@ -47,15 +50,16 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: REFERENCES,
     ) -> _QueryReturn[Properties, CrossReferences]:
@@ -65,15 +69,16 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Type[TReferences],
     ) -> _QueryReturn[Properties, TReferences]:
@@ -83,15 +88,16 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Literal[None] = None,
     ) -> _QueryReturn[TProperties, References]:
@@ -101,15 +107,16 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: REFERENCES,
     ) -> _QueryReturn[TProperties, CrossReferences]:
@@ -119,32 +126,150 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Type[TReferences],
     ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
+    ### GroupBy ###
+
+    @overload
     def near_vector(
         self,
         near_vector: List[float],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: GroupBy,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
         *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, CrossReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, CrossReferences]:
+        ...
+
+    @overload
+    def near_vector(
+        self,
+        near_vector: List[float],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
+        ...
+
+    def near_vector(
+        self,
+        near_vector: List[float],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[GroupBy] = None,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
         return_references: Optional[ReturnReferences[TReferences]] = None,
     ) -> Union[
@@ -154,6 +279,12 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
         _QueryReturn[TProperties, References],
         _QueryReturn[TProperties, CrossReferences],
         _QueryReturn[TProperties, TReferences],
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, CrossReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, CrossReferences],
+        _GroupByReturn[TProperties, TReferences],
     ]:
         """Search for objects by vector in this collection using and vector-based similarity search.
 
@@ -199,15 +330,16 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
             near_vector=near_vector,
             certainty=certainty,
             distance=distance,
-            filters=filters,
             limit=limit,
             autocut=auto_limit,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
             rerank=rerank,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
             return_references=self._parse_return_references(return_references),
         )
-        return self._result_to_query_return(
+        return self._result_to_query_or_groupby_return(
             res,
             _QueryOptions.from_input(
                 return_metadata,
@@ -216,6 +348,7 @@ class _NearVectorQuery(Generic[Properties, References], _BaseQuery[Properties, R
                 self._references,
                 return_references,
                 rerank,
+                group_by,
             ),
             return_properties,
             return_references,
@@ -567,6 +700,10 @@ class _NearVectorGroupBy(Generic[Properties, References], _BaseQuery[Properties,
     ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
+    @deprecated(
+        version="4.4b6",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+    )
     def near_vector(
         self,
         near_vector: List[float],

--- a/weaviate/collections/queries/near_video.py
+++ b/weaviate/collections/queries/near_video.py
@@ -2,10 +2,12 @@ from io import BufferedReader
 from pathlib import Path
 from typing import Generic, List, Literal, Optional, Type, Union, overload
 
+from deprecated import deprecated
+
 from weaviate.collections.classes.filters import (
     _Filters,
 )
-from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, Rerank
+from weaviate.collections.classes.grpc import METADATA, PROPERTIES, REFERENCES, GroupBy, Rerank
 from weaviate.collections.classes.internal import (
     _Generative,
     _GenerativeReturn,
@@ -31,15 +33,16 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Literal[None] = None,
     ) -> _QueryReturn[Properties, References]:
@@ -49,15 +52,16 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: REFERENCES,
     ) -> _QueryReturn[Properties, CrossReferences]:
@@ -67,15 +71,16 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Optional[PROPERTIES] = None,
         return_references: Type[TReferences],
     ) -> _QueryReturn[Properties, TReferences]:
@@ -85,15 +90,16 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Literal[None] = None,
     ) -> _QueryReturn[TProperties, References]:
@@ -103,15 +109,16 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: REFERENCES,
     ) -> _QueryReturn[TProperties, CrossReferences]:
@@ -121,32 +128,150 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: Literal[None] = None,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
-        *,
         return_properties: Type[TProperties],
         return_references: Type[TReferences],
     ) -> _QueryReturn[TProperties, TReferences]:
         ...
 
+    ### GroupBy ###
+
+    @overload
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],
+        *,
         certainty: Optional[float] = None,
         distance: Optional[float] = None,
         limit: Optional[int] = None,
         auto_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
+        group_by: GroupBy,
         rerank: Optional[Rerank] = None,
         include_vector: bool = False,
         return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[Properties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
         *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[Properties, CrossReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Optional[PROPERTIES] = None,
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[Properties, TReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Literal[None] = None,
+    ) -> _GroupByReturn[TProperties, References]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: REFERENCES,
+    ) -> _GroupByReturn[TProperties, CrossReferences]:
+        ...
+
+    @overload
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: GroupBy,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
+        return_properties: Type[TProperties],
+        return_references: Type[TReferences],
+    ) -> _GroupByReturn[TProperties, TReferences]:
+        ...
+
+    def near_video(
+        self,
+        near_video: Union[str, Path, BufferedReader],
+        *,
+        certainty: Optional[float] = None,
+        distance: Optional[float] = None,
+        limit: Optional[int] = None,
+        auto_limit: Optional[int] = None,
+        filters: Optional[_Filters] = None,
+        group_by: Optional[GroupBy] = None,
+        rerank: Optional[Rerank] = None,
+        include_vector: bool = False,
+        return_metadata: Optional[METADATA] = None,
         return_properties: Optional[ReturnProperties[TProperties]] = None,
         return_references: Optional[ReturnReferences[TReferences]] = None,
     ) -> Union[
@@ -156,6 +281,12 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
         _QueryReturn[TProperties, References],
         _QueryReturn[TProperties, CrossReferences],
         _QueryReturn[TProperties, TReferences],
+        _GroupByReturn[Properties, References],
+        _GroupByReturn[Properties, CrossReferences],
+        _GroupByReturn[Properties, TReferences],
+        _GroupByReturn[TProperties, References],
+        _GroupByReturn[TProperties, CrossReferences],
+        _GroupByReturn[TProperties, TReferences],
     ]:
         """Search for objects by video in this collection using an video-capable vectorisation module and vector-based similarity search.
 
@@ -204,15 +335,16 @@ class _NearVideoQuery(Generic[Properties, References], _BaseQuery[Properties, Re
             video=self._parse_media(near_video),
             certainty=certainty,
             distance=distance,
-            filters=filters,
             limit=limit,
             autocut=auto_limit,
+            filters=filters,
+            group_by=_GroupBy.from_input(group_by),
             rerank=rerank,
             return_metadata=self._parse_return_metadata(return_metadata, include_vector),
             return_properties=self._parse_return_properties(return_properties),
             return_references=self._parse_return_references(return_references),
         )
-        return self._result_to_query_return(
+        return self._result_to_query_or_groupby_return(
             res,
             _QueryOptions.from_input(
                 return_metadata,
@@ -575,6 +707,10 @@ class _NearVideoGroupBy(Generic[Properties, References], _BaseQuery[Properties, 
     ) -> _GroupByReturn[TProperties, TReferences]:
         ...
 
+    @deprecated(
+        version="4.4b6",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+    )
     def near_video(
         self,
         near_video: Union[str, Path, BufferedReader],

--- a/weaviate/collections/queries/near_video.py
+++ b/weaviate/collections/queries/near_video.py
@@ -708,8 +708,8 @@ class _NearVideoGroupBy(Generic[Properties, References], _BaseQuery[Properties, 
         ...
 
     @deprecated(
-        version="4.4b6",
-        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in GA.",
+        version="4.4b7",
+        reason="Use `query.near_vector` with the `group_by` argument instead. The `query_group_by` namespace will be removed in the final release.",
     )
     def near_video(
         self,


### PR DESCRIPTION
This PR adds the `group_by` argument to `near_text` queries and aggregations while deprecating all methods in the `query_group_by` and `aggregate_group_by` namespaces

This is done so that the feature complete group-by gRPC functionalities will be fully handled by the client, e.g. generative group by with reranking is currently impossible unless we duplicate namespaces, e.g. `generate_group_by`, which would therefore lead to significant code bloat

A tidyup PR will follow that splits each query into implementation and interface files using stubs, e.g. `query.py` and `query.pyi` within each named query dir: `queries/near_text/**.py` and `queries/near_text/**.pyi`