### PR TITLE
add `collection` field to `_InternalObject`

### DIFF
--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -111,6 +111,7 @@ class _InternalObject(Generic[P, R, M]):
     properties: P
     references: R
     vector: Optional[List[float]]
+    collection: str
 
 
 @dataclass

--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -550,6 +550,7 @@ class _DataCollectionModel(Generic[Model], _Data):
 
         uuid, vector, metadata = _metadata_from_dict(obj)
         model_object = _Object[Model, dict](
+            collection=self.name,
             properties=self.__model.model_validate(
                 {
                     **obj["properties"],

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -312,6 +312,7 @@ class _BaseQuery(Generic[Properties, References]):
         options: _QueryOptions,
     ) -> _Object[Any, Any]:
         return _Object(
+            collection=props.target_collection,
             properties=(
                 self.__parse_nonref_properties_result(props.non_ref_props)
                 if self._is_weaviate_version_123
@@ -340,6 +341,7 @@ class _BaseQuery(Generic[Properties, References]):
         options: _QueryOptions,
     ) -> _GenerativeObject[Any, Any]:
         return _GenerativeObject(
+            collection=props.target_collection,
             properties=(
                 self.__parse_nonref_properties_result(props.non_ref_props)
                 if self._is_weaviate_version_123
@@ -404,6 +406,7 @@ class _BaseQuery(Generic[Properties, References]):
         options: _QueryOptions,
     ) -> _GroupedObject[Any, Any]:
         return _GroupedObject(
+            collection=props.target_collection,
             properties=(
                 self.__parse_nonref_properties_result(props.non_ref_props)
                 if self._is_weaviate_version_123
@@ -518,6 +521,7 @@ class _BaseQuery(Generic[Properties, References]):
         }
         objects_group_by: List[_GroupByObject] = [
             _GroupByObject(
+                collection=obj.collection,
                 properties=obj.properties,
                 references=obj.references,
                 metadata=obj.metadata,
@@ -554,6 +558,7 @@ class _BaseQuery(Generic[Properties, References]):
         }
         objects_group_by: List[_GroupByObject] = [
             _GroupByObject(
+                collection=obj.collection,
                 properties=obj.properties,
                 references=obj.references,
                 metadata=obj.metadata,

--- a/weaviate/collections/queries/fetch_object_by_id/query.py
+++ b/weaviate/collections/queries/fetch_object_by_id/query.py
@@ -119,6 +119,7 @@ class _FetchObjectByIDQuery(Generic[Properties, References], _BaseQuery[Properti
                         is_consistent=obj.metadata.is_consistent,
                     ),
                     references=obj.references,
+                    collection=obj.collection,
                 ),
             )
         else:
@@ -251,6 +252,7 @@ class _FetchObjectByIDQuery(Generic[Properties, References], _BaseQuery[Properti
                 is_consistent=None,
             ),
             references=refs,
+            collection=collection,
         )
 
 


### PR DESCRIPTION
Is `collection` clear enough as a field name? The gRPC message field is `target_collection` but we use that name in relation to references in the client rather than in objects. Perhaps `collection_name` instead?