### PR TITLE
reintroduce str as input to group_by in aggregate

### DIFF
--- a/integration/test_collection_aggregate.py
+++ b/integration/test_collection_aggregate.py
@@ -483,7 +483,7 @@ def test_group_by_aggregation_argument(collection_factory: CollectionFactory) ->
     collection.data.insert({"text": "some text", "int": 2})
 
     res = collection.aggregate.over_all(
-        group_by=GroupByAggregate(prop="text"),
+        group_by="text",
         return_metrics=[
             Metrics("text").text(count=True),
             Metrics("int").integer(count=True),
@@ -499,7 +499,7 @@ def test_group_by_aggregation_argument(collection_factory: CollectionFactory) ->
     assert groups[0].properties["int"].count == 2
 
     res = collection.aggregate.over_all(
-        group_by=GroupByAggregate(prop="int"),
+        group_by="int",
         return_metrics=[
             Metrics("text").text(count=True),
             Metrics("int").integer(count=True),

--- a/test/collection/test_aggregates.py
+++ b/test/collection/test_aggregates.py
@@ -14,7 +14,7 @@ def test_bad_aggregate_inputs(connection: ConnectionV4) -> None:
     aggregate = _AggregateCollection(connection, "dummy", None, None)
     # over_all
     _test_aggregate(lambda: aggregate.over_all(filters="wrong"))
-    _test_aggregate(lambda: aggregate.over_all(group_by="wrong"))
+    _test_aggregate(lambda: aggregate.over_all(group_by=42))
     _test_aggregate(lambda: aggregate.over_all(total_count="wrong"))
     _test_aggregate(lambda: aggregate.over_all(return_metrics="wrong"))
 

--- a/weaviate/collections/aggregations/base.py
+++ b/weaviate/collections/aggregations/base.py
@@ -169,11 +169,13 @@ class _Aggregate:
 
     @staticmethod
     def _add_groupby_to_builder(
-        builder: AggregateBuilder, group_by: Optional[GroupByAggregate]
+        builder: AggregateBuilder, group_by: Union[str, GroupByAggregate, None]
     ) -> AggregateBuilder:
-        _validate_input(_ValidateArgument([GroupByAggregate, None], "group_by", group_by))
+        _validate_input(_ValidateArgument([str, GroupByAggregate, None], "group_by", group_by))
         if group_by is None:
             return builder
+        if isinstance(group_by, str):
+            group_by = GroupByAggregate(prop=group_by)
         builder = builder.with_group_by_filter([group_by.prop])
         if group_by.limit is not None:
             builder = builder.with_limit(group_by.limit)

--- a/weaviate/collections/aggregations/near_image.py
+++ b/weaviate/collections/aggregations/near_image.py
@@ -38,7 +38,7 @@ class _NearImage(_Aggregate):
         distance: Optional[NUMBER] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: GroupByAggregate,
+        group_by: Union[str, GroupByAggregate],
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> AggregateGroupByReturn:
@@ -52,7 +52,7 @@ class _NearImage(_Aggregate):
         distance: Optional[NUMBER] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Optional[GroupByAggregate] = None,
+        group_by: Optional[Union[str, GroupByAggregate]] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> Union[AggregateReturn, AggregateGroupByReturn]:

--- a/weaviate/collections/aggregations/near_object.py
+++ b/weaviate/collections/aggregations/near_object.py
@@ -36,7 +36,7 @@ class _NearObject(_Aggregate):
         distance: Optional[NUMBER] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: GroupByAggregate,
+        group_by: Union[str, GroupByAggregate],
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> AggregateGroupByReturn:
@@ -50,7 +50,7 @@ class _NearObject(_Aggregate):
         distance: Optional[NUMBER] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Optional[GroupByAggregate] = None,
+        group_by: Optional[Union[str, GroupByAggregate]] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> Union[AggregateReturn, AggregateGroupByReturn]:

--- a/weaviate/collections/aggregations/near_text.py
+++ b/weaviate/collections/aggregations/near_text.py
@@ -41,7 +41,7 @@ class _NearText(_Aggregate):
         move_away: Optional[Move] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: GroupByAggregate,
+        group_by: Union[str, GroupByAggregate],
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> AggregateGroupByReturn:
@@ -57,7 +57,7 @@ class _NearText(_Aggregate):
         move_away: Optional[Move] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Optional[GroupByAggregate] = None,
+        group_by: Optional[Union[str, GroupByAggregate]] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> Union[AggregateReturn, AggregateGroupByReturn]:

--- a/weaviate/collections/aggregations/near_vector.py
+++ b/weaviate/collections/aggregations/near_vector.py
@@ -36,7 +36,7 @@ class _NearVector(_Aggregate):
         distance: Optional[NUMBER] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: GroupByAggregate,
+        group_by: Union[str, GroupByAggregate],
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> AggregateGroupByReturn:
@@ -50,7 +50,7 @@ class _NearVector(_Aggregate):
         distance: Optional[NUMBER] = None,
         object_limit: Optional[int] = None,
         filters: Optional[_Filters] = None,
-        group_by: Optional[GroupByAggregate] = None,
+        group_by: Optional[Union[str, GroupByAggregate]] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> Union[AggregateReturn, AggregateGroupByReturn]:

--- a/weaviate/collections/aggregations/over_all.py
+++ b/weaviate/collections/aggregations/over_all.py
@@ -27,7 +27,7 @@ class _OverAll(_Aggregate):
         self,
         *,
         filters: Optional[_Filters] = None,
-        group_by: GroupByAggregate,
+        group_by: Union[str, GroupByAggregate],
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> AggregateGroupByReturn:
@@ -37,7 +37,7 @@ class _OverAll(_Aggregate):
         self,
         *,
         filters: Optional[_Filters] = None,
-        group_by: Optional[GroupByAggregate] = None,
+        group_by: Optional[Union[str, GroupByAggregate]] = None,
         total_count: bool = True,
         return_metrics: Optional[PropertiesMetrics] = None,
     ) -> Union[AggregateReturn, AggregateGroupByReturn]:


### PR DESCRIPTION
This PR reintroduces using just string syntax when performing a aggregate group by query so that the happy path of usage is easier as it was previously, e.g.:
```python
res = collection.aggregate.over_all(
    group_by="text",
    ...
)
```
instead of:
```python
res = collection.aggregate.over_all(
    group_by=weaviate.classes.aggregate.GroupByAggregate(prop="text"),
    ...
)
```