### PR TITLE
Fix typo in m2v method parameters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -75,7 +75,7 @@ This patch version includes:
 - Support for new modules in Weaviate 1.24.2:
   - ``text2vec-voyageai``
   - ``generative-mistral``
-  - Support new parameters for interference URLs in ``text2vec-transformers`` and ``multi2vec-clip``
+  - Support new parameters for inference URLs in ``text2vec-transformers`` and ``multi2vec-clip``
 - Support for new modules in Weaviate 1.24.3:
   - ``multi2vec-palm``
 

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Literal, Optional, Union
+import warnings
 
 from pydantic import AnyHttpUrl, Field
 
@@ -415,6 +416,7 @@ class _NamedVectors:
         vectorize_collection_name: bool = True,
         image_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
         text_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
+        interference_url: Optional[str] = None,
         inference_url: Optional[str] = None,
     ) -> _NamedVectorConfigCreate:
         """Create a named vector using the `multi2vec_clip` model.
@@ -436,6 +438,18 @@ class _NamedVectors:
             `inference_url`
                 The inference url to use where API requests should go. Defaults to `None`, which uses the server-defined default.
         """
+        if interference_url is not None:
+            if inference_url is not None:
+                raise ValueError(
+                    "You have provided `interference_url` as well as `inference_url`. Please only provide `inference_url`, as `interference_url` is deprecated."
+                )
+            else:
+                warnings.warn(
+                    message="""This parameter is deprecated and will be removed in a future release. Please use `inference_url` instead.""",
+                    category=DeprecationWarning,
+                    stacklevel=1,
+                )
+
         return _NamedVectorConfigCreate(
             name=name,
             vectorizer=_Multi2VecClipConfigCreate(

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -415,7 +415,7 @@ class _NamedVectors:
         vectorize_collection_name: bool = True,
         image_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
         text_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
-        interference_url: Optional[str] = None,
+        inference_url: Optional[str] = None,
     ) -> _NamedVectorConfigCreate:
         """Create a named vector using the `multi2vec_clip` model.
 
@@ -442,7 +442,7 @@ class _NamedVectors:
                 imageFields=_map_multi2vec_fields(image_fields),
                 textFields=_map_multi2vec_fields(text_fields),
                 vectorizeClassName=vectorize_collection_name,
-                inferenceUrl=interference_url,
+                inferenceUrl=inference_url,
             ),
             vector_index_config=vector_index_config,
         )

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union, cast
+import warnings
 
 from pydantic import AnyHttpUrl, BaseModel, Field, field_validator
 from typing_extensions import TypeAlias
@@ -455,6 +456,7 @@ class _Vectorizer:
     def multi2vec_clip(
         image_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
         text_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
+        interference_url: Optional[str] = None,
         inference_url: Optional[str] = None,
         vectorize_collection_name: bool = True,
     ) -> _VectorizerConfigCreate:
@@ -476,6 +478,18 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `image_fields` or `text_fields` are not `None` or a `list`.
         """
+        if interference_url is not None:
+            if inference_url is not None:
+                raise ValueError(
+                    "You have provided `interference_url` as well as `inference_url`. Please only provide `inference_url`, as `interference_url` is deprecated."
+                )
+            else:
+                warnings.warn(
+                    message="""This parameter is deprecated and will be removed in a future release. Please use `inference_url` instead.""",
+                    category=DeprecationWarning,
+                    stacklevel=1,
+                )
+
         return _Multi2VecClipConfigCreate(
             imageFields=_map_multi2vec_fields(image_fields),
             textFields=_map_multi2vec_fields(text_fields),

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -455,7 +455,7 @@ class _Vectorizer:
     def multi2vec_clip(
         image_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
         text_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
-        interference_url: Optional[str] = None,
+        inference_url: Optional[str] = None,
         vectorize_collection_name: bool = True,
     ) -> _VectorizerConfigCreate:
         """Create a `_Multi2VecClipConfigCreate` object for use when vectorizing using the `multi2vec-clip` model.
@@ -480,7 +480,7 @@ class _Vectorizer:
             imageFields=_map_multi2vec_fields(image_fields),
             textFields=_map_multi2vec_fields(text_fields),
             vectorizeClassName=vectorize_collection_name,
-            inferenceUrl=interference_url,
+            inferenceUrl=inference_url,
         )
 
     @staticmethod


### PR DESCRIPTION
Some parameters included typos `interference` where it should be `inference`.