### PR TITLE
add `nested_properties` to `_Property` dataclass for config output

### DIFF
--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -584,3 +584,27 @@ def test_config_reranker_module(
     assert conf.reranker_config is not None
     assert conf.reranker_config.reranker == expected_reranker
     assert conf.reranker_config.model == expected_model
+
+
+def test_config_nested_properties(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        vectorizer_config=Configure.Vectorizer.none(),
+        properties=[
+            Property(
+                name="name",
+                data_type=DataType.OBJECT,
+                nested_properties=[
+                    Property(name="first", data_type=DataType.TEXT),
+                    Property(name="last", data_type=DataType.TEXT),
+                ],
+            ),
+        ],
+    )
+    conf = collection.config.get()
+    assert conf.properties[0].name == "name"
+    assert conf.properties[0].data_type == DataType.OBJECT
+    assert conf.properties[0].nested_properties is not None
+    assert conf.properties[0].nested_properties[0].name == "first"
+    assert conf.properties[0].nested_properties[0].data_type == DataType.TEXT
+    assert conf.properties[0].nested_properties[1].name == "last"
+    assert conf.properties[0].nested_properties[1].data_type == DataType.TEXT

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1596,6 +1596,17 @@ class _PropertyVectorizerConfig:
 
 
 @dataclass
+class _NestedProperty:
+    data_type: DataType
+    description: Optional[str]
+    index_filterable: bool
+    index_searchable: bool
+    name: str
+    nested_properties: Optional[List["_NestedProperty"]]
+    tokenization: Optional[Tokenization]
+
+
+@dataclass
 class _PropertyBase(_ConfigBase):
     description: Optional[str]
     index_filterable: bool
@@ -1628,6 +1639,7 @@ class _PropertyBase(_ConfigBase):
 @dataclass
 class _Property(_PropertyBase):
     data_type: DataType
+    nested_properties: Optional[List[_NestedProperty]]
 
     def _to_dict(self) -> Dict[str, Any]:
         out = super()._to_dict()

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -283,29 +283,26 @@ def _properties_from_config(schema: Dict[str, Any]) -> List[_Property]:
 
 
 def _references_from_config(schema: Dict[str, Any]) -> List[_ReferenceProperty]:
-    refs: List[_ReferenceProperty] = []
-    for prop in schema["properties"]:
-        if _is_primitive(prop["dataType"]):
-            continue
-        refs.append(
-            _ReferenceProperty(
-                target_collections=prop["dataType"],
-                description=prop.get("description"),
-                index_filterable=prop["indexFilterable"],
-                index_searchable=prop["indexSearchable"],
-                name=prop["name"],
-                tokenization=Tokenization(prop["tokenization"])
-                if prop.get("tokenization") is not None
-                else None,
-                vectorizer_config=_PropertyVectorizerConfig(
-                    skip=prop["moduleConfig"][schema["vectorizer"]]["skip"],
-                    vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]][
-                        "vectorizePropertyName"
-                    ],
-                )
-                if schema["vectorizer"] != "none"
-                else None,
-                vectorizer=schema["vectorizer"],
+    return [
+        _ReferenceProperty(
+            target_collections=prop["dataType"],
+            description=prop.get("description"),
+            index_filterable=prop["indexFilterable"],
+            index_searchable=prop["indexSearchable"],
+            name=prop["name"],
+            tokenization=Tokenization(prop["tokenization"])
+            if prop.get("tokenization") is not None
+            else None,
+            vectorizer_config=_PropertyVectorizerConfig(
+                skip=prop["moduleConfig"][schema["vectorizer"]]["skip"],
+                vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]][
+                    "vectorizePropertyName"
+                ],
             )
+            if schema["vectorizer"] != "none"
+            else None,
+            vectorizer=schema["vectorizer"],
         )
-    return refs
+        for prop in schema["properties"]
+        if not _is_primitive(prop["dataType"])
+    ]

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -254,7 +254,6 @@ def _nested_properties_from_config(props: List[Dict[str, Any]]) -> List[_NestedP
 
 
 def _properties_from_config(schema: Dict[str, Any]) -> List[_Property]:
-    print(schema["properties"])
     return [
         _Property(
             data_type=DataType(prop["dataType"][0]),


### PR DESCRIPTION
This PR adds the `nested_properties` field to the `_Property` dataclass so that users can see the nested properties within their `object` and `object[]` properties when invoking `collection.config.get()`