### PR TITLE
stop passing empty config in backup

### DIFF
--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -101,7 +101,6 @@ class Backup:
 
         payload = {
             "id": backup_id,
-            "config": {},
             "include": include_classes,
             "exclude": exclude_classes,
         }


### PR DESCRIPTION
This PR fixes a recent bug with default behaviour as Weaviate now expects the backup config in a specific format of which an empty dictionary is not handled appropriately. Thus, sending `"config": {}` causes a Weaviate-side panic. Until this is fixed, and since we are not using the `"config"` field anyway, it should be removed