### PR TITLE
Improve aggregate API surface

### DIFF
--- a/integration/test_collection_aggregate.py
+++ b/integration/test_collection_aggregate.py
@@ -10,6 +10,7 @@ from weaviate.collections.classes.aggregate import (
     AggregateInteger,
     AggregateNumber,
     AggregateText,
+    AggregateReturn,
     Metrics,
 )
 from weaviate.collections.classes.config import DataType, Property, ReferenceProperty, Configure
@@ -76,7 +77,7 @@ def test_near_object_aggregation(
     text_2 = "nothing like the other one at all, not even a little bit"
     uuid = collection.data.insert({"text": text_1})
     collection.data.insert({"text": text_2})
-    res = collection.aggregate.near_object(
+    res: AggregateReturn = collection.aggregate.near_object(
         uuid,
         return_metrics=[
             Metrics("text").text(count=True, top_occurrences_count=True, top_occurrences_value=True)
@@ -151,7 +152,7 @@ def test_near_vector_aggregation(
     obj = collection.query.fetch_object_by_id(uuid, include_vector=True)
     assert obj.vector is not None
     collection.data.insert({"text": text_2})
-    res = collection.aggregate.near_vector(
+    res: AggregateReturn = collection.aggregate.near_vector(
         obj.vector,
         return_metrics=[
             Metrics("text").text(count=True, top_occurrences_count=True, top_occurrences_value=True)
@@ -223,7 +224,7 @@ def test_near_text_aggregation(
     text_2 = "nothing like the other one at all, not even a little bit"
     collection.data.insert({"text": text_1})
     collection.data.insert({"text": text_2})
-    res = collection.aggregate.near_text(
+    res: AggregateReturn = collection.aggregate.near_text(
         text_1,
         return_metrics=[
             Metrics("text").text(count=True, top_occurrences_count=True, top_occurrences_value=True)
@@ -281,7 +282,7 @@ def test_near_image_aggregation(collection_factory: CollectionFactory, option: d
     )
     img_path = pathlib.Path("integration/weaviate-logo.png")
     collection.data.insert({"image": file_encoder_b64(img_path), "rating": 9})
-    res = collection.aggregate.near_image(
+    res: AggregateReturn = collection.aggregate.near_image(
         img_path,
         return_metrics=[Metrics("rating").integer(count=True, maximum=True)],
         **option,

--- a/weaviate/classes/aggregate.py
+++ b/weaviate/classes/aggregate.py
@@ -1,0 +1,3 @@
+from weaviate.collections.classes.aggregate import Metrics
+
+__all__ = ["Metrics"]

--- a/weaviate/collections/aggregations/near_image.py
+++ b/weaviate/collections/aggregations/near_image.py
@@ -5,9 +5,9 @@ from typing import List, Literal, Optional, Union, overload
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
-    _AggregateReturn,
-    _AggregateGroupByReturn,
-    _AggregateGroup,
+    AggregateReturn,
+    AggregateGroupByReturn,
+    AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 from weaviate.warnings import _Warnings
@@ -27,7 +27,7 @@ class _NearImage(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateReturn:
+    ) -> AggregateReturn:
         ...
 
     @overload
@@ -43,7 +43,7 @@ class _NearImage(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateGroupByReturn:
+    ) -> AggregateGroupByReturn:
         ...
 
     def near_image(
@@ -58,7 +58,7 @@ class _NearImage(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
+    ) -> Union[AggregateReturn, AggregateGroupByReturn]:
         """Aggregate metrics over the objects returned by a near image vector search on this collection.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -86,7 +86,7 @@ class _NearImage(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `AggregateReturn` object or a `AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:
@@ -123,7 +123,7 @@ class _NearImageGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroup]:
+    ) -> List[AggregateGroup]:
         """Aggregate metrics over the objects returned by a near image vector search on this collection grouping the results by a property.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -151,7 +151,7 @@ class _NearImageGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A list of `_AggregateGroup` objects that includes the aggregation objects.
+            A list of `AggregateGroup` objects that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:

--- a/weaviate/collections/aggregations/near_object.py
+++ b/weaviate/collections/aggregations/near_object.py
@@ -3,9 +3,9 @@ from typing import List, Literal, Optional, Union, overload
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
-    _AggregateReturn,
-    _AggregateGroupByReturn,
-    _AggregateGroup,
+    AggregateReturn,
+    AggregateGroupByReturn,
+    AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 from weaviate.types import UUID
@@ -26,7 +26,7 @@ class _NearObject(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateReturn:
+    ) -> AggregateReturn:
         ...
 
     @overload
@@ -42,7 +42,7 @@ class _NearObject(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateGroupByReturn:
+    ) -> AggregateGroupByReturn:
         ...
 
     def near_object(
@@ -57,7 +57,7 @@ class _NearObject(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
+    ) -> Union[AggregateReturn, AggregateGroupByReturn]:
         """Aggregate metrics over the objects returned by a near object search on this collection.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -85,7 +85,7 @@ class _NearObject(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `AggregateReturn` object or a `AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:
@@ -122,7 +122,7 @@ class _NearObjectGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroup]:
+    ) -> List[AggregateGroup]:
         """Aggregate metrics over the objects returned by a near object vector search on this collection grouping the results by a property.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -150,7 +150,7 @@ class _NearObjectGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A list of `_AggregateGroup` objects that includes the aggregation objects.
+            A list of `AggregateGroup` objects that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:

--- a/weaviate/collections/aggregations/near_text.py
+++ b/weaviate/collections/aggregations/near_text.py
@@ -3,9 +3,9 @@ from typing import List, Literal, Optional, Union, overload
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
-    _AggregateReturn,
-    _AggregateGroupByReturn,
-    _AggregateGroup,
+    AggregateReturn,
+    AggregateGroupByReturn,
+    AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 from weaviate.collections.classes.grpc import Move
@@ -28,7 +28,7 @@ class _NearText(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateReturn:
+    ) -> AggregateReturn:
         ...
 
     @overload
@@ -46,7 +46,7 @@ class _NearText(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateGroupByReturn:
+    ) -> AggregateGroupByReturn:
         ...
 
     def near_text(
@@ -63,7 +63,7 @@ class _NearText(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
+    ) -> Union[AggregateReturn, AggregateGroupByReturn]:
         """Aggregate metrics over the objects returned by a near text vector search on this collection.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -95,7 +95,7 @@ class _NearText(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `AggregateReturn` object or a `AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:
@@ -135,7 +135,7 @@ class _NearTextGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroup]:
+    ) -> List[AggregateGroup]:
         """Aggregate metrics over the objects returned by a near text search on this collection grouping the results by a property.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -167,7 +167,7 @@ class _NearTextGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A list of `_AggregateGroup` objects that includes the aggregation objects.
+            A list of `AggregateGroup` objects that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:

--- a/weaviate/collections/aggregations/near_vector.py
+++ b/weaviate/collections/aggregations/near_vector.py
@@ -3,9 +3,9 @@ from typing import List, Literal, Optional, Union, overload
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
-    _AggregateReturn,
-    _AggregateGroupByReturn,
-    _AggregateGroup,
+    AggregateReturn,
+    AggregateGroupByReturn,
+    AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 from weaviate.warnings import _Warnings
@@ -25,7 +25,7 @@ class _NearVector(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateReturn:
+    ) -> AggregateReturn:
         ...
 
     @overload
@@ -41,7 +41,7 @@ class _NearVector(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateGroupByReturn:
+    ) -> AggregateGroupByReturn:
         ...
 
     def near_vector(
@@ -56,7 +56,7 @@ class _NearVector(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
+    ) -> Union[AggregateReturn, AggregateGroupByReturn]:
         """Aggregate metrics over the objects returned by a near vector search on this collection.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -84,7 +84,7 @@ class _NearVector(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `AggregateReturn` object or a `AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:
@@ -120,7 +120,7 @@ class _NearVectorGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroup]:
+    ) -> List[AggregateGroup]:
         """Aggregate metrics over the objects returned by a near vector search on this collection and grouping the results grouping the results by a property.
 
         At least one of `certainty`, `distance`, or `object_limit` must be specified here for the vector search.
@@ -148,7 +148,7 @@ class _NearVectorGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A list of `_AggregateGroup` object that includes the aggregation objects.
+            A list of `AggregateGroup` object that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:

--- a/weaviate/collections/aggregations/over_all.py
+++ b/weaviate/collections/aggregations/over_all.py
@@ -3,9 +3,9 @@ from typing import List, Literal, Optional, Union, overload
 from weaviate.collections.aggregations.base import _Aggregate
 from weaviate.collections.classes.aggregate import (
     PropertiesMetrics,
-    _AggregateReturn,
-    _AggregateGroupByReturn,
-    _AggregateGroup,
+    AggregateReturn,
+    AggregateGroupByReturn,
+    AggregateGroup,
 )
 from weaviate.collections.classes.filters import _Filters
 from weaviate.warnings import _Warnings
@@ -21,7 +21,7 @@ class _OverAll(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateReturn:
+    ) -> AggregateReturn:
         ...
 
     @overload
@@ -33,7 +33,7 @@ class _OverAll(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> _AggregateGroupByReturn:
+    ) -> AggregateGroupByReturn:
         ...
 
     def over_all(
@@ -44,7 +44,7 @@ class _OverAll(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> Union[_AggregateReturn, _AggregateGroupByReturn]:
+    ) -> Union[AggregateReturn, AggregateGroupByReturn]:
         """Aggregate metrics over all the objects in this collection without any vector search.
 
         Arguments:
@@ -60,7 +60,7 @@ class _OverAll(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            Depending on the presence of the `group_by` argument, either a `_AggregateReturn` object or a `_AggregateGroupByReturn that includes the aggregation objects.
+            Depending on the presence of the `group_by` argument, either a `AggregateReturn` object or a `AggregateGroupByReturn that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:
@@ -92,7 +92,7 @@ class _OverAllGroupBy(_Aggregate):
         limit: Optional[int] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
-    ) -> List[_AggregateGroup]:
+    ) -> List[AggregateGroup]:
         """Aggregate metrics over all the objects in this collection without any vector search grouping the results by a property.
 
         Arguments:
@@ -108,7 +108,7 @@ class _OverAllGroupBy(_Aggregate):
                 A list of property metrics to aggregate together after the text search.
 
         Returns:
-            A list of `_AggregateGroup` objects that includes the aggregation objects.
+            A list of `AggregateGroup` objects that includes the aggregation objects.
 
         Raises:
             `weaviate.exceptions.WeaviateGQLQueryError`:

--- a/weaviate/collections/classes/aggregate.py
+++ b/weaviate/collections/classes/aggregate.py
@@ -259,13 +259,13 @@ class Metrics:
 
     def text(
         self,
-        count: Optional[bool] = None,
-        top_occurrences_count: Optional[bool] = None,
-        top_occurrences_value: Optional[bool] = None,
+        count: bool = False,
+        top_occurrences_count: bool = False,
+        top_occurrences_value: bool = False,
     ) -> _MetricsText:
         """Define the metrics to be returned for a TEXT or TEXT_ARRAY property when aggregating over a collection.
 
-        If none of the arguments are provided then all metrics will be returned. Otherwise, a `None` is treated as `False`.
+        If none of the arguments are provided then all metrics will be returned.
 
         Arguments:
             `count`
@@ -295,17 +295,17 @@ class Metrics:
 
     def integer(
         self,
-        count: Optional[bool] = None,
-        maximum: Optional[bool] = None,
-        mean: Optional[bool] = None,
-        median: Optional[bool] = None,
-        minimum: Optional[bool] = None,
-        mode: Optional[bool] = None,
-        sum_: Optional[bool] = None,
+        count: bool = False,
+        maximum: bool = False,
+        mean: bool = False,
+        median: bool = False,
+        minimum: bool = False,
+        mode: bool = False,
+        sum_: bool = False,
     ) -> _MetricsInteger:
         """Define the metrics to be returned for an INT or INT_ARRAY property when aggregating over a collection.
 
-        If none of the arguments are provided then all metrics will be returned. Otherwise, a `None` is treated as `False`.
+        If none of the arguments are provided then all metrics will be returned.
 
         Arguments:
             `count`
@@ -326,17 +326,7 @@ class Metrics:
         Returns:
             A `_MetricsInteger` object that includes the metrics to be returned.
         """
-        if all(
-            [
-                count is None,
-                maximum is None,
-                mean is None,
-                median is None,
-                minimum is None,
-                mode is None,
-                sum_ is None,
-            ]
-        ):
+        if not all([not count, not maximum, not mean, not median, not minimum, not mode, not sum_]):
             count = True
             maximum = True
             mean = True
@@ -344,14 +334,6 @@ class Metrics:
             minimum = True
             mode = True
             sum_ = True
-        else:
-            count = count is True
-            maximum = maximum is True
-            mean = mean is True
-            median = median is True
-            minimum = minimum is True
-            mode = mode is True
-            sum_ = sum_ is True
         return _MetricsInteger(
             property_name=self.__property,
             count=count,
@@ -365,17 +347,17 @@ class Metrics:
 
     def number(
         self,
-        count: Optional[bool] = None,
-        maximum: Optional[bool] = None,
-        mean: Optional[bool] = None,
-        median: Optional[bool] = None,
-        minimum: Optional[bool] = None,
-        mode: Optional[bool] = None,
-        sum_: Optional[bool] = None,
+        count: bool = False,
+        maximum: bool = False,
+        mean: bool = False,
+        median: bool = False,
+        minimum: bool = False,
+        mode: bool = False,
+        sum_: bool = False,
     ) -> _MetricsNumber:
         """Define the metrics to be returned for a NUMBER or NUMBER_ARRAY property when aggregating over a collection.
 
-        If none of the arguments are provided then all metrics will be returned. Otherwise, a `None` is treated as `False`.
+        If none of the arguments are provided then all metrics will be returned.
 
         Arguments:
             `count`
@@ -396,17 +378,7 @@ class Metrics:
         Returns:
             A `_MetricsNumber` object that includes the metrics to be returned.
         """
-        if all(
-            [
-                count is None,
-                maximum is None,
-                mean is None,
-                median is None,
-                minimum is None,
-                mode is None,
-                sum_ is None,
-            ]
-        ):
+        if all([not count, not maximum, not mean, not median, not minimum, not mode, not sum_]):
             count = True
             maximum = True
             mean = True
@@ -435,15 +407,15 @@ class Metrics:
 
     def boolean(
         self,
-        count: Optional[bool] = None,
-        percentage_false: Optional[bool] = None,
-        percentage_true: Optional[bool] = None,
-        total_false: Optional[bool] = None,
-        total_true: Optional[bool] = None,
+        count: bool = False,
+        percentage_false: bool = False,
+        percentage_true: bool = False,
+        total_false: bool = False,
+        total_true: bool = False,
     ) -> _MetricsBoolean:
         """Define the metrics to be returned for a BOOL or BOOL_ARRAY property when aggregating over a collection.
 
-        If none of the arguments are provided then all metrics will be returned. Otherwise, a `None` is treated as `False`.
+        If none of the arguments are provided then all metrics will be returned.
 
         Arguments:
             `count`
@@ -461,25 +433,13 @@ class Metrics:
             A `_MetricsBoolean` object that includes the metrics to be returned.
         """
         if all(
-            [
-                count is None,
-                percentage_false is None,
-                percentage_true is None,
-                total_false is None,
-                total_true is None,
-            ]
+            [not count, not percentage_false, not percentage_true, not total_false, not total_true]
         ):
             count = True
             percentage_false = True
             percentage_true = True
             total_false = True
             total_true = True
-        else:
-            count = count is True
-            percentage_false = percentage_false is True
-            percentage_true = percentage_true is True
-            total_false = total_false is True
-            total_true = total_true is True
         return _MetricsBoolean(
             property_name=self.__property,
             count=count,
@@ -491,15 +451,15 @@ class Metrics:
 
     def date_(
         self,
-        count: Optional[bool] = None,
-        maximum: Optional[bool] = None,
-        median: Optional[bool] = None,
-        minimum: Optional[bool] = None,
-        mode: Optional[bool] = None,
+        count: bool = False,
+        maximum: bool = False,
+        median: bool = False,
+        minimum: bool = False,
+        mode: bool = False,
     ) -> _MetricsDate:
         """Define the metrics to be returned for a DATE or DATE_ARRAY property when aggregating over a collection.
 
-        If none of the arguments are provided then all metrics will be returned. Otherwise, a `None` is treated as `False`.
+        If none of the arguments are provided then all metrics will be returned.
 
         Arguments:
             `count`
@@ -516,18 +476,12 @@ class Metrics:
         Returns:
             A `_MetricsDate` object that includes the metrics to be returned.
         """
-        if all([count is None, maximum is None, median is None, minimum is None, mode is None]):
+        if all([not count, not maximum, not median, not minimum, not mode]):
             count = True
             maximum = True
             median = True
             minimum = True
             mode = True
-        else:
-            count = count is True
-            maximum = maximum is True
-            median = median is True
-            minimum = minimum is True
-            mode = mode is True
         return _MetricsDate(
             property_name=self.__property,
             count=count,
@@ -539,11 +493,11 @@ class Metrics:
 
     def reference(
         self,
-        pointing_to: Optional[bool] = None,
+        pointing_to: bool = False,
     ) -> _MetricsReference:
         """Define the metrics to be returned for a cross-reference property when aggregating over a collection.
 
-        If none of the arguments are provided then all metrics will be returned. Otherwise, a `None` is treated as `False`.
+        If none of the arguments are provided then all metrics will be returned.
 
         Arguments:
             `pointing_to`
@@ -552,10 +506,8 @@ class Metrics:
         Returns:
             A `_MetricsReference` object that includes the metrics to be returned.
         """
-        if pointing_to is None:
+        if all([not pointing_to]):
             pointing_to = True
-        else:
-            pointing_to = pointing_to is True
         return _MetricsReference(
             property_name=self.__property,
             pointing_to=pointing_to,

--- a/weaviate/collections/classes/aggregate.py
+++ b/weaviate/collections/classes/aggregate.py
@@ -278,14 +278,10 @@ class Metrics:
         Returns:
             A `_MetricsStr` object that includes the metrics to be returned.
         """
-        if all([count is None, top_occurrences_count is None, top_occurrences_value is None]):
+        if not any([count, top_occurrences_count, top_occurrences_value]):
             count = True
             top_occurrences_count = True
             top_occurrences_value = True
-        else:
-            count = count is True
-            top_occurrences_count = top_occurrences_count is True
-            top_occurrences_value = top_occurrences_value is True
         return _MetricsText(
             property_name=self.__property,
             count=count,
@@ -326,7 +322,7 @@ class Metrics:
         Returns:
             A `_MetricsInteger` object that includes the metrics to be returned.
         """
-        if not all([not count, not maximum, not mean, not median, not minimum, not mode, not sum_]):
+        if not any([count, maximum, mean, median, minimum, mode, sum_]):
             count = True
             maximum = True
             mean = True
@@ -378,7 +374,7 @@ class Metrics:
         Returns:
             A `_MetricsNumber` object that includes the metrics to be returned.
         """
-        if all([not count, not maximum, not mean, not median, not minimum, not mode, not sum_]):
+        if not any([count, maximum, mean, median, minimum, mode, sum_]):
             count = True
             maximum = True
             mean = True
@@ -386,14 +382,6 @@ class Metrics:
             minimum = True
             mode = True
             sum_ = True
-        else:
-            count = count is True
-            maximum = maximum is True
-            mean = mean is True
-            median = median is True
-            minimum = minimum is True
-            mode = mode is True
-            sum_ = sum_ is True
         return _MetricsNumber(
             property_name=self.__property,
             count=count,
@@ -432,9 +420,7 @@ class Metrics:
         Returns:
             A `_MetricsBoolean` object that includes the metrics to be returned.
         """
-        if all(
-            [not count, not percentage_false, not percentage_true, not total_false, not total_true]
-        ):
+        if not any([count, percentage_false, percentage_true, total_false, total_true]):
             count = True
             percentage_false = True
             percentage_true = True
@@ -476,7 +462,7 @@ class Metrics:
         Returns:
             A `_MetricsDate` object that includes the metrics to be returned.
         """
-        if all([not count, not maximum, not median, not minimum, not mode]):
+        if not any([count, maximum, median, minimum, mode]):
             count = True
             maximum = True
             median = True
@@ -506,7 +492,7 @@ class Metrics:
         Returns:
             A `_MetricsReference` object that includes the metrics to be returned.
         """
-        if all([not pointing_to]):
+        if not any([pointing_to]):
             pointing_to = True
         return _MetricsReference(
             property_name=self.__property,

--- a/weaviate/outputs/aggregate.py
+++ b/weaviate/outputs/aggregate.py
@@ -1,0 +1,27 @@
+from weaviate.collections.classes.aggregate import (
+    AggregateBoolean,
+    AggregateDate,
+    AggregateGroup,
+    AggregateGroupByReturn,
+    AggregateInteger,
+    AggregateNumber,
+    AggregateReference,
+    AggregateResult,
+    AggregateReturn,
+    AggregateText,
+    GroupedBy,
+)
+
+__all__ = [
+    "AggregateBoolean",
+    "AggregateDate",
+    "AggregateGroup",
+    "AggregateGroupByReturn",
+    "AggregateInteger",
+    "AggregateNumber",
+    "AggregateReference",
+    "AggregateResult",
+    "AggregateReturn",
+    "AggregateText",
+    "GroupedBy",
+]


### PR DESCRIPTION
This PR:

- Allows `Metrics().text()` to specify all the metrics back rather than none of them
- Exports all the returns from `weaviate.outputs.aggregate`