### PR TITLE
Refactor auth and init

### DIFF
--- a/weaviate/auth.py
+++ b/weaviate/auth.py
@@ -121,10 +121,10 @@ ClientPassword = _ClientPassword
 """@deprecated; use wvc.Auth.client_password() instead."""
 
 AuthApiKey = _APIKey
-"""@deprecated; use APIKey instead."""
+"""@deprecated; use wvc.Auth.api_key() instead."""
 AuthBearerToken = _BearerToken
-"""@deprecated; use BearerToken instead."""
+"""@deprecated; use wvc.Auth.api_key() instead."""
 AuthClientCredentials = _ClientCredentials
-"""@deprecated; use ClientCredentials instead."""
+"""@deprecated; use wvc.Auth.api_key() instead."""
 AuthClientPassword = _ClientPassword
-"""@deprecated; use ClientPassword instead."""
+"""@deprecated; use wvc.Auth.api_key() instead."""

--- a/weaviate/auth.py
+++ b/weaviate/auth.py
@@ -10,7 +10,7 @@ SCOPES = Union[str, List[str]]
 
 
 @dataclass
-class ClientCredentials:
+class _ClientCredentials:
     """Authenticate for the Client Credential flow using client secrets.
 
     Acquire the client secret from your identify provider and set the appropriate scope. The client includes hardcoded
@@ -33,7 +33,7 @@ class ClientCredentials:
 
 
 @dataclass
-class ClientPassword:
+class _ClientPassword:
     """Using username and password for authentication with Resource Owner Password flow.
 
     For some providers the scope needs to contain "offline_access" (and "openid" which is automatically added) to return
@@ -58,7 +58,7 @@ class ClientPassword:
 
 
 @dataclass
-class BearerToken:
+class _BearerToken:
     """Using a preexisting bearer/access token for authentication.
 
     The expiration time of access tokens is given in seconds.
@@ -77,20 +77,54 @@ class BearerToken:
 
 
 @dataclass
-class APIKey:
+class _APIKey:
     """Using the given API key to authenticate with weaviate."""
 
     api_key: str
 
 
-OidcAuth = Union[BearerToken, ClientPassword, ClientCredentials]
-AuthCredentials = Union[OidcAuth, APIKey]
+class Auth:
+    @staticmethod
+    def api_key(api_key: str) -> _APIKey:
+        return _APIKey(api_key)
 
-AuthApiKey = APIKey
+    @staticmethod
+    def client_credentials(
+        client_secret: str, scope: Optional[SCOPES] = None
+    ) -> _ClientCredentials:
+        return _ClientCredentials(client_secret, scope)
+
+    @staticmethod
+    def client_password(
+        username: str, password: str, scope: Optional[SCOPES] = None
+    ) -> _ClientPassword:
+        return _ClientPassword(username=username, password=password, scope=scope)
+
+    @staticmethod
+    def bearer_token(
+        bearer_token: str, expires_in: int = 60, refresh_token: Optional[str] = None
+    ) -> _BearerToken:
+        return _BearerToken(bearer_token)
+
+
+OidcAuth = Union[_BearerToken, _ClientPassword, _ClientCredentials]
+AuthCredentials = Union[OidcAuth, _APIKey]
+
+
+APIKey = _APIKey
+"""@deprecated; use wvc.Auth.api_key() instead."""
+BearerToken = _BearerToken
+"""@deprecated; use wvc.Auth.bearer_token() instead."""
+ClientCredentials = _ClientCredentials
+"""@deprecated; use wvc.Auth.client_credentials() instead."""
+ClientPassword = _ClientPassword
+"""@deprecated; use wvc.Auth.client_password() instead."""
+
+AuthApiKey = _APIKey
 """@deprecated; use APIKey instead."""
-AuthBearerToken = BearerToken
+AuthBearerToken = _BearerToken
 """@deprecated; use BearerToken instead."""
-AuthClientCredentials = ClientCredentials
+AuthClientCredentials = _ClientCredentials
 """@deprecated; use ClientCredentials instead."""
-AuthClientPassword = ClientPassword
+AuthClientPassword = _ClientPassword
 """@deprecated; use ClientPassword instead."""

--- a/weaviate/classes/__init__.py
+++ b/weaviate/classes/__init__.py
@@ -1,5 +1,5 @@
 from weaviate.collections.classes.aggregate import Metrics
-from weaviate.collections.classes.tenants import Tenant
+from .tenants import Tenant
 
 from .config import (
     Configure,
@@ -31,6 +31,9 @@ from .query import (
     QueryNested,
     QueryReference,
 )
+
+# make sure to import all classes that should be available in the weaviate module
+from . import batch, config, data, generics, init, query, tenants  # noqa: F401
 
 __all__ = [
     "Configure",

--- a/weaviate/classes/init.py
+++ b/weaviate/classes/init.py
@@ -1,0 +1,4 @@
+from weaviate.auth import Auth
+from weaviate.config import AdditionalConfig
+
+__all__ = ["Auth", "AdditionalConfig"]

--- a/weaviate/config.py
+++ b/weaviate/config.py
@@ -25,6 +25,7 @@ class ConnectionConfig:
             )
 
 
+# used in v3 only
 @dataclass
 class Config:
     grpc_port_experimental: Optional[int] = None

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for creating a new WeaviateClient in common scenarios."""
 from urllib.parse import urlparse
-from typing import Optional, Tuple, Dict
+from typing import Optional, Dict
 
 from weaviate.auth import AuthCredentials
 from weaviate.client import WeaviateClient
@@ -13,7 +13,7 @@ def connect_to_wcs(
     cluster_url: str,
     auth_credentials: Optional[AuthCredentials],
     headers: Optional[Dict[str, str]] = None,
-    timeout: Tuple[int, int] = (10, 60),
+    additional_config: Optional[AdditionalConfig] = None,
     skip_init_checks: bool = False,
 ) -> WeaviateClient:
     """
@@ -32,9 +32,8 @@ def connect_to_wcs(
             or a username and password, in which case use `weaviate.AuthClientPassword`.
         `headers`
             Additional headers to include in the requests, e.g. API keys for third-party Cloud vectorisation.
-        `timeout`
-            The timeout to use for the underlying HTTP calls. Accepts a tuple of integers, where the first integer
-            represents the connect timeout and the second integer represents the read timeout.
+        `additional_config`
+            This includes many additional, rarely used config options. use wvc.init.AdditionalConfig() to configure.
         `skip_init_checks`
             Whether to skip the initialisation checks when connecting to Weaviate.
 
@@ -73,7 +72,7 @@ def connect_to_wcs(
         ),
         auth_client_secret=auth_credentials,
         additional_headers=headers,
-        additional_config=AdditionalConfig(timeout=timeout),
+        additional_config=additional_config,
         skip_init_checks=skip_init_checks,
     )
     client.connect()
@@ -85,7 +84,7 @@ def connect_to_local(
     port: int = 8080,
     grpc_port: int = 50051,
     headers: Optional[Dict[str, str]] = None,
-    timeout: Tuple[int, int] = (10, 60),
+    additional_config: Optional[AdditionalConfig] = None,
     skip_init_checks: bool = False,
     auth_credentials: Optional[AuthCredentials] = None,
 ) -> WeaviateClient:
@@ -148,7 +147,7 @@ def connect_to_local(
             grpc=ProtocolParams(host=host, port=grpc_port, secure=False),
         ),
         additional_headers=headers,
-        additional_config=AdditionalConfig(timeout=timeout),
+        additional_config=additional_config,
         skip_init_checks=skip_init_checks,
         auth_client_secret=auth_credentials,
     )
@@ -158,9 +157,9 @@ def connect_to_local(
 
 def connect_to_embedded(
     port: int = 8079,
-    grpc_port: int = 50051,
+    grpc_port: int = 50050,
     headers: Optional[Dict[str, str]] = None,
-    timeout: Tuple[int, int] = (10, 60),
+    additional_config: Optional[AdditionalConfig] = None,
     version: str = "1.22.3",
 ) -> WeaviateClient:
     """
@@ -177,9 +176,8 @@ def connect_to_embedded(
             The port to use for the underlying gRPC API.
         `headers`
             Additional headers to include in the requests, e.g. API keys for Cloud vectorisation.
-        `timeout`
-            The timeout to use for the underlying HTTP calls. Accepts a tuple of integers, where the first integer
-            represents the connect timeout and the second integer represents the read timeout.
+        `additional_config`
+            This includes many additional, rarely used config options. use wvc.init.AdditionalConfig() to configure.
 
     Returns
         `weaviate.WeaviateClient`
@@ -211,7 +209,7 @@ def connect_to_embedded(
             version=version,
         ),
         additional_headers=headers,
-        additional_config=AdditionalConfig(timeout=timeout),
+        additional_config=additional_config,
     )
     client.connect()
     return client
@@ -225,7 +223,7 @@ def connect_to_custom(
     grpc_port: int,
     grpc_secure: bool,
     headers: Optional[Dict[str, str]] = None,
-    timeout: Tuple[int, int] = (10, 60),
+    additional_config: Optional[AdditionalConfig] = None,
     auth_credentials: Optional[AuthCredentials] = None,
     skip_init_checks: bool = False,
 ) -> WeaviateClient:
@@ -305,7 +303,7 @@ def connect_to_custom(
         ),
         auth_client_secret=auth_credentials,
         additional_headers=headers,
-        additional_config=AdditionalConfig(timeout=timeout),
+        additional_config=additional_config,
         skip_init_checks=skip_init_checks,
     )
     client.connect()


### PR DESCRIPTION
- Adds a factory for auth, now you can do
```
client = weaviate.connect_to_xx(..., auth=wvc.init.Auth.api_key("cy4ua772mBlMdfw3YnclqAWzFhQt0RLIN0sl"))
```
- Adds `additional_config` directly to `connect_to_xx` methods replacing timeout
- Make sure all files in classes/ are imported