### PR TITLE
Allow None as query for BM25 and hybrid

### DIFF
--- a/weaviate/collections/queries/bm25/generate.py
+++ b/weaviate/collections/queries/bm25/generate.py
@@ -20,7 +20,7 @@ from weaviate.types import INCLUDE_VECTOR
 class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, References]):
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         single_prompt: Optional[str] = None,
         grouped_task: Optional[str] = None,
@@ -42,7 +42,7 @@ class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, Refe
 
         Arguments:
             `query`
-                The keyword-based query to search for, REQUIRED.
+                The keyword-based query to search for, REQUIRED. If None, a normal search will be performed.
             `single_prompt`
                 The prompt to use for RaG on each object individually.
             `grouped_task`

--- a/weaviate/collections/queries/bm25/generate.pyi
+++ b/weaviate/collections/queries/bm25/generate.pyi
@@ -16,7 +16,7 @@ class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, Refe
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         single_prompt: Optional[str] = None,
         grouped_task: Optional[str] = None,
@@ -36,7 +36,7 @@ class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, Refe
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         single_prompt: Optional[str] = None,
         grouped_task: Optional[str] = None,
@@ -56,7 +56,7 @@ class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, Refe
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         single_prompt: Optional[str] = None,
         grouped_task: Optional[str] = None,
@@ -76,7 +76,7 @@ class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, Refe
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         single_prompt: Optional[str] = None,
         grouped_task: Optional[str] = None,
@@ -96,7 +96,7 @@ class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, Refe
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         single_prompt: Optional[str] = None,
         grouped_task: Optional[str] = None,
@@ -116,7 +116,7 @@ class _BM25Generate(Generic[Properties, References], _BaseQuery[Properties, Refe
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         single_prompt: Optional[str] = None,
         grouped_task: Optional[str] = None,

--- a/weaviate/collections/queries/bm25/query.py
+++ b/weaviate/collections/queries/bm25/query.py
@@ -18,7 +18,7 @@ from weaviate.types import INCLUDE_VECTOR
 class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, References]):
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         query_properties: Optional[List[str]] = None,
         limit: Optional[int] = None,
@@ -37,7 +37,7 @@ class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, Referen
 
         Arguments:
             `query`
-                The keyword-based query to search for, REQUIRED.
+                The keyword-based query to search for, REQUIRED. If None, a normal search will be performed.
             `query_properties`
                 The properties to search in. If not specified, all properties are searched.
             `limit`

--- a/weaviate/collections/queries/bm25/query.pyi
+++ b/weaviate/collections/queries/bm25/query.pyi
@@ -16,7 +16,7 @@ class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, Referen
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         query_properties: Optional[List[str]] = None,
         limit: Optional[int] = None,
@@ -33,7 +33,7 @@ class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, Referen
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         query_properties: Optional[List[str]] = None,
         limit: Optional[int] = None,
@@ -50,7 +50,7 @@ class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, Referen
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         query_properties: Optional[List[str]] = None,
         limit: Optional[int] = None,
@@ -67,7 +67,7 @@ class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, Referen
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         query_properties: Optional[List[str]] = None,
         limit: Optional[int] = None,
@@ -84,7 +84,7 @@ class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, Referen
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         query_properties: Optional[List[str]] = None,
         limit: Optional[int] = None,
@@ -101,7 +101,7 @@ class _BM25Query(Generic[Properties, References], _BaseQuery[Properties, Referen
     @overload
     def bm25(
         self,
-        query: str,
+        query: Optional[str],
         *,
         query_properties: Optional[List[str]] = None,
         limit: Optional[int] = None,

--- a/weaviate/collections/queries/hybrid/generate.py
+++ b/weaviate/collections/queries/hybrid/generate.py
@@ -45,7 +45,7 @@ class _HybridGenerate(Generic[Properties, References], _BaseQuery[Properties, Re
 
         Arguments:
             `query`
-                The keyword-based query to search for, REQUIRED.
+                The keyword-based query to search for, REQUIRED. If query and vector are both None, a normal search will be performed.
             `single_prompt`
                 The prompt to use for RaG on each object individually.
             `grouped_task`
@@ -92,7 +92,7 @@ class _HybridGenerate(Generic[Properties, References], _BaseQuery[Properties, Re
                 If the network connection to Weaviate fails.
         """
         res = self._query.hybrid(
-            query=query or "",
+            query=query,
             alpha=alpha,
             vector=vector,
             properties=query_properties,

--- a/weaviate/collections/queries/hybrid/query.py
+++ b/weaviate/collections/queries/hybrid/query.py
@@ -41,7 +41,7 @@ class _HybridQuery(Generic[Properties, References], _BaseQuery[Properties, Refer
 
         Arguments:
             `query`
-                The keyword-based query to search for, REQUIRED.
+                The keyword-based query to search for, REQUIRED. If query and vector are both None, a normal search will be performed.
             `alpha`
                 The weight of the BM25 score. If not specified, the default weight specified by the server is used.
             `vector`
@@ -82,7 +82,7 @@ class _HybridQuery(Generic[Properties, References], _BaseQuery[Properties, Refer
                 If the network connection to Weaviate fails.
         """
         res = self._query.hybrid(
-            query=query or "",
+            query=query,
             alpha=alpha,
             vector=vector,
             properties=query_properties,


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-python-client/issues/894

For Bm25:
If query is None, => normal GET, eg results have all score 0 (if you request them)
For hybrid:
if query is None, vector is not None, alpha => 1, pure vector search, but still hybrid-type scores (scaled)
if vector is None, query is not None, alpha = 0, pure keyword search, but still hybrid-type scores (scaled)
both None => normal GET, eg results have all score 0 (if you request them)