### PR TITLE
enforce that all optional args must be supplied as kw args

### DIFF
--- a/weaviate/collections/collections.py
+++ b/weaviate/collections/collections.py
@@ -28,6 +28,7 @@ class _Collections(_CollectionsBase):
     def create(
         self,
         name: str,
+        *,
         description: Optional[str] = None,
         generative_config: Optional[_GenerativeConfigCreate] = None,
         inverted_index_config: Optional[_InvertedIndexConfigCreate] = None,

--- a/weaviate/collections/config.py
+++ b/weaviate/collections/config.py
@@ -83,6 +83,7 @@ class _ConfigBase:
 
     def update(
         self,
+        *,
         description: Optional[str] = None,
         inverted_index_config: Optional[_InvertedIndexConfigUpdate] = None,
         replication_config: Optional[_ReplicationConfigUpdate] = None,


### PR DESCRIPTION
This PR enforces that `client.collections.create` and `collection.config.update` must have their optional parameters called in the keyword format so that any future changes to this API cannot be breaking due to the parameter order