### PR TITLE
Fix node handling for shards when shards: null.

### DIFF
--- a/integration/test_client.py
+++ b/integration/test_client.py
@@ -332,6 +332,18 @@ def test_client_cluster(client: weaviate.WeaviateClient, request: SubRequest) ->
     assert nodes[0].shards[0].collection == collection.name
 
 
+def test_client_cluster_multitenant(client: weaviate.WeaviateClient, request: SubRequest) -> None:
+    client.collections.delete(request.node.name)
+    collection = client.collections.create(
+        name=request.node.name,
+        multi_tenancy_config=Configure.multi_tenancy(enabled=True),
+    )
+
+    nodes = client.cluster.nodes(collection.name, output="verbose")
+    assert len(nodes) == 1
+    assert len(nodes[0].shards) == 0
+
+
 def test_client_cluster_minimal(client: weaviate.WeaviateClient, request: SubRequest) -> None:
     client.collections.delete(request.node.name)
     collection = client.collections.create(name=request.node.name)

--- a/weaviate/collections/classes/cluster.py
+++ b/weaviate/collections/classes/cluster.py
@@ -56,7 +56,7 @@ class _ConvertFromREST:
                         )
                         for shard in cast(List[ShardREST], node["shards"])
                     ]
-                    if "shards" in node
+                    if "shards" in node and node["shards"] is not None
                     else []
                 ),
                 stats=(


### PR DESCRIPTION
Currently, when no shards are present on a node, Weaviate returns shards: null, however the python-client code expects the shards option to include a list of shards or not appear at all if there is no shard information for that node.

fixes: gh-989