### PR TITLE
Add option to loop through input vectors and convert their entries to `float`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ on:
 env:
   WEAVIATE_123: 1.23.14
   WEAVIATE_124: 1.24.10
-  WEAVIATE_125: preview--grpc-clean-up-target-vectors-in-hybrid-30c49be
+  WEAVIATE_125: 1.25.1
 
 
 jobs:

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -627,10 +627,12 @@ class _BatchBase:
         uuid: Optional[UUID] = None,
         vector: Optional[VECTORS] = None,
         tenant: Optional[str] = None,
+        convert_vector_data_type: bool = False,
     ) -> UUID:
         self.__check_bg_thread_alive()
         try:
             batch_object = BatchObject(
+                convert_vector_data_type=convert_vector_data_type,
                 collection=collection,
                 properties=properties,
                 references=references,

--- a/weaviate/collections/batch/client.py
+++ b/weaviate/collections/batch/client.py
@@ -35,6 +35,7 @@ class _BatchClient(_BatchBase):
         uuid: Optional[UUID] = None,
         vector: Optional[VECTORS] = None,
         tenant: Optional[Union[str, Tenant]] = None,
+        convert_vector_data_type: bool = False,
     ) -> UUID:
         """
         Add one object to this batch.
@@ -61,6 +62,9 @@ class _BatchClient(_BatchBase):
                 - for named vectors: Dict[str, *list above*], where the string is the name of the vector.
             `tenant`
                 The tenant name or Tenant object to be used for this request.
+            `convert_vector_data_type`
+                Whether to convert the data types of the object vectors to the one supported by Weaviate. If set to `True`, the client will loop through
+                the vectors converting the internal data type to float. This will have a significant impact on performance for large vectors.
 
         Returns:
             `str`
@@ -77,6 +81,7 @@ class _BatchClient(_BatchBase):
             uuid=uuid,
             vector=vector,
             tenant=tenant.name if isinstance(tenant, Tenant) else tenant,
+            convert_vector_data_type=convert_vector_data_type,
         )
 
     def add_reference(

--- a/weaviate/collections/batch/collection.py
+++ b/weaviate/collections/batch/collection.py
@@ -47,6 +47,7 @@ class _BatchCollection(Generic[Properties], _BatchBase):
         references: Optional[ReferenceInputs] = None,
         uuid: Optional[UUID] = None,
         vector: Optional[VECTORS] = None,
+        convert_vector_data_type: bool = False,
     ) -> UUID:
         """Add one object to this batch.
 
@@ -57,16 +58,18 @@ class _BatchCollection(Generic[Properties], _BatchBase):
                 The data properties of the object to be added as a dictionary.
             `references`
                 The references of the object to be added as a dictionary.
-            `uuid`:
+            `uuid`
                 The UUID of the object as an uuid.UUID object or str. If it is None an UUIDv4 will generated, by default None
-            `vector`:
+            `vector`
                 The embedding of the object. Can be used when a collection does not have a vectorization module or the given
-                vector was generated using the _identical_ vectorization module that is configured for the class. In this
+                vector was generated using the *identical* vectorization module that is configured for the class. In this
                 case this vector takes precedence.
-                Supported types are
-                - for single vectors: `list`, 'numpy.ndarray`, `torch.Tensor` and `tf.Tensor`, by default None.
-                - for named vectors: Dict[str, *list above*], where the string is the name of the vector.
-
+                    Supported types are:
+                        for single vectors: `list`, `numpy.ndarray`, `torch.Tensor` and `tf.Tensor`, by default None.
+                        for named vectors: `Dict[str, *list above*]`, where the string is the name of the vector.
+            `convert_vector_data_type`
+                Whether to convert the data types of the object vectors to the one supported by Weaviate. If set to `True`, the client will loop through
+                the vectors converting the internal data type to float. This will have a significant impact on performance for large vectors.
         Returns:
             `str`
                 The UUID of the added object. If one was not provided a UUIDv4 will be auto-generated for you and returned here.
@@ -82,6 +85,7 @@ class _BatchCollection(Generic[Properties], _BatchBase):
             uuid=uuid,
             vector=vector,
             tenant=self.__tenant,
+            convert_vector_data_type=convert_vector_data_type,
         )
 
     def add_reference(

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -48,15 +48,15 @@ class _BatchGRPC(_BaseGRPC):
         super().__init__(connection, consistency_level)
 
     def __grpc_objects(self, objects: List[_BatchObject]) -> List[batch_pb2.BatchObject]:
-        def pack_vector(vector: Any) -> bytes:
-            vector_list = _get_vector_v4(vector)
-            return struct.pack("{}f".format(len(vector_list)), *vector_list)
+        def pack_vector(vector: List[float], parse_dtype: bool) -> bytes:
+            vec = _get_vector_v4(vector, parse_dtype)
+            return struct.pack("{}f".format(len(vec)), *vec)
 
         return [
             batch_pb2.BatchObject(
                 collection=obj.collection,
                 vector_bytes=(
-                    pack_vector(obj.vector)
+                    pack_vector(obj.vector, obj.convert_vector_data_type)
                     if obj.vector is not None and isinstance(obj.vector, list)
                     else None
                 ),

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -19,6 +19,7 @@ class _BatchObject:
     tenant: Optional[str]
     references: Optional[ReferenceInputs]
     retry_count: int = 0
+    convert_vector_data_type: bool = False
 
 
 @dataclass
@@ -43,16 +44,18 @@ class BatchObject(BaseModel):
     uuid: Optional[UUID] = Field(default=None)
     vector: Optional[VECTORS] = Field(default=None)
     tenant: Optional[str] = Field(default=None)
+    convert_vector_data_type: bool = Field(default=False)
 
     def __init__(self, **data: Any) -> None:
         v = data.get("vector")
+        parse_dtype = cast(bool, data.get("convert_vector_data_type")) or False
         if v is not None:
             if isinstance(v, dict):  # named vector
                 for key, val in v.items():
-                    v[key] = _get_vector_v4(val)
+                    v[key] = _get_vector_v4(val, parse_dtype)
                 data["vector"] = v
             else:
-                data["vector"] = _get_vector_v4(v)
+                data["vector"] = _get_vector_v4(v, parse_dtype)
 
         data["uuid"] = (
             get_valid_uuid(u) if (u := data.get("uuid")) is not None else uuid_package.uuid4()
@@ -67,6 +70,7 @@ class BatchObject(BaseModel):
             properties=self.properties,
             tenant=self.tenant,
             references=self.references,
+            convert_vector_data_type=self.convert_vector_data_type,
         )
 
     @field_validator("collection")

--- a/weaviate/collections/grpc/query.py
+++ b/weaviate/collections/grpc/query.py
@@ -314,7 +314,7 @@ class _QueryGRPC(_BaseGRPC):
                 ]
             )
 
-        near_vector = _get_vector_v4(near_vector)
+        near_vector = _get_vector_v4(near_vector, False)
         certainty, distance = self.__parse_near_options(certainty, distance)
 
         request = self.__create_request(

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -414,7 +414,7 @@ def get_valid_uuid(uuid: Union[str, uuid_lib.UUID]) -> str:
     return _uuid
 
 
-def get_vector(vector: Sequence) -> List[float]:
+def get_vector(vector: Sequence) -> list:
     """
     Get weaviate compatible format of the embedding vector.
 
@@ -459,9 +459,12 @@ def get_vector(vector: Sequence) -> List[float]:
     ) from None
 
 
-def _get_vector_v4(vector: Sequence) -> List[float]:
+def _get_vector_v4(vector: Sequence, parse_dtype: bool) -> List[float]:
     try:
-        return get_vector(vector)
+        vec = get_vector(vector)
+        if parse_dtype:
+            return [float(entry) for entry in vec]
+        return vec
     except TypeError as e:
         raise WeaviateInvalidInputError(
             f"The vector you supplied was malformatted! Vector:  {vector}"


### PR DESCRIPTION
Enhances the client with an optional `bool` to set if users want the client to automatically convert their inputted vectors to `List[float]` for them. Due to the performance penalty associated with such an operation, its value is set to `False` by default. [Relevant SO question](https://stackoverflow.com/questions/78503685/cant-use-my-own-vectors-in-bring-your-own-vectors-in-weaviate-it-defaults-to-se/78503789#78503789)