### PR TITLE
Export submodules to ease usage of `weaviate.outputs`

### DIFF
--- a/weaviate/collections/classes/cluster.py
+++ b/weaviate/collections/classes/cluster.py
@@ -73,7 +73,10 @@ class _ConvertFromREST:
                         shard_count=node["stats"]["shardCount"],
                     )
                     if "stats" in node
-                    else []
+                    else Stats(
+                        object_count=0,
+                        shard_count=0,
+                    )
                 ),
                 status=node["status"],
                 version=node["version"],

--- a/weaviate/collections/grpc/query.py
+++ b/weaviate/collections/grpc/query.py
@@ -118,7 +118,7 @@ class _QueryGRPC(_BaseGRPC):
             _validate_input(_ValidateArgument([_Sorting, None], "sort", sort))
 
         if sort is not None:
-            sort_by: grpc.RepeatedCompositeFieldContainer[search_get_pb2.SortBy] = [
+            sort_by = [
                 search_get_pb2.SortBy(ascending=sort.ascending, path=[sort.prop])
                 for sort in sort.sorts
             ]

--- a/weaviate/conftest.py
+++ b/weaviate/conftest.py
@@ -10,4 +10,4 @@ class MyScheduler(LoadScopeScheduling):
 
 
 def pytest_xdist_make_scheduler(config: object, log: object) -> MyScheduler:
-    return MyScheduler(config, log)
+    return MyScheduler(config, log)  # pyright: ignore

--- a/weaviate/outputs/__init__.py
+++ b/weaviate/outputs/__init__.py
@@ -1,0 +1,3 @@
+from . import aggregate, backup, batch, cluster, config, data, query, tenants
+
+__all__ = ["aggregate", "backup", "batch", "cluster", "config", "data", "query", "tenants"]


### PR DESCRIPTION
- Also required were a number of seemingly irrelevant pyright fixes due to change in version number on `main`