### PR TITLE
Fix: Wrong reference target path

### DIFF
--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -190,7 +190,7 @@ class _Data:
                 batch.appendleft(
                     _BatchReference(
                         from_=f"{BEACON}{self.name}/{ref.from_uuid}/{ref.from_property}",
-                        to=f"{BEACON}{self.name}/{ref.to_uuid}",
+                        to=f"{BEACON}{ref.to_uuid}",
                         tenant=self._tenant,
                     )
                 )


### PR DESCRIPTION
Hi there, since version 4.4b2 the target path when batch-adding references is incorrectly generated. Instead of targeting the destination collection, it targets the source collection. As a result, the paths are invalid as the UUIDs of the target collection are used to target the source collection. The issue lies in the line I changed, where `self.name` was added to the path (probably by mistake). I tested this fix and the client now works as expected.