### PR TITLE
Extend Tokenization enum options

### DIFF
--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -128,12 +128,18 @@ class Tokenization(str, Enum):
             Tokenize by lowercase.
         `FIELD`
             Tokenize by field.
+        `GSE`
+            Tokenize using GSE (for Chinese and Japanese).
+        `TRIGRAM`
+            Tokenize into trigrams.
     """
 
     WORD = "word"
     WHITESPACE = "whitespace"
     LOWERCASE = "lowercase"
     FIELD = "field"
+    GSE = "gse"
+    TRIGRAM = "trigram"
 
 
 class GenerativeSearches(str, Enum):


### PR DESCRIPTION
Extend Tokenization enum options to make use of https://github.com/weaviate/weaviate/pull/4028/files 