### PR TITLE
relax httpx requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ platforms = any
 include_package_data = True
 install_requires =
     requests>=2.30.0,<3.0.0
-    httpx>=0.27.0
+    httpx>=0.26.0
     validators==0.28.1
     authlib>=1.2.1,<2.0.0
     pydantic>=2.5.0,<3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ platforms = any
 include_package_data = True
 install_requires =
     requests>=2.30.0,<3.0.0
-    httpx==0.27.0
+    httpx>=0.27.0
     validators==0.28.1
     authlib>=1.2.1,<2.0.0
     pydantic>=2.5.0,<3.0.0


### PR DESCRIPTION
The current setup.cfg file requires a very specific version of httpx, httpx==0.27.0. That requirement is to harsh for most projects where various packages are used, making it difficult to resolve dependnecies.