### PR TITLE
allow skip and vectorizePropertyName be optional

### DIFF
--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -242,10 +242,10 @@ def _properties_from_config(schema: Dict[str, Any]) -> List[_Property]:
             ),
             vectorizer_config=(
                 _PropertyVectorizerConfig(
-                    skip=prop["moduleConfig"][schema["vectorizer"]]["skip"],
-                    vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]][
+                    skip=prop["moduleConfig"][schema["vectorizer"]].get("skip"),
+                    vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]].get(
                         "vectorizePropertyName"
-                    ],
+                    ),
                 )
                 if schema["vectorizer"] != "none"
                 else None

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -242,9 +242,9 @@ def _properties_from_config(schema: Dict[str, Any]) -> List[_Property]:
             ),
             vectorizer_config=(
                 _PropertyVectorizerConfig(
-                    skip=prop["moduleConfig"][schema["vectorizer"]].get("skip"),
+                    skip=prop["moduleConfig"][schema["vectorizer"]].get("skip", False),
                     vectorize_property_name=prop["moduleConfig"][schema["vectorizer"]].get(
-                        "vectorizePropertyName"
+                        "vectorizePropertyName", False
                     ),
                 )
                 if schema["vectorizer"] != "none"


### PR DESCRIPTION
In some modules, like `multi2vec_bind`, skip and vectorizePropertyName may not be present on the response for the schema.

This is the output of the created schema below:

```
{
   "class":"Animals",
   "invertedIndexConfig":{
      "bm25":{
         "b":0.75,
         "k1":1.2
      },
      "cleanupIntervalSeconds":60,
      "stopwords":{
         "additions":null,
         "preset":"en",
         "removals":null
      }
   },
   "moduleConfig":{
      "multi2vec-bind":{
         "audioFields":[
            "audio"
         ],
         "imageFields":[
            "image"
         ],
         "vectorizeClassName":true,
         "videoFields":[
            "video"
         ]
      }
   },
   "multiTenancyConfig":{
      "enabled":false
   },
   "properties":[
      {
         "dataType":[
            "text"
         ],
         "description":"This property was generated by Weaviate's auto-schema feature on Mon Feb 19 21:26:04 2024",
         "indexFilterable":true,
         "indexSearchable":true,
         "moduleConfig":{
            "multi2vec-bind":{
               
            }
         },
         "name":"name",
         "tokenization":"word"
      },
      {
         "dataType":[
            "text"
         ],
         "description":"This property was generated by Weaviate's auto-schema feature on Mon Feb 19 21:26:04 2024",
         "indexFilterable":true,
         "indexSearchable":true,
         "moduleConfig":{
            "multi2vec-bind":{
               
            }
         },
         "name":"path",
         "tokenization":"word"
      },
      {
         "dataType":[
            "text"
         ],
         "description":"This property was generated by Weaviate's auto-schema feature on Mon Feb 19 21:26:04 2024",
         "indexFilterable":true,
         "indexSearchable":true,
         "moduleConfig":{
            "multi2vec-bind":{
               
            }
         },
         "name":"image",
         "tokenization":"word"
      },
      {
         "dataType":[
            "text"
         ],
         "description":"This property was generated by Weaviate's auto-schema feature on Mon Feb 19 21:26:04 2024",
         "indexFilterable":true,
         "indexSearchable":true,
         "moduleConfig":{
            "multi2vec-bind":{
               
            }
         },
         "name":"mediaType",
         "tokenization":"word"
      }
   ],
   "replicationConfig":{
      "factor":1
   },
   "shardingConfig":{
      "virtualPerPhysical":128,
      "desiredCount":1,
      "actualCount":1,
      "desiredVirtualCount":128,
      "actualVirtualCount":128,
      "key":"_id",
      "strategy":"hash",
      "function":"murmur3"
   },
   "vectorIndexConfig":{
      "skip":false,
      "cleanupIntervalSeconds":300,
      "maxConnections":64,
      "efConstruction":128,
      "ef":-1,
      "dynamicEfMin":100,
      "dynamicEfMax":500,
      "dynamicEfFactor":8,
      "vectorCacheMaxObjects":1000000000000,
      "flatSearchCutoff":40000,
      "distance":"cosine",
      "pq":{
         "enabled":false,
         "bitCompression":false,
         "segments":0,
         "centroids":256,
         "trainingLimit":100000,
         "encoder":{
            "type":"kmeans",
            "distribution":"log-normal"
         }
      }
   },
   "vectorIndexType":"hnsw",
   "vectorizer":"multi2vec-bind"
}
```

How to reproduce:

```python
import weaviate
client = weaviate.connect_to_local()

from weaviate import classes as wvc
client.collections.delete("Test")
c = client.collections.create(
    "Test",
    vectorizer_config=wvc.config.Configure.Vectorizer.multi2vec_bind(
        text_fields=["text"],
    )
)
# work here
c.config.get()

c.data.insert({"text": "text"})

# not anymore
c.config.get()

# ERROR: KeyError: 'skip'
```