### PR TITLE
Adds support for enabling and disabling async replication in schema

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ env:
   WEAVIATE_123: 1.23.14
   WEAVIATE_124: 1.24.10
   WEAVIATE_125: 1.25.5
-  WEAVIATE_126: 1.26.0-preview0-b97790d
+  WEAVIATE_126: "1.26.0-preview0-b97790d"
   INTEGRATION_TEST_VERSIONS: [
     { py: "3.8", weaviate: $WEAVIATE_126},
     { py: "3.9", weaviate: $WEAVIATE_126},

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,16 +18,6 @@ env:
   WEAVIATE_124: 1.24.10
   WEAVIATE_125: 1.25.5
   WEAVIATE_126: 1.26.0-preview0-b97790d
-  INTEGRATION_TEST_VERSIONS: [
-    { py: "3.8", weaviate: $WEAVIATE_126},
-    { py: "3.9", weaviate: $WEAVIATE_126},
-    { py: "3.10", weaviate: $WEAVIATE_126},
-    { py: "3.11", weaviate: $WEAVIATE_123},
-    { py: "3.11", weaviate: $WEAVIATE_124},
-    { py: "3.11", weaviate: $WEAVIATE_125},
-    { py: "3.11", weaviate: $WEAVIATE_126},
-    { py: "3.12", weaviate: $WEAVIATE_126}
-  ]
 
 
 jobs:
@@ -131,7 +121,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: $INTEGRATION_TEST_VERSIONS
+        versions: [
+          { py: "3.8", weaviate: $WEAVIATE_126},
+          { py: "3.9", weaviate: $WEAVIATE_126},
+          { py: "3.10", weaviate: $WEAVIATE_126},
+          { py: "3.11", weaviate: $WEAVIATE_123},
+          { py: "3.11", weaviate: $WEAVIATE_124},
+          { py: "3.11", weaviate: $WEAVIATE_125},
+          { py: "3.11", weaviate: $WEAVIATE_126},
+          { py: "3.12", weaviate: $WEAVIATE_126}
+        ]
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -174,7 +173,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: $INTEGRATION_TEST_VERSIONS
+        versions: [
+          { py: "3.8", weaviate: $WEAVIATE_126},
+          { py: "3.9", weaviate: $WEAVIATE_126},
+          { py: "3.10", weaviate: $WEAVIATE_126},
+          { py: "3.11", weaviate: $WEAVIATE_123},
+          { py: "3.11", weaviate: $WEAVIATE_124},
+          { py: "3.11", weaviate: $WEAVIATE_125},
+          { py: "3.11", weaviate: $WEAVIATE_126},
+          { py: "3.12", weaviate: $WEAVIATE_126}
+        ]
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,18 @@ on:
 env:
   WEAVIATE_123: 1.23.14
   WEAVIATE_124: 1.24.10
-  WEAVIATE_125: preview--c57fecf
+  WEAVIATE_125: 1.25.5
+  WEAVIATE_126: 1.26.0-preview0-b97790d
+  INTEGRATION_TEST_VERSIONS: [
+    { py: "3.8", weaviate: $WEAVIATE_126},
+    { py: "3.9", weaviate: $WEAVIATE_126},
+    { py: "3.10", weaviate: $WEAVIATE_126},
+    { py: "3.11", weaviate: $WEAVIATE_123},
+    { py: "3.11", weaviate: $WEAVIATE_124},
+    { py: "3.11", weaviate: $WEAVIATE_125},
+    { py: "3.11", weaviate: $WEAVIATE_126}
+    { py: "3.12", weaviate: $WEAVIATE_126}
+  ]
 
 
 jobs:
@@ -120,15 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: [
-          { py: "3.8", weaviate: $WEAVIATE_125},
-          { py: "3.9", weaviate: $WEAVIATE_125},
-          { py: "3.10", weaviate: $WEAVIATE_125},
-          { py: "3.11", weaviate: $WEAVIATE_123},
-          { py: "3.11", weaviate: $WEAVIATE_124},
-          { py: "3.11", weaviate: $WEAVIATE_125},
-          { py: "3.12", weaviate: $WEAVIATE_125}
-        ]
+        versions: $INTEGRATION_TEST_VERSIONS
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -171,15 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: [
-          { py: "3.8", weaviate: $WEAVIATE_125},
-          { py: "3.9", weaviate: $WEAVIATE_125},
-          { py: "3.10", weaviate: $WEAVIATE_125},
-          { py: "3.11", weaviate: $WEAVIATE_123},
-          { py: "3.11", weaviate: $WEAVIATE_124},
-          { py: "3.11", weaviate: $WEAVIATE_125},
-          { py: "3.12", weaviate: $WEAVIATE_125}
-        ]
+        versions: $INTEGRATION_TEST_VERSIONS
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -284,7 +279,8 @@ jobs:
         server: [
           $WEAVIATE_123,
           $WEAVIATE_124,
-          $WEAVIATE_125
+          $WEAVIATE_125,
+          $WEAVIATE_126
         ]
     steps:
       - name: Download build artifact to append to release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ env:
   WEAVIATE_123: 1.23.15
   WEAVIATE_124: 1.24.19
   WEAVIATE_125: 1.25.5
-  WEAVIATE_126: 1.26.0-preview0-b97790d
+  WEAVIATE_126: preview-replace-if-targetvectors-nil-with-if-vectorsearch-when-extracting-metadata-certainty-ea8d536
 
 
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,16 @@ env:
   WEAVIATE_124: 1.24.10
   WEAVIATE_125: 1.25.5
   WEAVIATE_126: 1.26.0-preview0-b97790d
+  INTEGRATION_TEST_VERSIONS: [
+    { py: "3.8", weaviate: $WEAVIATE_126},
+    { py: "3.9", weaviate: $WEAVIATE_126},
+    { py: "3.10", weaviate: $WEAVIATE_126},
+    { py: "3.11", weaviate: $WEAVIATE_123},
+    { py: "3.11", weaviate: $WEAVIATE_124},
+    { py: "3.11", weaviate: $WEAVIATE_125},
+    { py: "3.11", weaviate: $WEAVIATE_126},
+    { py: "3.12", weaviate: $WEAVIATE_126}
+  ]
 
 
 jobs:
@@ -121,16 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: [
-          { py: "3.8", weaviate: $WEAVIATE_126},
-          { py: "3.9", weaviate: $WEAVIATE_126},
-          { py: "3.10", weaviate: $WEAVIATE_126},
-          { py: "3.11", weaviate: $WEAVIATE_123},
-          { py: "3.11", weaviate: $WEAVIATE_124},
-          { py: "3.11", weaviate: $WEAVIATE_125},
-          { py: "3.11", weaviate: $WEAVIATE_126}
-          { py: "3.12", weaviate: $WEAVIATE_126}
-        ]
+        versions: $INTEGRATION_TEST_VERSIONS
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -173,16 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: [
-          { py: "3.8", weaviate: $WEAVIATE_126},
-          { py: "3.9", weaviate: $WEAVIATE_126},
-          { py: "3.10", weaviate: $WEAVIATE_126},
-          { py: "3.11", weaviate: $WEAVIATE_123},
-          { py: "3.11", weaviate: $WEAVIATE_124},
-          { py: "3.11", weaviate: $WEAVIATE_125},
-          { py: "3.11", weaviate: $WEAVIATE_126}
-          { py: "3.12", weaviate: $WEAVIATE_126}
-        ]
+        versions: $INTEGRATION_TEST_VERSIONS
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,17 +17,7 @@ env:
   WEAVIATE_123: 1.23.14
   WEAVIATE_124: 1.24.10
   WEAVIATE_125: 1.25.5
-  WEAVIATE_126: "1.26.0-preview0-b97790d"
-  INTEGRATION_TEST_VERSIONS: [
-    { py: "3.8", weaviate: $WEAVIATE_126},
-    { py: "3.9", weaviate: $WEAVIATE_126},
-    { py: "3.10", weaviate: $WEAVIATE_126},
-    { py: "3.11", weaviate: $WEAVIATE_123},
-    { py: "3.11", weaviate: $WEAVIATE_124},
-    { py: "3.11", weaviate: $WEAVIATE_125},
-    { py: "3.11", weaviate: $WEAVIATE_126}
-    { py: "3.12", weaviate: $WEAVIATE_126}
-  ]
+  WEAVIATE_126: 1.26.0-preview0-b97790d
 
 
 jobs:
@@ -131,7 +121,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: $INTEGRATION_TEST_VERSIONS
+        versions: [
+          { py: "3.8", weaviate: $WEAVIATE_126},
+          { py: "3.9", weaviate: $WEAVIATE_126},
+          { py: "3.10", weaviate: $WEAVIATE_126},
+          { py: "3.11", weaviate: $WEAVIATE_123},
+          { py: "3.11", weaviate: $WEAVIATE_124},
+          { py: "3.11", weaviate: $WEAVIATE_125},
+          { py: "3.11", weaviate: $WEAVIATE_126}
+          { py: "3.12", weaviate: $WEAVIATE_126}
+        ]
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -174,7 +173,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        versions: $INTEGRATION_TEST_VERSIONS
+        versions: [
+          { py: "3.8", weaviate: $WEAVIATE_126},
+          { py: "3.9", weaviate: $WEAVIATE_126},
+          { py: "3.10", weaviate: $WEAVIATE_126},
+          { py: "3.11", weaviate: $WEAVIATE_123},
+          { py: "3.11", weaviate: $WEAVIATE_124},
+          { py: "3.11", weaviate: $WEAVIATE_125},
+          { py: "3.11", weaviate: $WEAVIATE_126}
+          { py: "3.12", weaviate: $WEAVIATE_126}
+        ]
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ env:
   WEAVIATE_123: 1.23.15
   WEAVIATE_124: 1.24.19
   WEAVIATE_125: 1.25.5
-  WEAVIATE_126: preview-replace-if-targetvectors-nil-with-if-vectorsearch-when-extracting-metadata-certainty-ea8d536
+  WEAVIATE_126: 1.26.0-preview0-87c34a9
 
 
 jobs:

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -400,7 +400,9 @@ def test_collection_config_update(collection_factory: CollectionFactory) -> None
 
     config = collection.config.get()
 
-    if collection._connection._weaviate_version.is_at_least(1, 25, 2):
+    if collection._connection._weaviate_version.is_at_least(
+        1, 25, 2
+    ) or collection._connection._weaviate_version.is_lower_than(1, 25, 0):
         assert config.description == "Test"
     else:
         assert config.description is None
@@ -459,7 +461,9 @@ def test_collection_config_update(collection_factory: CollectionFactory) -> None
     )
     config = collection.config.get()
 
-    if collection._connection._weaviate_version.is_at_least(1, 25, 2):
+    if collection._connection._weaviate_version.is_at_least(
+        1, 25, 2
+    ) or collection._connection._weaviate_version.is_lower_than(1, 25, 0):
         assert config.description == "Test"
     else:
         assert config.description is None

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -136,6 +136,7 @@ def test_collection_config_empty(collection_factory: CollectionFactory) -> None:
     assert config.multi_tenancy_config.enabled is False
 
     assert config.replication_config.factor == 1
+    assert config.replication_config.async_enabled is False
 
     assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
     assert config.vector_index_config.cleanup_interval_seconds == 300
@@ -189,6 +190,7 @@ def test_collection_config_defaults(collection_factory: CollectionFactory) -> No
     assert config.multi_tenancy_config.enabled is True
 
     assert config.replication_config.factor == 1
+    assert config.replication_config.async_enabled is False
 
     assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
     assert config.vector_index_config.cleanup_interval_seconds == 300
@@ -241,7 +243,7 @@ def test_collection_config_full(collection_factory: CollectionFactory) -> None:
         multi_tenancy_config=Configure.multi_tenancy(
             enabled=True, auto_tenant_activation=True, auto_tenant_creation=True
         ),
-        # replication_config=Configure.replication(factor=2), # currently not updateable in RAFT
+        # replication_config=Configure.replication(factor=2, async_enabled=True), # currently not updateable in RAFT
         vector_index_config=Configure.VectorIndex.hnsw(
             cleanup_interval_seconds=10,
             distance_metric=VectorDistances.DOT,
@@ -373,7 +375,7 @@ def test_collection_config_update(collection_factory: CollectionFactory) -> None
             stopwords_preset=StopwordsPreset.EN,
             stopwords_removals=["the"],
         ),
-        # replication_config=Reconfigure.replication(factor=2), # currently not updateable in RAFT
+        # replication_config=Reconfigure.replication(factor=2, async_enabled=True), # currently not updateable in RAFT
         vectorizer_config=Reconfigure.VectorIndex.hnsw(
             vector_cache_max_objects=2000000,
             quantizer=Reconfigure.VectorIndex.Quantizer.pq(
@@ -711,7 +713,7 @@ def test_config_export_and_recreate_from_dict(collection_factory: CollectionFact
             Property(name="age", data_type=DataType.INT),
         ],
         multi_tenancy_config=Configure.multi_tenancy(enabled=True),
-        replication_config=Configure.replication(factor=1),
+        replication_config=Configure.replication(factor=1, async_enabled=False),
         vector_index_config=Configure.VectorIndex.hnsw(
             quantizer=Configure.VectorIndex.Quantizer.pq(centroids=256)
         ),

--- a/integration/test_collection_multi_node.py
+++ b/integration/test_collection_multi_node.py
@@ -22,7 +22,7 @@ def test_consistency_on_multinode(
         properties=[
             Property(name="name", data_type=DataType.TEXT),
         ],
-        replication_config=Configure.replication(factor=2),
+        replication_config=Configure.replication(factor=2, async_enabled=False),
         ports=(8087, 50058),
     ).with_consistency_level(level)
 

--- a/integration_v3/test_graphql.py
+++ b/integration_v3/test_graphql.py
@@ -94,7 +94,7 @@ def client(request):
         if opts.get("cluster"):
             port = 8087
             for _, c in enumerate(schema["classes"]):
-                c["replicationConfig"] = {"factor": 2}
+                c["replicationConfig"] = {"factor": 2, "async_enabled": False}
 
     client = weaviate.Client(f"http://localhost:{port}")
     client.schema.delete_all()

--- a/integration_v3/test_graphql.py
+++ b/integration_v3/test_graphql.py
@@ -94,7 +94,7 @@ def client(request):
         if opts.get("cluster"):
             port = 8087
             for _, c in enumerate(schema["classes"]):
-                c["replicationConfig"] = {"factor": 2, "async_enabled": False}
+                c["replicationConfig"] = {"factor": 2, "asyncEnabled": False}
 
     client = weaviate.Client(f"http://localhost:{port}")
     client.schema.delete_all()

--- a/integration_v3/test_graphql.py
+++ b/integration_v3/test_graphql.py
@@ -94,7 +94,7 @@ def client(request):
         if opts.get("cluster"):
             port = 8087
             for _, c in enumerate(schema["classes"]):
-                c["replicationConfig"] = {"factor": 2, "asyncEnabled": False}
+                c["replicationConfig"] = {"factor": 2}
 
     client = weaviate.Client(f"http://localhost:{port}")
     client.schema.delete_all()

--- a/integration_v3/test_schema.py
+++ b/integration_v3/test_schema.py
@@ -16,7 +16,7 @@ def client():
 
 @pytest.mark.parametrize("replicationFactor", [None, 1])
 def test_create_class_with_implicit_and_explicit_replication_config(
-    client: weaviate.Client, replicationFactor: Optional[int], asyncEnabled: Optional[bool]
+    client: weaviate.Client, replicationFactor: Optional[int]
 ):
     single_class = {
         "class": "Barbecue",

--- a/integration_v3/test_schema.py
+++ b/integration_v3/test_schema.py
@@ -15,7 +15,6 @@ def client():
 
 
 @pytest.mark.parametrize("replicationFactor", [None, 1])
-@pytest.mark.parametrize("asyncEnabled", [None, False])
 def test_create_class_with_implicit_and_explicit_replication_config(
     client: weaviate.Client, replicationFactor: Optional[int], asyncEnabled: Optional[bool]
 ):
@@ -30,19 +29,18 @@ def test_create_class_with_implicit_and_explicit_replication_config(
             },
         ],
     }
-
-    expected_factor = 1 if replicationFactor == None else replicationFactor
-    expected_async_enabled = False if asyncEnabled == None else asyncEnabled
-    single_class["replicationConfig"] = {
-        "factor": replicationFactor,
-        "asyncEnabled": asyncEnabled,
-    }
+    if replicationFactor is None:
+        expected_factor = 1
+    else:
+        expected_factor = replicationFactor
+        single_class["replicationConfig"] = {
+            "factor": replicationFactor,
+        }
 
     client.schema.create_class(single_class)
     created_class = client.schema.get("Barbecue")
     assert created_class["class"] == "Barbecue"
     assert created_class["replicationConfig"]["factor"] == expected_factor
-    assert created_class["replicationConfig"].get("asyncEnabled", False) == expected_async_enabled
 
     client.schema.delete_class("Barbecue")
 

--- a/integration_v3/test_schema.py
+++ b/integration_v3/test_schema.py
@@ -15,8 +15,9 @@ def client():
 
 
 @pytest.mark.parametrize("replicationFactor", [None, 1])
-def test_create_class_with_implicit_and_explicit_replication_factor(
-    client: weaviate.Client, replicationFactor: Optional[int]
+@pytest.mark.parametrize("asyncEnabled", [None, False])
+def test_create_class_with_implicit_and_explicit_replication_config(
+    client: weaviate.Client, replicationFactor: Optional[int], asyncEnabled: Optional[bool]
 ):
     single_class = {
         "class": "Barbecue",
@@ -31,16 +32,20 @@ def test_create_class_with_implicit_and_explicit_replication_factor(
     }
     if replicationFactor is None:
         expected_factor = 1
+    if asyncEnabled is None:
+        expected_async_enabled = False
     else:
         expected_factor = replicationFactor
         single_class["replicationConfig"] = {
             "factor": replicationFactor,
+            "async_enabled": asyncEnabled,
         }
 
     client.schema.create_class(single_class)
     created_class = client.schema.get("Barbecue")
     assert created_class["class"] == "Barbecue"
     assert created_class["replicationConfig"]["factor"] == expected_factor
+    assert created_class["replicationConfig"].get("async_enabled") == expected_async_enabled
 
     client.schema.delete_class("Barbecue")
 

--- a/integration_v3/test_schema.py
+++ b/integration_v3/test_schema.py
@@ -30,22 +30,19 @@ def test_create_class_with_implicit_and_explicit_replication_config(
             },
         ],
     }
-    if replicationFactor is None:
-        expected_factor = 1
-    if asyncEnabled is None:
-        expected_async_enabled = False
-    else:
-        expected_factor = replicationFactor
-        single_class["replicationConfig"] = {
-            "factor": replicationFactor,
-            "async_enabled": asyncEnabled,
-        }
+
+    expected_factor = 1 if replicationFactor == None else replicationFactor
+    expected_async_enabled = False if asyncEnabled == None else asyncEnabled
+    single_class["replicationConfig"] = {
+        "factor": replicationFactor,
+        "asyncEnabled": asyncEnabled,
+    }
 
     client.schema.create_class(single_class)
     created_class = client.schema.get("Barbecue")
     assert created_class["class"] == "Barbecue"
     assert created_class["replicationConfig"]["factor"] == expected_factor
-    assert created_class["replicationConfig"].get("async_enabled") == expected_async_enabled
+    assert created_class["replicationConfig"].get("asyncEnabled", False) == expected_async_enabled
 
     client.schema.delete_class("Barbecue")
 

--- a/mock_tests/test_collection.py
+++ b/mock_tests/test_collection.py
@@ -180,7 +180,7 @@ def test_missing_multi_tenancy_config(
         ),
         properties=[],
         references=[],
-        replication_config=ReplicationConfig(factor=0),
+        replication_config=ReplicationConfig(factor=0, async_enabled=False),
         vector_index_config=vic,
         vector_index_type=VectorIndexType.FLAT,
         vectorizer=Vectorizers.NONE,
@@ -242,7 +242,7 @@ def test_return_from_bind_module(
         "invertedIndexConfig": ii_config,
         "multiTenancyConfig": config.multi_tenancy()._to_dict(),
         "vectorizer": "multi2vec-bind",
-        "replicationConfig": {"factor": 2},
+        "replicationConfig": {"factor": 2, "async_enabled": False},
         "moduleConfig": {"multi2vec-bind": {}},
     }
     weaviate_auth_mock.expect_request("/v1/schema/TestBindCollection").respond_with_json(

--- a/mock_tests/test_collection.py
+++ b/mock_tests/test_collection.py
@@ -242,7 +242,7 @@ def test_return_from_bind_module(
         "invertedIndexConfig": ii_config,
         "multiTenancyConfig": config.multi_tenancy()._to_dict(),
         "vectorizer": "multi2vec-bind",
-        "replicationConfig": {"factor": 2, "async_enabled": False},
+        "replicationConfig": {"factor": 2, "asyncEnabled": False},
         "moduleConfig": {"multi2vec-bind": {}},
     }
     weaviate_auth_mock.expect_request("/v1/schema/TestBindCollection").respond_with_json(

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -310,10 +310,12 @@ class _ShardingConfigCreate(_ConfigCreateModel):
 
 class _ReplicationConfigCreate(_ConfigCreateModel):
     factor: Optional[int]
+    async_enabled: Optional[bool]
 
 
 class _ReplicationConfigUpdate(_ConfigUpdateModel):
     factor: Optional[int]
+    async_enabled: Optional[bool]
 
 
 class _BM25ConfigCreate(_ConfigCreateModel):
@@ -1053,6 +1055,7 @@ ReferencePropertyConfig = _ReferenceProperty
 @dataclass
 class _ReplicationConfig(_ConfigBase):
     factor: int
+    async_enabled: bool
 
 
 ReplicationConfig = _ReplicationConfig
@@ -1775,14 +1778,18 @@ class Configure:
         )
 
     @staticmethod
-    def replication(factor: Optional[int] = None) -> _ReplicationConfigCreate:
+    def replication(
+        factor: Optional[int] = None, async_enabled: Optional[bool] = None
+    ) -> _ReplicationConfigCreate:
         """Create a `ReplicationConfigCreate` object to be used when defining the replication configuration of Weaviate.
 
         Arguments:
             `factor`
                 The replication factor.
+            `async_enabled`
+                Enabled async replication.
         """
-        return _ReplicationConfigCreate(factor=factor)
+        return _ReplicationConfigCreate(factor=factor, async_enabled=async_enabled)
 
     @staticmethod
     def sharding(
@@ -1977,7 +1984,9 @@ class Reconfigure:
         )
 
     @staticmethod
-    def replication(factor: Optional[int] = None) -> _ReplicationConfigUpdate:
+    def replication(
+        factor: Optional[int] = None, async_enabled: Optional[bool] = None
+    ) -> _ReplicationConfigUpdate:
         """Create a `ReplicationConfigUpdate` object.
 
         Use this method when defining the `replication_config` argument in `collection.update()`.
@@ -1985,8 +1994,10 @@ class Reconfigure:
         Arguments:
             `factor`
                 The replication factor.
+            `async_enabled`
+                Enable async replication.
         """
-        return _ReplicationConfigUpdate(factor=factor)
+        return _ReplicationConfigUpdate(factor=factor, async_enabled=async_enabled)
 
     @staticmethod
     def multi_tenancy(

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1783,6 +1783,8 @@ class Configure:
     ) -> _ReplicationConfigCreate:
         """Create a `ReplicationConfigCreate` object to be used when defining the replication configuration of Weaviate.
 
+        NOTE: `async_enabled` is only available with WeaviateDB `>=v1.26.0`
+
         Arguments:
             `factor`
                 The replication factor.

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -310,12 +310,12 @@ class _ShardingConfigCreate(_ConfigCreateModel):
 
 class _ReplicationConfigCreate(_ConfigCreateModel):
     factor: Optional[int]
-    async_enabled: Optional[bool]
+    asyncEnabled: Optional[bool]
 
 
 class _ReplicationConfigUpdate(_ConfigUpdateModel):
     factor: Optional[int]
-    async_enabled: Optional[bool]
+    asyncEnabled: Optional[bool]
 
 
 class _BM25ConfigCreate(_ConfigCreateModel):
@@ -1789,7 +1789,7 @@ class Configure:
             `async_enabled`
                 Enabled async replication.
         """
-        return _ReplicationConfigCreate(factor=factor, async_enabled=async_enabled)
+        return _ReplicationConfigCreate(factor=factor, asyncEnabled=async_enabled)
 
     @staticmethod
     def sharding(
@@ -1997,7 +1997,7 @@ class Reconfigure:
             `async_enabled`
                 Enable async replication.
         """
-        return _ReplicationConfigUpdate(factor=factor, async_enabled=async_enabled)
+        return _ReplicationConfigUpdate(factor=factor, asyncEnabled=async_enabled)
 
     @staticmethod
     def multi_tenancy(

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -251,7 +251,10 @@ def _collection_config_from_json(schema: Dict[str, Any]) -> _CollectionConfig:
         ),
         properties=_properties_from_config(schema) if schema.get("properties") is not None else [],
         references=_references_from_config(schema) if schema.get("properties") is not None else [],
-        replication_config=_ReplicationConfig(factor=schema["replicationConfig"]["factor"]),
+        replication_config=_ReplicationConfig(
+            factor=schema["replicationConfig"]["factor"],
+            async_enabled=schema["replicationConfig"].get("async_enabled"),
+        ),
         reranker_config=__get_rerank_config(schema),
         sharding_config=(
             None

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -253,7 +253,7 @@ def _collection_config_from_json(schema: Dict[str, Any]) -> _CollectionConfig:
         references=_references_from_config(schema) if schema.get("properties") is not None else [],
         replication_config=_ReplicationConfig(
             factor=schema["replicationConfig"]["factor"],
-            async_enabled=schema["replicationConfig"].get("async_enabled"),
+            async_enabled=schema["replicationConfig"]["asyncEnabled"],
         ),
         reranker_config=__get_rerank_config(schema),
         sharding_config=(

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -253,7 +253,7 @@ def _collection_config_from_json(schema: Dict[str, Any]) -> _CollectionConfig:
         references=_references_from_config(schema) if schema.get("properties") is not None else [],
         replication_config=_ReplicationConfig(
             factor=schema["replicationConfig"]["factor"],
-            async_enabled=schema["replicationConfig"]["asyncEnabled"],
+            async_enabled=schema["replicationConfig"].get("asyncEnabled", False),
         ),
         reranker_config=__get_rerank_config(schema),
         sharding_config=(

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -516,7 +516,8 @@ class Schema:
                 "vectorIndexType": "hnsw",
                 "vectorizer": "text2vec-contextionary",
                 "replicationConfig": {
-                    "factor": 1
+                    "factor": 1,
+                    "async_enabled": false
                 }
                 }
             ]
@@ -545,7 +546,8 @@ class Schema:
             "vectorIndexType": "hnsw",
             "vectorizer": "text2vec-contextionary",
             "replicationConfig": {
-                "factor": 1
+                "factor": 1,
+                "async_enabled": false
             }
         }
 

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -517,7 +517,7 @@ class Schema:
                 "vectorizer": "text2vec-contextionary",
                 "replicationConfig": {
                     "factor": 1,
-                    "async_enabled": false
+                    "asyncEnabled": false
                 }
                 }
             ]
@@ -547,7 +547,7 @@ class Schema:
             "vectorizer": "text2vec-contextionary",
             "replicationConfig": {
                 "factor": 1,
-                "async_enabled": false
+                "asyncEnabled": false
             }
         }
 

--- a/weaviate/schema/crud_schema.py
+++ b/weaviate/schema/crud_schema.py
@@ -517,7 +517,6 @@ class Schema:
                 "vectorizer": "text2vec-contextionary",
                 "replicationConfig": {
                     "factor": 1,
-                    "asyncEnabled": false
                 }
                 }
             ]
@@ -547,7 +546,6 @@ class Schema:
             "vectorizer": "text2vec-contextionary",
             "replicationConfig": {
                 "factor": 1,
-                "asyncEnabled": false
             }
         }
 


### PR DESCRIPTION
This can be used `ONLY` with Weaviate Server ``v1.26.0`` or later. This can be configured in class schema like this:

```python
my_class = {
    "class": "MyClass",
    ...,
    "replicationConfig": {
        "factor": 1,
        "async_enabled": true
    }
}
```