### PR TITLE
Add WCS sandbox support to connect_to_wcs.

### DIFF
--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -14,7 +14,6 @@ WCS_HOST = "piblpmmdsiknacjnm1ltla.c1.europe-west3.gcp.weaviate.cloud"
 WCS_URL = f"https://{WCS_HOST}"
 WCS_GRPC_HOST = f"grpc-{WCS_HOST}"
 WCS_CREDS = wvc.init.Auth.api_key("cy4ua772mBlMdfw3YnclqAWzFhQt0RLIN0sl")
-WCS_SANDBOX_CREDS = wvc.init.Auth.api_key("h6kmJ3K0HR2t5H7AvClwXDyBFHOKy4pTuG6R")
 
 
 @pytest.fixture(scope="module")
@@ -136,14 +135,6 @@ def test_connect_to_wcs() -> None:
     client = weaviate.connect_to_wcs(
         "https://piblpmmdsiknacjnm1ltla.c1.europe-west3.gcp.weaviate.cloud",
         auth_credentials=WCS_CREDS,
-    )
-    client.get_meta()
-
-
-def test_connect_to_wcs_sandbox() -> None:
-    client = weaviate.connect_to_wcs(
-        "https://grpc10-urzaj18j.dev.weaviate.network",
-        auth_credentials=WCS_SANDBOX_CREDS,
     )
     client.get_meta()
 

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -14,6 +14,7 @@ WCS_HOST = "piblpmmdsiknacjnm1ltla.c1.europe-west3.gcp.weaviate.cloud"
 WCS_URL = f"https://{WCS_HOST}"
 WCS_GRPC_HOST = f"grpc-{WCS_HOST}"
 WCS_CREDS = wvc.init.Auth.api_key("cy4ua772mBlMdfw3YnclqAWzFhQt0RLIN0sl")
+WCS_SANDBOX_CREDS = wvc.init.Auth.api_key("h6kmJ3K0HR2t5H7AvClwXDyBFHOKy4pTuG6R")
 
 
 @pytest.fixture(scope="module")
@@ -135,6 +136,14 @@ def test_connect_to_wcs() -> None:
     client = weaviate.connect_to_wcs(
         "https://piblpmmdsiknacjnm1ltla.c1.europe-west3.gcp.weaviate.cloud",
         auth_credentials=WCS_CREDS,
+    )
+    client.get_meta()
+
+
+def test_connect_to_wcs_sandbox() -> None:
+    client = weaviate.connect_to_wcs(
+        "https://grpc10-urzaj18j.dev.weaviate.network",
+        auth_credentials=WCS_SANDBOX_CREDS,
     )
     client.get_meta()
 

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -28,9 +28,9 @@ def connect_to_wcs(
         `cluster_url`
             The WCS cluster URL or hostname to connect to. Usually in the form rAnD0mD1g1t5.something.weaviate.cloud
         `auth_credentials`
-            The credentials to use for authentication with your WCS instance. This can be an API key, in which case use `weaviate.AuthApiKey`,
-            a bearer token, in which case use `weaviate.AuthBearerToken`, a client secret, in which case use `weaviate.AuthClientCredentials`
-            or a username and password, in which case use `weaviate.AuthClientPassword`.
+            The credentials to use for authentication with your Weaviate instance. This can be an API key, in which case use `weaviate.classes.init.Auth.api_key()`,
+            a bearer token, in which case use `weaviate.classes.init.Auth.bearer_token()`, a client secret, in which case use `weaviate.classes.init.Auth.client_credentials()`
+            or a username and password, in which case use `weaviate.classes.init.Auth.client_password()`.
         `headers`
             Additional headers to include in the requests, e.g. API keys for third-party Cloud vectorization.
         `additional_config`
@@ -46,7 +46,7 @@ def connect_to_wcs(
         >>> import weaviate
         >>> client = weaviate.connect_to_wcs(
         ...     cluster_url="rAnD0mD1g1t5.something.weaviate.cloud",
-        ...     auth_credentials=weaviate.auth.AuthApiKey("my-api-key"),
+        ...     auth_credentials=weaviate.classes.init.Auth.api_key("my-api-key"),
         ... )
         >>> client.is_ready()
         True
@@ -55,7 +55,7 @@ def connect_to_wcs(
         >>> import weaviate
         >>> with weaviate.connect_to_wcs(
         ...     cluster_url="rAnD0mD1g1t5.something.weaviate.cloud",
-        ...     auth_credentials=weaviate.auth.AuthApiKey("my-api-key"),
+        ...     auth_credentials=weaviate.classes.init.Auth.api_key("my-api-key"),
         ... ) as client:
         ...     client.is_ready()
         True
@@ -80,12 +80,7 @@ def connect_to_wcs(
         additional_config=additional_config,
         skip_init_checks=skip_init_checks,
     )
-    try:
-        client.connect()
-    except Exception as e:
-        client.close()
-        raise e
-    return client
+    return __connect(client)
 
 
 def connect_to_local(
@@ -119,9 +114,9 @@ def connect_to_local(
         `skip_init_checks`
             Whether to skip the initialization checks when connecting to Weaviate.
         `auth_credentials`
-            The credentials to use for authentication with your instance. This can be an API key, in which case use `weaviate.AuthApiKey`,
-            a bearer token, in which case use `weaviate.AuthBearerToken`, a client secret, in which case use `weaviate.AuthClientCredentials`
-            or a username and password, in which case use `weaviate.AuthClientPassword`.
+            The credentials to use for authentication with your Weaviate instance. This can be an API key, in which case use `weaviate.classes.init.Auth.api_key()`,
+            a bearer token, in which case use `weaviate.classes.init.Auth.bearer_token()`, a client secret, in which case use `weaviate.classes.init.Auth.client_credentials()`
+            or a username and password, in which case use `weaviate.classes.init.Auth.client_password()`.
 
     Returns
         `weaviate.WeaviateClient`
@@ -158,12 +153,7 @@ def connect_to_local(
         skip_init_checks=skip_init_checks,
         auth_client_secret=auth_credentials,
     )
-    try:
-        client.connect()
-    except Exception as e:
-        client.close()
-        raise e
-    return client
+    return __connect(client)
 
 
 def connect_to_embedded(
@@ -249,12 +239,7 @@ def connect_to_embedded(
         additional_headers=headers,
         additional_config=additional_config,
     )
-    try:
-        client.connect()
-    except Exception as e:
-        client.close()
-        raise e
-    return client
+    return __connect(client)
 
 
 def connect_to_custom(
@@ -297,9 +282,9 @@ def connect_to_custom(
             The timeout to use for the underlying HTTP calls. Accepts a tuple of integers, where the first integer
             represents the connect timeout and the second integer represents the read timeout.
         `auth_credentials`
-            The credentials to use for authentication with your Weaviate instance. This can be an API key, in which case use `weaviate.AuthApiKey`,
-            a bearer token, in which case use `weaviate.AuthBearerToken`, a client secret, in which case use `weaviate.AuthClientCredentials`
-            or a username and password, in which case use `weaviate.AuthClientPassword`.
+            The credentials to use for authentication with your Weaviate instance. This can be an API key, in which case use `weaviate.classes.init.Auth.api_key()`,
+            a bearer token, in which case use `weaviate.classes.init.Auth.bearer_token()`, a client secret, in which case use `weaviate.classes.init.Auth.client_credentials()`
+            or a username and password, in which case use `weaviate.classes.init.Auth.client_password()`.
         `skip_init_checks`
             Whether to skip the initialization checks when connecting to Weaviate.
 
@@ -348,9 +333,13 @@ def connect_to_custom(
         additional_config=additional_config,
         skip_init_checks=skip_init_checks,
     )
+    return __connect(client)
+
+
+def __connect(client: WeaviateClient) -> WeaviateClient:
     try:
         client.connect()
+        return client
     except Exception as e:
         client.close()
         raise e
-    return client

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -80,7 +80,11 @@ def connect_to_wcs(
         additional_config=additional_config,
         skip_init_checks=skip_init_checks,
     )
-    client.connect()
+    try:
+        client.connect()
+    except Exception as e:
+        client.close()
+        raise e
     return client
 
 
@@ -154,7 +158,11 @@ def connect_to_local(
         skip_init_checks=skip_init_checks,
         auth_client_secret=auth_credentials,
     )
-    client.connect()
+    try:
+        client.connect()
+    except Exception as e:
+        client.close()
+        raise e
     return client
 
 
@@ -241,7 +249,11 @@ def connect_to_embedded(
         additional_headers=headers,
         additional_config=additional_config,
     )
-    client.connect()
+    try:
+        client.connect()
+    except Exception as e:
+        client.close()
+        raise e
     return client
 
 
@@ -336,5 +348,9 @@ def connect_to_custom(
         additional_config=additional_config,
         skip_init_checks=skip_init_checks,
     )
-    client.connect()
+    try:
+        client.connect()
+    except Exception as e:
+        client.close()
+        raise e
     return client

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -46,7 +46,7 @@ def connect_to_wcs(
         >>> import weaviate
         >>> client = weaviate.connect_to_wcs(
         ...     cluster_url="rAnD0mD1g1t5.something.weaviate.cloud",
-        ...     auth_credentials=weaviate.AuthApiKey("my-api-key"),
+        ...     auth_credentials=weaviate.auth.AuthApiKey("my-api-key"),
         ... )
         >>> client.is_ready()
         True
@@ -55,7 +55,7 @@ def connect_to_wcs(
         >>> import weaviate
         >>> with weaviate.connect_to_wcs(
         ...     cluster_url="rAnD0mD1g1t5.something.weaviate.cloud",
-        ...     auth_credentials=weaviate.AuthApiKey("my-api-key"),
+        ...     auth_credentials=weaviate.auth.AuthApiKey("my-api-key"),
         ... ) as client:
         ...     client.is_ready()
         True
@@ -64,7 +64,11 @@ def connect_to_wcs(
     if cluster_url.startswith("http"):
         # Handle the common case of copy/pasting a URL instead of the hostname.
         cluster_url = urlparse(cluster_url).netloc
-    grpc_host = f"grpc-{cluster_url}"
+    if cluster_url.endswith(".weaviate.network"):
+        ident, domain = cluster_url.split(".", 1)
+        grpc_host = f"{ident}.grpc.{domain}"
+    else:
+        grpc_host = f"grpc-{cluster_url}"
 
     client = WeaviateClient(
         connection_params=ConnectionParams(

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -640,7 +640,7 @@ class ConnectionV4(_Connection):
             embedded_db,
         )
 
-    def _ping_grpc(self, close_on_error: bool = True) -> None:
+    def _ping_grpc(self) -> None:
         """Performs a grpc health check and raises WeaviateGRPCUnavailableError if not."""
         if not self.is_connected():
             raise WeaviateClosedClientError()
@@ -652,12 +652,8 @@ class ConnectionV4(_Connection):
                 response_deserializer=health_pb2.HealthCheckResponse.FromString,
             )(health_pb2.HealthCheckRequest(), timeout=1)
             if res.status != health_pb2.HealthCheckResponse.SERVING:
-                if close_on_error:
-                    self.close()
                 raise WeaviateGRPCUnavailableError(f"Weaviate v{self.server_version}")
         except _channel._InactiveRpcError as e:
-            if close_on_error:
-                self.close()
             raise WeaviateGRPCUnavailableError(f"Weaviate v{self.server_version}") from e
 
     def connect(self, skip_init_checks: bool) -> None:


### PR DESCRIPTION
WCS sandbox clusters are hosted on a different domain (weaviate.network) and use a different hostname schema for their grpc endpoint.

Also update the examples in the docstring to use AuthApiKey via weaviate.auth.