### PR TITLE
Make cache and rescoreLimit optional for HNSW BQ

### DIFF
--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -135,8 +135,8 @@ def _collection_config_from_json(schema: Dict[str, Any]) -> _CollectionConfig:
     quantizer: Optional[Union[_PQConfig, _BQConfig]] = None
     if "bq" in schema["vectorIndexConfig"] and schema["vectorIndexConfig"]["bq"]["enabled"]:
         quantizer = _BQConfig(
-            cache=schema["vectorIndexConfig"]["bq"]["cache"],
-            rescore_limit=schema["vectorIndexConfig"]["bq"]["rescoreLimit"],
+            cache=schema["vectorIndexConfig"]["bq"].get("cache", None),
+            rescore_limit=schema["vectorIndexConfig"]["bq"].get("rescoreLimit", None),
         )
     elif "pq" in schema["vectorIndexConfig"] and schema["vectorIndexConfig"]["pq"]["enabled"]:
         quantizer = _PQConfig(


### PR DESCRIPTION
- HNSW BQ doesn't currently expose these fields as cache=false only makes sense for the flat index type and the rescoreLimit is currently just set to ef cc @abdelr
- This PR makes those fields optional when parsing the collection