### PR TITLE
Fixes error on calling cluster.nodes(output="verbose") on empty cluster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,10 @@ There are three kinds of tests:
 To run the integration tests,
 
 1. Ensure that you have Docker installed.
-2. Start the weaviate instances.
+2. Start the weaviate instances, changing `WEAVIATE_VERSION` to your weaviate docker image target
 
 ```shell
-./ci/start_weaviate.sh
+./ci/start_weaviate.sh WEAVIATE_VERSION
 ```
 
 3. Run the tests.

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,6 @@ The client is tested for python 3.8 and higher.
 
 Visit the official `Weaviate <https://weaviate.io/>`_ website for more information about the Weaviate and how to use it in production.
 
-Check out our `Command Line Interface (CLI) tool <https://pypi.org/project/weaviate-cli/>`_ for interacting with a Weaviate instance directly from your Terminal.
-
 Articles
 --------
 

--- a/weaviate/collections/classes/cluster.py
+++ b/weaviate/collections/classes/cluster.py
@@ -54,11 +54,11 @@ class _ConvertFromREST:
                         object_count=shard["objectCount"],
                     )
                     for shard in cast(List[ShardREST], node["shards"])
-                ] if node.get("shards") else None,
+                ] if "shards" in nodes else None,
                 stats=Stats(
                     object_count=node["stats"]["objectCount"],
                     shard_count=node["stats"]["shardCount"],
-                ) if node.get("stats") else None,
+                ) if "stats" in node else None,
                 status=node["status"],
                 version=node["version"],
             )

--- a/weaviate/collections/classes/cluster.py
+++ b/weaviate/collections/classes/cluster.py
@@ -54,11 +54,11 @@ class _ConvertFromREST:
                         object_count=shard["objectCount"],
                     )
                     for shard in cast(List[ShardREST], node["shards"])
-                ],
+                ] if node.get("shards") else None,
                 stats=Stats(
                     object_count=node["stats"]["objectCount"],
                     shard_count=node["stats"]["shardCount"],
-                ),
+                ) if node.get("stats") else None,
                 status=node["status"],
                 version=node["version"],
             )


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-python-client/issues/896

How to reproduce:

run:
```python
client.cluster.nodes(output="verbose")
```

on an empty cluster. It will not have shards or stats, and will fail with:
```
TypeError: 'NoneType' object is not iterable
```

Also some small changes in README and CONTRIBUTING.