### PR TITLE
fix: Multi tenancy enabled bots need tenant passed

### DIFF
--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -807,17 +807,13 @@ class Batch:
             class_name = obj["class"]
             tenant = obj.get("tenant", None)
             uuid = obj["id"]
-            
-            if tenant is None:
-                response_head = self._connection.head(
-                    path="/objects/" + class_name + "/" + uuid,
-                )
-            else:
-                response_head = self._connection.head(
-                    path="/objects/" + class_name + "/" + uuid,
-                    params={"tenant": tenant},
-                )
-            
+            params = {"tenant": tenant} if tenant is not None else None
+
+            response_head = self._connection.head(
+                path="/objects/" + class_name + "/" + uuid,
+                params=params,
+            )
+        
             if response_head.status_code == 404:
                 new_batch.add(
                     class_name=_capitalize_first_letter(class_name),
@@ -827,17 +823,13 @@ class Batch:
                 )
                 continue
 
-            if tenant is None:
-                response = self._connection.get(
-                    path="/objects/" + class_name + "/" + uuid,
-                )
-            else:
-                response = self._connection.get(
-                    path="/objects/" + class_name + "/" + uuid,
-                    params={"tenant": tenant},
-                )
-
-            obj_weav = response.json()
+            
+            response = self._connection.get(
+                path="/objects/" + class_name + "/" + uuid,
+                params=params,
+            )
+            obj_weav = _decode_json_response_dict(response, "Re-add objects")
+            assert obj_weav is not None
             if obj_weav["properties"] != obj["properties"] or obj.get(
                 "vector", None
             ) != obj_weav.get("vector", None):

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -828,6 +828,7 @@ class Batch:
                 path="/objects/" + class_name + "/" + uuid,
                 params=params,
             )
+
             obj_weav = _decode_json_response_dict(response, "Re-add objects")
             assert obj_weav is not None
             if obj_weav["properties"] != obj["properties"] or obj.get(

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -823,7 +823,7 @@ class Batch:
                 )
                 continue
 
-            
+            # object might already exist and needs to be overwritten in case of an update
             response = self._connection.get(
                 path="/objects/" + class_name + "/" + uuid,
                 params=params,

--- a/weaviate/batch/crud_batch.py
+++ b/weaviate/batch/crud_batch.py
@@ -813,7 +813,7 @@ class Batch:
                 path="/objects/" + class_name + "/" + uuid,
                 params=params,
             )
-        
+
             if response_head.status_code == 404:
                 new_batch.add(
                     class_name=_capitalize_first_letter(class_name),


### PR DESCRIPTION
Context:
We have a weaviate cluster with multi tenancy turned on. Whenever the create batch times out and throws a ReadTimeout, the behaviour is to retry the object creation, in which the the object is fetched, the properties are compared and if there is a change in properties it is added to the new batch.

Behaviour (as of 3.26.2):
Since it is a multi tenancy enabled cluster, making a get/head request to fetch the object by uuid returns a 422 which suggests:
```
{
      error: [
                {
                     message: 'repo: object by id: search index sind: class TestClass has multi-tenancy 
                     enabled, but request was without tenant'
                }
     ]
}
```
After this PR is merged:
The object get by id and the head requests, now pass the tenant if its being passed when making the batch request