### PR TITLE
Split embedded integration tests in CI to separate job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,8 +14,8 @@ on:
   pull_request:
 
 env:
-  OLD_WEAVIATE_VERSION: 1.23.10
-  NEW_WEAVIATE_VERSION: preview-improved-update-of-target-vector-configs-3688182
+  OLD_WEAVIATE_VERSION: 1.23.13
+  NEW_WEAVIATE_VERSION: 1.24.5
 
 jobs:
   lint-and-format:
@@ -87,16 +87,8 @@ jobs:
     name: Run Integration Tests Embedded
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        versions: [
-          { py: "3.8", weaviate: $NEW_WEAVIATE_VERSION},
-          { py: "3.9", weaviate: $NEW_WEAVIATE_VERSION},
-          { py: "3.10", weaviate: $NEW_WEAVIATE_VERSION},
-          { py: "3.11", weaviate: $NEW_WEAVIATE_VERSION},
-          { py: "3.11", weaviate: $OLD_WEAVIATE_VERSION},
-          { py: "3.12", weaviate: $NEW_WEAVIATE_VERSION}
-        ]
+        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -105,7 +97,7 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.versions.py }}
+          python-version: ${{ matrix.version }}
           cache: 'pip' # caching pip dependencies
       - run: |
           pip install -r requirements-devel.txt
@@ -242,11 +234,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-report-integration-v3
+      - name: Download coverage integration embedded
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report-integration-embedded
       - name: Codecov
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          files: ./coverage-integration.xml, ./coverage-integration-v3.xml, ./coverage-test.xml, ./coverage-mock_tests.xml
+          files: ./coverage-integration.xml, ./coverage-integration-v3.xml, ./coverage-integration-embedded.xml, ./coverage-test.xml, ./coverage-mock_tests.xml
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -110,8 +110,8 @@ jobs:
       - run: |
           pip install -r requirements-devel.txt
           pip install .
-      - name: Run integration tests without auth secrets (for forks)
-        if: ${{ github.event.pull_request.head.repo.fork }}
+      - name: Run integration tests
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: pytest -v --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage-integration-embedded.xml integration_embedded
       - name: Archive code coverage results
         if: matrix.versions.py == '3.10' && (github.ref_name != 'main')

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,6 +83,43 @@ jobs:
           name: coverage-report-${{ matrix.folder }}
           path: coverage-${{ matrix.folder }}.xml
 
+  integration-tests-embedded:
+    name: Run Integration Tests Embedded
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        versions: [
+          { py: "3.8", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.9", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.10", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.11", weaviate: $NEW_WEAVIATE_VERSION},
+          { py: "3.11", weaviate: $OLD_WEAVIATE_VERSION},
+          { py: "3.12", weaviate: $NEW_WEAVIATE_VERSION}
+        ]
+        optional_dependencies: [false]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.versions.py }}
+          cache: 'pip' # caching pip dependencies
+      - run: |
+          pip install -r requirements-devel.txt
+          pip install .
+      - name: Run integration tests without auth secrets (for forks)
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        run: pytest -v --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage-integration-embedded.xml integration_embedded
+      - name: Archive code coverage results
+        if: matrix.versions.py == '3.10' && (github.ref_name != 'main')
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-integration-embedded
+          path: coverage-integration-embedded.xml
+
   integration-tests-v3:
     name: Run Integration Tests v3
     runs-on: ubuntu-latest
@@ -97,7 +134,6 @@ jobs:
           { py: "3.11", weaviate: $OLD_WEAVIATE_VERSION},
           { py: "3.12", weaviate: $NEW_WEAVIATE_VERSION}
         ]
-
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +184,6 @@ jobs:
           { py: "3.11", weaviate: $OLD_WEAVIATE_VERSION},
           { py: "3.12", weaviate: $NEW_WEAVIATE_VERSION}
         ]
-
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4

--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -451,73 +451,8 @@ def test_client_with_extra_options(timeout: Union[Tuple[int, int], Timeout]) -> 
             auth_credentials=WCS_CREDS,
             additional_config=additional_config,
         ),
-        weaviate.connect_to_embedded(
-            port=8070, grpc_port=50040, additional_config=additional_config
-        ),
     ]:
         assert client._connection.timeout_config == Timeout(query=1, insert=2, init=1)
-
-
-def test_connect_and_close_to_embedded() -> None:
-    # Can't use the default port values as they are already in use by the local instances
-    client = weaviate.connect_to_embedded(port=8078, grpc_port=50151, version="1.23.7")
-
-    client.connect()
-    assert client.is_connected()
-    metadata = client.get_meta()
-    assert "1.23.7" == metadata["version"]
-    assert client.is_ready()
-    assert "8078" == metadata["hostname"].split(":")[2]
-    assert client.is_live()
-
-    client.close()
-    assert not client.is_connected()
-    with pytest.raises(WeaviateClosedClientError):
-        client.get_meta()
-
-
-def test_embedded_as_context_manager() -> None:
-    default_version = "1.23.7"
-    with weaviate.connect_to_embedded(port=8077, grpc_port=50152) as client:
-        assert client.is_connected()
-        metadata = client.get_meta()
-        assert default_version == metadata["version"]
-        assert client.is_ready()
-        assert client.is_live()
-
-    assert not client.is_connected()
-    with pytest.raises(WeaviateClosedClientError):
-        client.get_meta()
-
-
-def test_embedded_with_wrong_version() -> None:
-    with pytest.raises(weaviate.exceptions.WeaviateEmbeddedInvalidVersionError):
-        weaviate.connect_to_embedded(version="this_version_does_not_exist")
-
-
-def test_embedded_already_running() -> None:
-    client = weaviate.connect_to_embedded(port=8096, grpc_port=50155)
-    assert client._connection.embedded_db is not None
-    assert client._connection.embedded_db.process is not None
-
-    with pytest.raises(weaviate.exceptions.WeaviateStartUpError):
-        weaviate.connect_to_embedded(port=8096, grpc_port=50155)
-
-    client.close()
-
-
-def test_embedded_startup_with_blocked_http_port() -> None:
-    client = weaviate.connect_to_embedded(port=8098, grpc_port=50096)
-    with pytest.raises(weaviate.exceptions.WeaviateStartUpError):
-        weaviate.connect_to_embedded(port=8098, grpc_port=50097)
-    client.close()
-
-
-def test_embedded_startup_with_blocked_grpc_port() -> None:
-    client = weaviate.connect_to_embedded(port=8099, grpc_port=50150)
-    with pytest.raises(weaviate.exceptions.WeaviateStartUpError):
-        weaviate.connect_to_embedded(port=8100, grpc_port=50150)
-    client.close()
 
 
 def test_client_error_for_wcs_without_auth() -> None:

--- a/integration_embedded/test_client.py
+++ b/integration_embedded/test_client.py
@@ -1,0 +1,78 @@
+import pytest
+from typing import Tuple, Union
+
+from .. import weaviate
+from weaviate.classes.init import AdditionalConfig, Timeout
+from weaviate.exceptions import WeaviateClosedClientError
+
+
+@pytest.mark.parametrize("timeout", [(1, 2), Timeout(query=1, insert=2, init=1)])
+def test_client_with_extra_options(timeout: Union[Tuple[int, int], Timeout]) -> None:
+    additional_config = AdditionalConfig(timeout=timeout, trust_env=True)
+
+    client = weaviate.connect_to_embedded(
+        port=8070, grpc_port=50040, additional_config=additional_config
+    )
+    assert client._connection.timeout_config == Timeout(query=1, insert=2, init=1)
+
+
+def test_connect_and_close_to_embedded() -> None:
+    # Can't use the default port values as they are already in use by the local instances
+    client = weaviate.connect_to_embedded(port=8078, grpc_port=50151, version="1.23.7")
+
+    client.connect()
+    assert client.is_connected()
+    metadata = client.get_meta()
+    assert "1.23.7" == metadata["version"]
+    assert client.is_ready()
+    assert "8078" == metadata["hostname"].split(":")[2]
+    assert client.is_live()
+
+    client.close()
+    assert not client.is_connected()
+    with pytest.raises(WeaviateClosedClientError):
+        client.get_meta()
+
+
+def test_embedded_as_context_manager() -> None:
+    default_version = "1.23.7"
+    with weaviate.connect_to_embedded(port=8077, grpc_port=50152) as client:
+        assert client.is_connected()
+        metadata = client.get_meta()
+        assert default_version == metadata["version"]
+        assert client.is_ready()
+        assert client.is_live()
+
+    assert not client.is_connected()
+    with pytest.raises(WeaviateClosedClientError):
+        client.get_meta()
+
+
+def test_embedded_with_wrong_version() -> None:
+    with pytest.raises(weaviate.exceptions.WeaviateEmbeddedInvalidVersionError):
+        weaviate.connect_to_embedded(version="this_version_does_not_exist")
+
+
+def test_embedded_already_running() -> None:
+    client = weaviate.connect_to_embedded(port=8096, grpc_port=50155)
+    assert client._connection.embedded_db is not None
+    assert client._connection.embedded_db.process is not None
+
+    with pytest.raises(weaviate.exceptions.WeaviateStartUpError):
+        weaviate.connect_to_embedded(port=8096, grpc_port=50155)
+
+    client.close()
+
+
+def test_embedded_startup_with_blocked_http_port() -> None:
+    client = weaviate.connect_to_embedded(port=8098, grpc_port=50096)
+    with pytest.raises(weaviate.exceptions.WeaviateStartUpError):
+        weaviate.connect_to_embedded(port=8098, grpc_port=50097)
+    client.close()
+
+
+def test_embedded_startup_with_blocked_grpc_port() -> None:
+    client = weaviate.connect_to_embedded(port=8099, grpc_port=50150)
+    with pytest.raises(weaviate.exceptions.WeaviateStartUpError):
+        weaviate.connect_to_embedded(port=8100, grpc_port=50150)
+    client.close()

--- a/integration_embedded/test_client.py
+++ b/integration_embedded/test_client.py
@@ -1,7 +1,7 @@
 import pytest
 from typing import Tuple, Union
 
-from .. import weaviate
+import weaviate
 from weaviate.classes.init import AdditionalConfig, Timeout
 from weaviate.exceptions import WeaviateClosedClientError
 


### PR DESCRIPTION
Moving the embedded integration tests into a separate CI job that runs them sequentially avoids competition for resources and reduces flakiness