### PR TITLE
Unify all ref input

### DIFF
--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -156,11 +156,10 @@ def test_add_reference(
             uuid=to_object_uuid,
         )
         batch.add_reference(
-            from_object_uuid=from_object_uuid,
-            from_object_collection=name,
-            from_property_name="test",
-            to_object_uuid=to_object_uuid,
-            to_object_collection=name if to_object_collection else None,
+            from_uuid=from_object_uuid,
+            from_collection=name,
+            from_property="test",
+            to=to_object_uuid,
         )
     objs = (
         client.collections.get(name)
@@ -244,11 +243,10 @@ def test_add_ref_batch_with_tenant(client_factory: ClientFactory, request: SubRe
 
             # add refs between all tenants
             batch.add_reference(
-                from_property_name="test",
-                from_object_collection=name,
-                from_object_uuid=obj_uuid0,
-                to_object_collection=name,
-                to_object_uuid=obj_uuid0,
+                from_property="test",
+                from_collection=name,
+                from_uuid=obj_uuid0,
+                to=obj_uuid0,
                 tenant=tenant,
             )
 
@@ -356,11 +354,10 @@ def test_add_bad_ref(client_factory: ClientFactory) -> None:
         # client.batch.configure(retry_failed_references=True)
         with client.batch as batch:
             batch.add_reference(
-                from_object_uuid=uuid.uuid4(),
-                from_object_collection=name,
-                from_property_name="bad",
-                to_object_uuid=uuid.uuid4(),
-                to_object_collection=name,
+                from_uuid=uuid.uuid4(),
+                from_collection=name,
+                from_property="bad",
+                to=uuid.uuid4(),
             )
         assert len(client.batch.failed_references()) == 1
     #

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -16,7 +16,7 @@ from weaviate.collections.classes.config import (
     ReferenceProperty,
 )
 from weaviate.collections.classes.grpc import FromReference
-from weaviate.collections.classes.internal import _CrossReference
+from weaviate.collections.classes.internal import _CrossReference, Reference
 from weaviate.collections.classes.tenants import Tenant
 from weaviate.types import UUID
 
@@ -246,7 +246,9 @@ def test_add_ref_batch_with_tenant(client_factory: ClientFactory, request: SubRe
                 from_property="test",
                 from_collection=name,
                 from_uuid=obj_uuid0,
-                to=obj_uuid0,
+                to=Reference.to_multi_target(
+                    obj_uuid0, target_collection=name
+                ),  # workaround for autodetection with tenant
                 tenant=tenant,
             )
 
@@ -289,11 +291,10 @@ def make_refs(uuids: List[UUID], name: str) -> List[dict]:
         for to in tos:
             refs.append(
                 {
-                    "from_object_uuid": from_,
-                    "from_object_collection": name,
-                    "from_property_name": "test",
-                    "to_object_uuid": to,
-                    "to_object_collection": name,
+                    "from_uuid": from_,
+                    "from_collection": name,
+                    "from_property": "test",
+                    "to": to,
                 }
             )
     return refs

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -267,7 +267,6 @@ def test_add_ref_batch(client_factory: ClientFactory, to_ref: Callable) -> None:
             objects_class0.append(obj_uuid0)
             batch.add_object(collection=name, uuid=obj_uuid0)
 
-            # add refs between all tenants
             batch.add_reference(
                 from_property="test",
                 from_collection=name,

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -907,7 +907,9 @@ def test_refs_different_references_add(
     assert obj.references["ref"].objects[0].uuid == TO_UUID
 
 
-@pytest.mark.parametrize("to_uuid", [Reference.to(uuids=TO_UUID2), TO_UUID2, str(TO_UUID2)])
+@pytest.mark.parametrize(
+    "to_uuid", [Reference.to(uuids=TO_UUID2), TO_UUID2, str(TO_UUID2), [TO_UUID2], [str(TO_UUID2)]]
+)
 def test_refs_different_reference_replace(
     collection_factory: CollectionFactory, to_uuid: WeaviateReference
 ) -> None:

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -729,9 +729,7 @@ def test_ref_case_sensitivity(collection_factory: CollectionFactory) -> None:
     to.data.insert(uuid=uuid_upper_str, properties={})
 
     # adding a ref as lower-case UUID should work
-    from1 = source.data.insert(
-        properties={}, references={"ref": Reference.to(uuids=uuid_upper_str.lower())}
-    )
+    from1 = source.data.insert(properties={}, references={"ref": uuid_upper_str.lower()})
 
     # try to add as upper-case UUID via different methods
     from2 = source.data.insert(
@@ -767,9 +765,7 @@ def test_empty_return_reference(collection_factory: CollectionFactory) -> None:
         ],
         vectorizer_config=Configure.Vectorizer.none(),
     )
-    if not source._connection._weaviate_version.is_at_least(
-        1, 23, 2
-    ):  # TODO: change this to 1.23.3 when it is released
+    if not source._connection._weaviate_version.is_at_least(1, 23, 3):
         pytest.skip("references return empty object only supported in 1.23.3+")
     uuid_source = source.data.insert(properties={})
     obj = source.query.fetch_object_by_id(
@@ -777,8 +773,6 @@ def test_empty_return_reference(collection_factory: CollectionFactory) -> None:
     )
     assert (
         obj.references == {}
-        if source._connection._weaviate_version.is_at_least(
-            1, 23, 2
-        )  # TODO: change to 1.23.3 when released
+        if source._connection._weaviate_version.is_at_least(1, 23, 3)
         else obj.references is None
     )

--- a/integration/test_collection_references.py
+++ b/integration/test_collection_references.py
@@ -879,8 +879,8 @@ def test_refs_different_reference_add(
     assert obj.references["ref"].objects[0].uuid == TO_UUID
 
 
-@pytest.mark.parametrize("to_uuid", [TO_UUID, str(TO_UUID)])
-def test_refs_different_references_add(
+@pytest.mark.parametrize("to_uuid", [TO_UUID, str(TO_UUID), [TO_UUID], [str(TO_UUID)]])
+def test_refs_different_reference_add_many(
     collection_factory: CollectionFactory, to_uuid: UUID
 ) -> None:
     to = collection_factory(name="To", vectorizer_config=Configure.Vectorizer.none())

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -6,6 +6,7 @@ from abc import ABC
 from copy import copy
 from dataclasses import dataclass, field
 from typing import Any, Dict, Generic, List, Optional, Sequence, Set, TypeVar, Union
+import uuid as uuid_package
 
 from pydantic import ValidationError
 from requests import ReadTimeout
@@ -425,9 +426,11 @@ class _BatchBase:
         tenant: Optional[str] = None,
     ) -> None:
         if isinstance(to, _Reference):
-            to_strs = to.uuids_str
-        elif isinstance(to, str):
+            to_strs: Union[List[str], List[UUID]] = to.uuids_str
+        elif isinstance(to, str) or isinstance(to, uuid_package.UUID):
             to_strs = [to]
+        else:
+            to_strs = to
 
         for uid in to_strs:
             try:

--- a/weaviate/collections/batch/client.py
+++ b/weaviate/collections/batch/client.py
@@ -67,14 +67,13 @@ class _BatchClient(_BatchBase):
         Arguments:
             `from_uuid`
                 The UUID of the object, as an uuid.UUID object or str, that should reference another object.
-                It can be a Weaviate beacon or Weaviate href.
-            `from_object_collection`
+            `from_collection`
                 The name of the collection that should reference another object.
-            `from_property_name`
+            `from_property`
                 The name of the property that contains the reference.
             `to`
-                The UUID of the object, as an uuid.UUID object or str, that is actually referenced.
-                It can be a Weaviate beacon or Weaviate href.
+                The UUID of the referenced object, as an uuid.UUID object or str, that is actually referenced.
+                For multi-target references use wvc.Reference.to_multi_targer().
             `tenant`
                 Name of the tenant.
 

--- a/weaviate/collections/batch/client.py
+++ b/weaviate/collections/batch/client.py
@@ -1,8 +1,9 @@
-from typing import Optional, Sequence, Union
+from typing import List, Optional, Sequence, Union
 
 from weaviate.collections.batch.base import _BatchBase
 from weaviate.collections.batch.batch_wrapper import _BatchWrapper
 from weaviate.collections.classes.config import ConsistencyLevel
+from weaviate.collections.classes.internal import WeaviateReference
 from weaviate.collections.classes.tenants import Tenant
 from weaviate.collections.classes.types import WeaviateProperties
 from weaviate.types import UUID
@@ -55,28 +56,25 @@ class _BatchClient(_BatchBase):
 
     def add_reference(
         self,
-        from_object_uuid: UUID,
-        from_object_collection: str,
-        from_property_name: str,
-        to_object_uuid: UUID,
-        to_object_collection: Optional[str] = None,
+        from_uuid: UUID,
+        from_collection: str,
+        from_property: str,
+        to: Union[WeaviateReference, List[UUID]],
         tenant: Optional[str] = None,
     ) -> None:
         """Add one reference to this batch.
 
         Arguments:
-            `from_object_uuid`
+            `from_uuid`
                 The UUID of the object, as an uuid.UUID object or str, that should reference another object.
                 It can be a Weaviate beacon or Weaviate href.
             `from_object_collection`
                 The name of the collection that should reference another object.
             `from_property_name`
                 The name of the property that contains the reference.
-            `to_object_uuid`
+            `to`
                 The UUID of the object, as an uuid.UUID object or str, that is actually referenced.
                 It can be a Weaviate beacon or Weaviate href.
-            `to_object_collection`
-                The referenced object collection to which to add the reference (with UUID `to_object_uuid`).
             `tenant`
                 Name of the tenant.
 
@@ -85,11 +83,10 @@ class _BatchClient(_BatchBase):
                 If the provided options are in the format required by Weaviate.
         """
         super()._add_reference(
-            from_object_uuid=from_object_uuid,
-            from_object_collection=from_object_collection,
-            from_property_name=from_property_name,
-            to_object_uuid=to_object_uuid,
-            to_object_collection=to_object_collection,
+            from_object_uuid=from_uuid,
+            from_object_collection=from_collection,
+            from_property_name=from_property,
+            to=to,
             tenant=tenant,
         )
 

--- a/weaviate/collections/batch/collection.py
+++ b/weaviate/collections/batch/collection.py
@@ -1,4 +1,4 @@
-from typing import Generic, Optional, Sequence
+from typing import Generic, List, Optional, Sequence, Union
 
 from weaviate.collections.batch.base import _BatchBase, _BatchDataWrapper
 from weaviate.collections.batch.batch_wrapper import _BatchWrapper
@@ -65,7 +65,9 @@ class _BatchCollection(Generic[Properties], _BatchBase):
             tenant=self.__tenant,
         )
 
-    def add_reference(self, from_uuid: UUID, from_property: str, to: WeaviateReference) -> None:
+    def add_reference(
+        self, from_uuid: UUID, from_property: str, to: Union[WeaviateReference, List[UUID]]
+    ) -> None:
         """Add a reference to this batch.
 
         Arguments:
@@ -81,15 +83,13 @@ class _BatchCollection(Generic[Properties], _BatchBase):
             `WeaviateBatchValidationError`
                 If the provided options are in the format required by Weaviate.
         """
-        for uuid in to.uuids_str:
-            self._add_reference(
-                from_uuid,
-                self.__name,
-                from_property,
-                uuid,
-                to.target_collection if to.is_multi_target else None,
-                self.__tenant,
-            )
+        self._add_reference(
+            from_uuid,
+            self.__name,
+            from_property,
+            to,
+            self.__tenant,
+        )
 
 
 class _BatchCollectionWrapper(Generic[Properties], _BatchWrapper):

--- a/weaviate/collections/batch/collection.py
+++ b/weaviate/collections/batch/collection.py
@@ -73,11 +73,11 @@ class _BatchCollection(Generic[Properties], _BatchBase):
         Arguments:
             `from_uuid`
                 The UUID of the object, as an uuid.UUID object or str, that should reference another object.
-                It can be a Weaviate beacon or Weaviate href.
             `from_property`
                 The name of the property that contains the reference.
             `to`
-                The reference to add, REQUIRED. Use `wvc.Reference.to` to create the correct value.
+                The UUID of the referenced object, as an uuid.UUID object or str, that is actually referenced.
+                For multi-target references use wvc.Reference.to_multi_targer().
 
         Raises:
             `WeaviateBatchValidationError`

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -14,13 +14,14 @@ from weaviate.collections.classes.batch import (
 )
 from weaviate.collections.classes.config import ConsistencyLevel
 from weaviate.collections.classes.types import GeoCoordinate, PhoneNumber
-from weaviate.collections.classes.internal import _Reference
+from weaviate.collections.classes.internal import _Reference, WeaviateReferences
 from weaviate.collections.grpc.shared import _BaseGRPC
 from weaviate.connect import ConnectionV4
 from weaviate.exceptions import (
     WeaviateGRPCBatchError,
     WeaviateInsertInvalidPropertyError,
     WeaviateInsertManyAllFailedError,
+    WeaviateInvalidInputError,
 )
 from weaviate.proto.v1 import batch_pb2, base_pb2
 from weaviate.util import _datetime_to_string, get_vector
@@ -66,7 +67,8 @@ class _BatchGRPC(_BaseGRPC):
                 else None,
                 uuid=str(obj.uuid) if obj.uuid is not None else str(uuid_package.uuid4()),
                 properties=self.__translate_properties_from_python_to_grpc(
-                    {**obj.properties, **(obj.references if obj.references is not None else {})},
+                    obj.properties,
+                    obj.references if obj.references is not None else {},
                     False,
                 )
                 if obj.properties is not None
@@ -160,7 +162,8 @@ class _BatchGRPC(_BaseGRPC):
                 else None,
                 uuid=str(obj.uuid) if obj.uuid is not None else str(uuid_package.uuid4()),
                 properties=self.__translate_properties_from_python_to_grpc(
-                    {**obj.properties, **(obj.references if obj.references is not None else {})},
+                    obj.properties,
+                    obj.references if obj.references is not None else {},
                     False,
                 )
                 if obj.properties is not None
@@ -227,9 +230,9 @@ class _BatchGRPC(_BaseGRPC):
             raise WeaviateGRPCBatchError(e.details())
 
     def __translate_properties_from_python_to_grpc(
-        self, data: Dict[str, Any], clean_props: bool
+        self, data: Dict[str, Any], refs: WeaviateReferences, clean_props: bool
     ) -> batch_pb2.BatchObject.Properties:
-        if data is None:
+        if data is None and refs is None:
             return None
 
         _validate_props(data, clean_props)
@@ -243,6 +246,36 @@ class _BatchGRPC(_BaseGRPC):
         float_arrays: List[base_pb2.NumberArrayProperties] = []
         object_properties: List[base_pb2.ObjectProperties] = []
         object_array_properties: List[base_pb2.ObjectArrayProperties] = []
+
+        for key, val in refs.items():
+            if isinstance(val, _Reference):
+                if val.is_multi_target:
+                    multi_target.append(
+                        batch_pb2.BatchObject.MultiTargetRefProps(
+                            uuids=val.uuids_str,
+                            target_collection=val.target_collection,
+                            prop_name=key,
+                        )
+                    )
+                else:
+                    single_target.append(
+                        batch_pb2.BatchObject.SingleTargetRefProps(
+                            uuids=val.uuids_str, prop_name=key
+                        )
+                    )
+            elif isinstance(val, str):
+                single_target.append(
+                    batch_pb2.BatchObject.SingleTargetRefProps(uuids=[val], prop_name=key)
+                )
+            elif isinstance(val, uuid_package.UUID):
+                single_target.append(
+                    batch_pb2.BatchObject.SingleTargetRefProps(
+                        uuids=[str(object=val)], prop_name=key
+                    )
+                )
+            else:
+                raise WeaviateInvalidInputError(f"Invalid reference: {val}")
+
         for key, val in data.items():
             if isinstance(val, _Reference):
                 if val.is_multi_target:
@@ -260,7 +293,7 @@ class _BatchGRPC(_BaseGRPC):
                         )
                     )
             elif isinstance(val, dict):
-                parsed = self.__translate_properties_from_python_to_grpc(val, clean_props)
+                parsed = self.__translate_properties_from_python_to_grpc(val, {}, clean_props)
                 object_properties.append(
                     base_pb2.ObjectProperties(
                         prop_name=key,

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -328,7 +328,7 @@ class _BatchGRPC(_BaseGRPC):
                             for v in val
                             if (
                                 parsed := self.__translate_properties_from_python_to_grpc(
-                                    v, clean_props
+                                    v, {}, clean_props
                                 )
                             )
                         ],

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -27,7 +27,7 @@ from weaviate.collections.classes.grpc import (
 from weaviate.collections.classes.types import Properties, M, P, R, TProperties, WeaviateProperties
 from weaviate.exceptions import WeaviateGRPCQueryError, InvalidDataModelException
 from weaviate.util import _to_beacons
-from weaviate.types import UUIDS
+from weaviate.types import UUID, UUIDS
 
 from weaviate.proto.v1 import search_get_pb2
 
@@ -436,7 +436,7 @@ class Reference:
         )
 
 
-WeaviateReference: TypeAlias = _Reference
+WeaviateReference: TypeAlias = Union[_Reference, UUID]
 WeaviateReferences: TypeAlias = Mapping[str, WeaviateReference]
 
 

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -401,7 +401,7 @@ class Reference:
     def to(
         cls,
         uuids: UUIDS,
-    ) -> "WeaviateReference":
+    ) -> _Reference:
         """Define cross references to other objects by their UUIDs.
 
         Can be made to be generic by supplying a type to the `data_model` argument.
@@ -417,7 +417,7 @@ class Reference:
         cls,
         uuids: UUIDS,
         target_collection: Union[str, _CollectionBase],
-    ) -> "WeaviateReference":
+    ) -> _Reference:
         """Define cross references to other objects by their UUIDs and the collection in which they are stored.
 
         Can be made to be generic by supplying a type to the `data_model` argument.

--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -59,7 +59,7 @@ from weaviate.util import (
     _decode_json_response_dict,
     get_vector,
 )
-from weaviate.types import BEACON, UUID
+from weaviate.types import BEACON, UUID, UUIDS
 
 
 class _Data:
@@ -554,7 +554,7 @@ class _DataCollection(Generic[Properties], _Data):
         )
 
     def reference_replace(
-        self, from_uuid: UUID, from_property: str, to: Union[UUID, WeaviateReference]
+        self, from_uuid: UUID, from_property: str, to: Union[WeaviateReference, UUIDS]
     ) -> None:
         """Replace a reference of an object within the collection.
 
@@ -570,6 +570,7 @@ class _DataCollection(Generic[Properties], _Data):
             not isinstance(to, str)
             and not isinstance(to, uuid_package.UUID)
             and not isinstance(to, _Reference)
+            and not isinstance(to, list)
         ):
             _raise_invalid_input("to", to, Union[UUID, _Reference])
         self._reference_replace(


### PR DESCRIPTION
- unify reference_add parameter names for collection-batch and client-batch. To can be either Reference.to(_multi) or UUID/List[UUID]
```
collection_batch.add_reference(from_property=.., from_uuid=..,to=..)
client_batch.add_reference(from_property=.., from_uuid=..,to=..,from_collection=..,tenant=...)
```
removed to-collection as it can be either auto-detected or be supplied via multi-target

- reference_add accepts to=UUID, str and Reference.to
- reference_replace accepts to=UUID, str, List[str], List[UUID] and Reference.to
- reference_add_many accepts UUID, str, List[str], List[UUID] as to in [DataReference(to=)]

- insert accepts reference.to(), str, UUID
- insert_many accepts reference.to(), str, UUID as part of DataObject