### PR TITLE
Scalar Quantization

### DIFF
--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -481,6 +481,7 @@ def test_hnsw_with_bq(collection_factory: CollectionFactory) -> None:
     assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
     assert isinstance(config.vector_index_config.quantizer, _BQConfig)
 
+
 def test_hnsw_with_sq(collection_factory: CollectionFactory) -> None:
     collection = collection_factory(
         vector_index_config=Configure.VectorIndex.hnsw(

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -486,7 +486,7 @@ def test_hnsw_with_sq(collection_factory: CollectionFactory) -> None:
     collection = collection_factory(
         vector_index_config=Configure.VectorIndex.hnsw(
             vector_cache_max_objects=5,
-            quantizer=Configure.VectorIndex.Quantizer.sq(rescore_limit=10),
+            quantizer=Configure.VectorIndex.Quantizer.sq(rescore_limit=10, training_limit=1000000),
         ),
     )
     if collection._connection._weaviate_version.is_lower_than(1, 26, 0):

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -490,7 +490,7 @@ def test_hnsw_with_sq(collection_factory: CollectionFactory) -> None:
         ),
     )
     if collection._connection._weaviate_version.is_lower_than(1, 26, 0):
-        pytest.skip("BQ+HNSW is not supported in Weaviate versions lower than 1.26.0")
+        pytest.skip("SQ+HNSW is not supported in Weaviate versions lower than 1.26.0")
 
     config = collection.config.get()
     assert config.vector_index_type == VectorIndexType.HNSW

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -7,6 +7,7 @@ from integration.conftest import OpenAICollection, CollectionFactory
 from integration.conftest import _sanitize_collection_name
 from weaviate.collections.classes.config import (
     _BQConfig,
+    _SQConfig,
     _CollectionConfig,
     _CollectionConfigSimple,
     _PQConfig,
@@ -479,6 +480,22 @@ def test_hnsw_with_bq(collection_factory: CollectionFactory) -> None:
     assert config.vector_index_config is not None
     assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
     assert isinstance(config.vector_index_config.quantizer, _BQConfig)
+
+def test_hnsw_with_sq(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        vector_index_config=Configure.VectorIndex.hnsw(
+            vector_cache_max_objects=5,
+            quantizer=Configure.VectorIndex.Quantizer.sq(rescore_limit=10),
+        ),
+    )
+    if collection._connection._weaviate_version.is_lower_than(1, 26, 0):
+        pytest.skip("BQ+HNSW is not supported in Weaviate versions lower than 1.26.0")
+
+    config = collection.config.get()
+    assert config.vector_index_type == VectorIndexType.HNSW
+    assert config.vector_index_config is not None
+    assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
+    assert isinstance(config.vector_index_config.quantizer, _SQConfig)
 
 
 def test_update_flat(collection_factory: CollectionFactory) -> None:

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -975,6 +975,16 @@ def test_vector_config_hnsw_bq() -> None:
     assert vi_dict["efConstruction"] == 128
     assert vi_dict["bq"]["rescoreLimit"] == 123
 
+def test_vector_config_hnsw_sq() -> None:
+    vector_index = Configure.VectorIndex.hnsw(
+        ef_construction=128, quantizer=Configure.VectorIndex.Quantizer.sq(rescore_limit=123)
+    )
+
+    vi_dict = vector_index._to_dict()
+
+    assert vi_dict["efConstruction"] == 128
+    assert vi_dict["sq"]["rescoreLimit"] == 123
+
 
 def test_vector_config_flat_pq() -> None:
     vector_index = Configure.VectorIndex.flat(

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -978,13 +978,15 @@ def test_vector_config_hnsw_bq() -> None:
 
 def test_vector_config_hnsw_sq() -> None:
     vector_index = Configure.VectorIndex.hnsw(
-        ef_construction=128, quantizer=Configure.VectorIndex.Quantizer.sq(rescore_limit=123)
+        ef_construction=128,
+        quantizer=Configure.VectorIndex.Quantizer.sq(rescore_limit=123, training_limit=5012),
     )
 
     vi_dict = vector_index._to_dict()
 
     assert vi_dict["efConstruction"] == 128
     assert vi_dict["sq"]["rescoreLimit"] == 123
+    assert vi_dict["sq"]["trainingLimit"] == 5012
 
 
 def test_vector_config_flat_pq() -> None:

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -975,6 +975,7 @@ def test_vector_config_hnsw_bq() -> None:
     assert vi_dict["efConstruction"] == 128
     assert vi_dict["bq"]["rescoreLimit"] == 123
 
+
 def test_vector_config_hnsw_sq() -> None:
     vector_index = Configure.VectorIndex.hnsw(
         ef_construction=128, quantizer=Configure.VectorIndex.Quantizer.sq(rescore_limit=123)

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1644,7 +1644,7 @@ class _VectorIndexQuantizer:
     def sq(
         cache: Optional[bool] = None,
         rescore_limit: Optional[int] = None,
-    ) -> _BQConfigCreate:
+    ) -> _SQConfigCreate:
         """Create a `_SQConfigCreate` object to be used when defining the scalar quantization (SQ) configuration of Weaviate.
 
         Use this method when defining the `quantizer` argument in the `vector_index` configuration. Note that the arguments have no effect for HNSW.
@@ -1911,7 +1911,7 @@ class _VectorIndexQuantizerUpdate:
         return _BQConfigUpdate(rescoreLimit=rescore_limit)
 
     @staticmethod
-    def sq(rescore_limit: Optional[int] = None) -> _BQConfigUpdate:
+    def sq(rescore_limit: Optional[int] = None) -> _SQConfigUpdate:
         """Create a `_SQConfigUpdate` object to be used when updating the scalar quantization (SQ) configuration of Weaviate.
 
         Use this method when defining the `quantizer` argument in the `vector_index` configuration in `collection.update()`.

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -310,6 +310,7 @@ class _BQConfigUpdate(_QuantizerConfigUpdate):
 
 
 class _SQConfigUpdate(_QuantizerConfigUpdate):
+    enabled: Optional[bool]
     rescoreLimit: Optional[int]
     trainingLimit: Optional[int]
 
@@ -1917,7 +1918,9 @@ class _VectorIndexQuantizerUpdate:
 
     @staticmethod
     def sq(
-        rescore_limit: Optional[int] = None, training_limit: Optional[int] = None
+        rescore_limit: Optional[int] = None,
+        training_limit: Optional[int] = None,
+        enabled: bool = True,
     ) -> _SQConfigUpdate:
         """Create a `_SQConfigUpdate` object to be used when updating the scalar quantization (SQ) configuration of Weaviate.
 
@@ -1926,7 +1929,9 @@ class _VectorIndexQuantizerUpdate:
         Arguments:
             See [the docs](https://weaviate.io/developers/weaviate/concepts/vector-index#hnsw-with-compression) for a more detailed view!
         """  # noqa: D417 (missing argument descriptions in the docstring)
-        return _SQConfigUpdate(rescoreLimit=rescore_limit, trainingLimit=training_limit)
+        return _SQConfigUpdate(
+            enabled=enabled, rescoreLimit=rescore_limit, trainingLimit=training_limit
+        )
 
 
 class _VectorIndexUpdate:

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -277,6 +277,7 @@ class _BQConfigCreate(_QuantizerConfigCreate):
     def quantizer_name() -> str:
         return "bq"
 
+
 class _SQConfigCreate(_QuantizerConfigCreate):
     cache: Optional[bool]
     rescoreLimit: Optional[int]
@@ -306,12 +307,14 @@ class _BQConfigUpdate(_QuantizerConfigUpdate):
     def quantizer_name() -> str:
         return "bq"
 
+
 class _SQConfigUpdate(_QuantizerConfigUpdate):
     rescoreLimit: Optional[int]
 
     @staticmethod
     def quantizer_name() -> str:
         return "sq"
+
 
 class _ShardingConfigCreate(_ConfigCreateModel):
     virtualPerPhysical: Optional[int]
@@ -1124,6 +1127,7 @@ class _BQConfig(_ConfigBase):
     cache: Optional[bool]
     rescore_limit: int
 
+
 @dataclass
 class _SQConfig(_ConfigBase):
     cache: Optional[bool]
@@ -1652,6 +1656,7 @@ class _VectorIndexQuantizer:
             cache=cache,
             rescoreLimit=rescore_limit,
         )
+
 
 class _VectorIndex:
     Quantizer = _VectorIndexQuantizer

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -281,6 +281,7 @@ class _BQConfigCreate(_QuantizerConfigCreate):
 class _SQConfigCreate(_QuantizerConfigCreate):
     cache: Optional[bool]
     rescoreLimit: Optional[int]
+    trainingLimit: Optional[int]
 
     @staticmethod
     def quantizer_name() -> str:
@@ -310,6 +311,7 @@ class _BQConfigUpdate(_QuantizerConfigUpdate):
 
 class _SQConfigUpdate(_QuantizerConfigUpdate):
     rescoreLimit: Optional[int]
+    trainingLimit: Optional[int]
 
     @staticmethod
     def quantizer_name() -> str:
@@ -1132,6 +1134,7 @@ class _BQConfig(_ConfigBase):
 class _SQConfig(_ConfigBase):
     cache: Optional[bool]
     rescore_limit: int
+    training_limit: int
 
 
 BQConfig = _BQConfig
@@ -1644,6 +1647,7 @@ class _VectorIndexQuantizer:
     def sq(
         cache: Optional[bool] = None,
         rescore_limit: Optional[int] = None,
+        training_limit: Optional[int] = None,
     ) -> _SQConfigCreate:
         """Create a `_SQConfigCreate` object to be used when defining the scalar quantization (SQ) configuration of Weaviate.
 
@@ -1655,6 +1659,7 @@ class _VectorIndexQuantizer:
         return _SQConfigCreate(
             cache=cache,
             rescoreLimit=rescore_limit,
+            trainingLimit=training_limit,
         )
 
 
@@ -1911,7 +1916,9 @@ class _VectorIndexQuantizerUpdate:
         return _BQConfigUpdate(rescoreLimit=rescore_limit)
 
     @staticmethod
-    def sq(rescore_limit: Optional[int] = None) -> _SQConfigUpdate:
+    def sq(
+        rescore_limit: Optional[int] = None, training_limit: Optional[int] = None
+    ) -> _SQConfigUpdate:
         """Create a `_SQConfigUpdate` object to be used when updating the scalar quantization (SQ) configuration of Weaviate.
 
         Use this method when defining the `quantizer` argument in the `vector_index` configuration in `collection.update()`.
@@ -1919,7 +1926,7 @@ class _VectorIndexQuantizerUpdate:
         Arguments:
             See [the docs](https://weaviate.io/developers/weaviate/concepts/vector-index#hnsw-with-compression) for a more detailed view!
         """  # noqa: D417 (missing argument descriptions in the docstring)
-        return _SQConfigUpdate(rescoreLimit=rescore_limit)
+        return _SQConfigUpdate(rescoreLimit=rescore_limit, trainingLimit=training_limit)
 
 
 class _VectorIndexUpdate:

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 from weaviate.collections.classes.config import (
     _BQConfig,
+    _SQConfig,
     _CollectionConfig,
     _CollectionConfigSimple,
     _NamedVectorConfig,
@@ -99,13 +100,19 @@ def __get_vector_index_type(schema: Dict[str, Any]) -> Optional[VectorIndexType]
         return None
 
 
-def __get_quantizer_config(config: Dict[str, Any]) -> Optional[Union[_PQConfig, _BQConfig]]:
-    quantizer: Optional[Union[_PQConfig, _BQConfig]] = None
+def __get_quantizer_config(config: Dict[str, Any]) -> Optional[Union[_PQConfig, _BQConfig, _SQConfig]]:
+    quantizer: Optional[Union[_PQConfig, _BQConfig, _SQConfig]] = None
     if "bq" in config and config["bq"]["enabled"]:
         # values are not present for bq+hnsw
         quantizer = _BQConfig(
             cache=config["bq"].get("cache"),
             rescore_limit=config["bq"].get("rescoreLimit"),
+        )
+    elif "sq" in config and config["sq"]["enabled"]:
+        # values are not present for bq+hnsw
+        quantizer = _BQConfig(
+            cache=config["sq"].get("cache"),
+            rescore_limit=config["sq"].get("rescoreLimit"),
         )
     elif "pq" in config and config["pq"].get("enabled"):
         quantizer = _PQConfig(

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -112,9 +112,10 @@ def __get_quantizer_config(
         )
     elif "sq" in config and config["sq"]["enabled"]:
         # values are not present for bq+hnsw
-        quantizer = _BQConfig(
+        quantizer = _SQConfig(
             cache=config["sq"].get("cache"),
             rescore_limit=config["sq"].get("rescoreLimit"),
+            training_limit=config["sq"].get("trainingLimit"),
         )
     elif "pq" in config and config["pq"].get("enabled"):
         quantizer = _PQConfig(

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -100,7 +100,9 @@ def __get_vector_index_type(schema: Dict[str, Any]) -> Optional[VectorIndexType]
         return None
 
 
-def __get_quantizer_config(config: Dict[str, Any]) -> Optional[Union[_PQConfig, _BQConfig, _SQConfig]]:
+def __get_quantizer_config(
+    config: Dict[str, Any]
+) -> Optional[Union[_PQConfig, _BQConfig, _SQConfig]]:
     quantizer: Optional[Union[_PQConfig, _BQConfig, _SQConfig]] = None
     if "bq" in config and config["bq"]["enabled"]:
         # values are not present for bq+hnsw


### PR DESCRIPTION
- Adds scalar quantization `sq` option
- Following binary quantization in configuration format
- Requires Weaviate 1.26 or higher https://github.com/weaviate/weaviate/pull/5125

Usage:

```python
import weaviate
import numpy as np
import weaviate.classes.config as wc

client = weaviate.connect_to_local()
foo = client.collections.create(name="Foo")
with foo.batch.dynamic() as batch:
    for i in range(2000):
        batch.add_object(vector=np.random.rand(100).tolist())

foo = client.collections.get("Foo")
foo.config.update(
    vectorizer_config=wc.Reconfigure.VectorIndex.hnsw(
        quantizer=wc.Reconfigure.VectorIndex.Quantizer.sq(rescore_limit=31, training_limit=2001)
    )
)

# After training complete
foo.config.get().vector_index_config.to_dict()

{'cleanupIntervalSeconds': 300,
 'distanceMetric': 'cosine',
 'dynamicEfMin': 100,
 'dynamicEfMax': 500,
 'dynamicEfFactor': 8,
 'ef': -1,
 'efConstruction': 128,
 'flatSearchCutoff': 40000,
 'maxConnections': 64,
 'skip': False,
 'vectorCacheMaxObjects': 1000000000000,
 'sq': {'rescoreLimit': 31, 'trainingLimit': 2001, 'enabled': True}}
 ```
 
 If using async indexing you can simple enable at start i.e:
 
 ```python
 client.collections.create(
    name="Bar",
    vector_index_config=wc.Configure.VectorIndex.hnsw(
        quantizer=wc.Configure.VectorIndex.Quantizer.sq(training_limit=1000)
    ),
    properties=[
        wc.Property(name="question", data_type=wc.DataType.TEXT),
        wc.Property(name="answer", data_type=wc.DataType.TEXT),
    ],
)
```