### PR TITLE
DX/Update connection error msgs

### DIFF
--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -244,7 +244,7 @@ class _Connection(_ConnectionBase):
                 response = client.get(oidc_url)
             except Exception as e:
                 raise WeaviateConnectionError(
-                    f"Error: {e}. Is Weaviate running and reachable at {self.url}?"
+                    f"Error: {e}. \nIs Weaviate running and reachable at {self.url}?"
                 )
 
         if response.status_code == 200:

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -243,7 +243,9 @@ class _Connection(_ConnectionBase):
             try:
                 response = client.get(oidc_url)
             except Exception as e:
-                raise WeaviateConnectionError(f"Error: {e}. Is Weaviate running and reachable at {self.url}?")
+                raise WeaviateConnectionError(
+                    f"Error: {e}. Is Weaviate running and reachable at {self.url}?"
+                )
 
         if response.status_code == 200:
             # Some setups are behind proxies that return some default page - for example a login - for all requests.
@@ -651,9 +653,13 @@ class ConnectionV4(_Connection):
                 response_deserializer=health_pb2.HealthCheckResponse.FromString,
             )(health_pb2.HealthCheckRequest(), timeout=self.timeout_config.init)
             if res.status != health_pb2.HealthCheckResponse.SERVING:
-                raise WeaviateGRPCUnavailableError(f"v{self.server_version}", self._connection_params._grpc_address)
+                raise WeaviateGRPCUnavailableError(
+                    f"v{self.server_version}", self._connection_params._grpc_address
+                )
         except _channel._InactiveRpcError as e:
-            raise WeaviateGRPCUnavailableError(f"v{self.server_version}", self._connection_params._grpc_address) from e
+            raise WeaviateGRPCUnavailableError(
+                f"v{self.server_version}", self._connection_params._grpc_address
+            ) from e
 
     def connect(self, skip_init_checks: bool) -> None:
         super().connect(skip_init_checks)

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -240,7 +240,11 @@ class _Connection(_ConnectionBase):
 
         oidc_url = self.url + self._api_version_path + "/.well-known/openid-configuration"
         with self.__make_sync_client() as client:
-            response = client.get(oidc_url)
+            try:
+                response = client.get(oidc_url)
+            except Exception as e:
+                raise WeaviateConnectionError(f"Error: {e}. Is Weaviate running and reachable at {self.url}?")
+
         if response.status_code == 200:
             # Some setups are behind proxies that return some default page - for example a login - for all requests.
             # If the response is not json, we assume that this is the case and try unauthenticated access. Any auth
@@ -647,9 +651,9 @@ class ConnectionV4(_Connection):
                 response_deserializer=health_pb2.HealthCheckResponse.FromString,
             )(health_pb2.HealthCheckRequest(), timeout=self.timeout_config.init)
             if res.status != health_pb2.HealthCheckResponse.SERVING:
-                raise WeaviateGRPCUnavailableError(f"v{self.server_version}")
+                raise WeaviateGRPCUnavailableError(f"v{self.server_version}", self._connection_params._grpc_address)
         except _channel._InactiveRpcError as e:
-            raise WeaviateGRPCUnavailableError(f"v{self.server_version}") from e
+            raise WeaviateGRPCUnavailableError(f"v{self.server_version}", self._connection_params._grpc_address) from e
 
     def connect(self, skip_init_checks: bool) -> None:
         super().connect(skip_init_checks)

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -280,9 +280,10 @@ class WeaviateGRPCUnavailableError(WeaviateBaseError):
         else:
             grpc_msg = f"Please check that the server address and port ({grpc_address[0]}:{grpc_address[1]}) are correct."
         msg = f"""
-The gRPC health check against Weaviate could not be completed.
 Weaviate {weaviate_version} makes use of a high-speed gRPC API as well as a REST API.
-This could be due to one of several reasons:
+Unfortunately, the gRPC health check against Weaviate could not be completed.
+
+This error could be due to one of several reasons:
 - The gRPC traffic at the specified port is blocked by a firewall.
 - gRPC is not enabled or incorrectly configured on the server or the client.
     - {grpc_msg}

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -273,15 +273,19 @@ class WeaviateGRPCUnavailableError(WeaviateBaseError):
     """Is raised when a gRPC-backed query is made with no gRPC connection present."""
 
     def __init__(
-        self, weaviate_version: str = "", grpc_address: Tuple[str, str] = ("", "")
+        self, weaviate_version: str = "", grpc_address: Tuple[str, int] = ("not provided", 0)
     ) -> None:
+        if grpc_address[0] == "not provided":
+            grpc_msg = "Please check the server address and port."
+        else:
+            grpc_msg = f"Please check that the server address and port ({grpc_address[0]}:{grpc_address[1]}) are correct."
         msg = f"""
-The gRPC health check against Weaviate at {grpc_address[0]}:{grpc_address[1]} could not be completed.
+The gRPC health check against Weaviate could not be completed.
 Weaviate {weaviate_version} makes use of a high-speed gRPC API as well as a REST API.
 This could be due to one of several reasons:
 - The gRPC traffic at the specified port is blocked by a firewall.
 - gRPC is not enabled or incorrectly configured on the server or the client.
-    - Please check the server address and port, currently set to {grpc_address[0]}:{grpc_address[1]}.
+    - {grpc_msg}
 - your connection is unstable or has a high latency. In this case you can:
     - increase init-timeout in `weaviate.connect_to_local(additional_config=wvc.init.AdditionalConfig(timeout=wvc.init.Timeout(init=X)))`
     - disable startup checks by connecting using `skip_init_checks=True`

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -272,13 +272,18 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
 class WeaviateGRPCUnavailableError(WeaviateBaseError):
     """Is raised when a gRPC-backed query is made with no gRPC connection present."""
 
-    def __init__(self, weaviate_version: str = "") -> None:
-        msg = f"""gRPC health check could not be completed. This could have several reasons:
-        - gRPC is not enabled or incorrectly configured on the server with version {weaviate_version} or the client
-        - your connection is unstable or has a high latency. In this case you can:
-            - increase init-timeout in `weaviate.connect_to_local(additional_config=wvc.init.AdditionalConfig(timeout=wvc.init.Timeout(init=X)))`
-            - disable startup checks by connecting using `skip_init_checks=True`
-        """
+    def __init__(self, weaviate_version: str = "", grpc_address = ("", "")) -> None:
+        msg = f"""
+The gRPC health check against Weaviate at {grpc_address[0]}:{grpc_address[1]} could not be completed.
+Weaviate {weaviate_version} makes use of a high-speed gRPC API as well as a REST API.
+This could be due to one of several reasons:
+- The gRPC traffic at the specified port is blocked by a firewall.
+- gRPC is not enabled or incorrectly configured on the server or the client.
+    - Please check the server address and port, currently set to {grpc_address[0]}:{grpc_address[1]}.
+- your connection is unstable or has a high latency. In this case you can:
+    - increase init-timeout in `weaviate.connect_to_local(additional_config=wvc.init.AdditionalConfig(timeout=wvc.init.Timeout(init=X)))`
+    - disable startup checks by connecting using `skip_init_checks=True`
+"""
         super().__init__(msg)
 
 

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -272,7 +272,7 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
 class WeaviateGRPCUnavailableError(WeaviateBaseError):
     """Is raised when a gRPC-backed query is made with no gRPC connection present."""
 
-    def __init__(self, weaviate_version: str = "", grpc_address = ("", "")) -> None:
+    def __init__(self, weaviate_version: str = "", grpc_address=("", "")) -> None:
         msg = f"""
 The gRPC health check against Weaviate at {grpc_address[0]}:{grpc_address[1]} could not be completed.
 Weaviate {weaviate_version} makes use of a high-speed gRPC API as well as a REST API.

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -3,7 +3,7 @@ Weaviate Exceptions.
 """
 
 from json.decoder import JSONDecodeError
-from typing import Union
+from typing import Union, Tuple
 import httpx
 import requests
 
@@ -272,7 +272,7 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
 class WeaviateGRPCUnavailableError(WeaviateBaseError):
     """Is raised when a gRPC-backed query is made with no gRPC connection present."""
 
-    def __init__(self, weaviate_version: str = "", grpc_address=("", "")) -> None:
+    def __init__(self, weaviate_version: str = "", grpc_address: Tuple[str, str]=("", "")) -> None:
         msg = f"""
 The gRPC health check against Weaviate at {grpc_address[0]}:{grpc_address[1]} could not be completed.
 Weaviate {weaviate_version} makes use of a high-speed gRPC API as well as a REST API.

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -272,7 +272,7 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
 class WeaviateGRPCUnavailableError(WeaviateBaseError):
     """Is raised when a gRPC-backed query is made with no gRPC connection present."""
 
-    def __init__(self, weaviate_version: str = "", grpc_address: Tuple[str, str]=("", "")) -> None:
+    def __init__(self, weaviate_version: str = "", grpc_address: Tuple[str, str] = ("", "")) -> None:
         msg = f"""
 The gRPC health check against Weaviate at {grpc_address[0]}:{grpc_address[1]} could not be completed.
 Weaviate {weaviate_version} makes use of a high-speed gRPC API as well as a REST API.

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -272,7 +272,9 @@ class WeaviateInsertInvalidPropertyError(WeaviateBaseError):
 class WeaviateGRPCUnavailableError(WeaviateBaseError):
     """Is raised when a gRPC-backed query is made with no gRPC connection present."""
 
-    def __init__(self, weaviate_version: str = "", grpc_address: Tuple[str, str] = ("", "")) -> None:
+    def __init__(
+        self, weaviate_version: str = "", grpc_address: Tuple[str, str] = ("", "")
+    ) -> None:
         msg = f"""
 The gRPC health check against Weaviate at {grpc_address[0]}:{grpc_address[1]} could not be completed.
 Weaviate {weaviate_version} makes use of a high-speed gRPC API as well as a REST API.


### PR DESCRIPTION
This PR updates error messages for:
- The start-up REST connection error, which can occur at startup as the client checks for OIDC details 
    - By asking whether Weaviate is running and reachable at {self.url}.
    - (at https://github.com/weaviate/weaviate-python-client/blob/dx/update-connection-error-msgs/weaviate/connect/v4.py#L241 `oidc_url = self.url + self._api_version_path + "/.well-known/openid-configuration"`)
- gRPC health check errors, by
    - Distinguishing gRPC & REST connections for the user
    - Including the gRPC url/port in the error message & suggesting the user check those
    - Suggest whether there may be a firewall