### PR TITLE
Refactor batch results storage and publishing

### DIFF
--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -546,3 +546,24 @@ def test_non_existant_collection(client_factory: ClientFactory) -> None:
 
     # above should not throw - depending on the autoschema config this might create an error or
     # not, so we do not check for errors here
+
+
+def test_number_of_stored_results_in_batch(client_factory: ClientFactory) -> None:
+    client, name = client_factory()
+    with client.batch.dynamic() as batch:
+        for i in range(99999):
+            batch.add_object(properties={"name": str(i)}, collection=name)
+
+    assert len(client.batch.results.objs.all_responses) == 99999
+    assert len(client.batch.results.objs.errors) == 0
+    assert len(client.batch.results.objs.uuids) == 99999
+    assert list(client.batch.results.objs.uuids.keys()) == list(range(99999))
+
+    with client.batch.dynamic() as batch:
+        for i in range(100001):
+            batch.add_object(properties={"name": str(i)}, collection=name)
+
+    assert len(client.batch.results.objs.all_responses) == 100000
+    assert len(client.batch.results.objs.errors) == 0
+    assert len(client.batch.results.objs.uuids) == 100000
+    assert list(client.batch.results.objs.uuids.keys()) == list(range(100000))

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -566,4 +566,4 @@ def test_number_of_stored_results_in_batch(client_factory: ClientFactory) -> Non
     assert len(client.batch.results.objs.all_responses) == 100000
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 100000
-    assert list(client.batch.results.objs.uuids.keys()) == list(range(100000))
+    assert list(client.batch.results.objs.uuids.keys()) == list(range(1, 100001))

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -580,6 +580,6 @@ def test_uuids_keys_and_original_index(client_factory: ClientFactory) -> None:
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 100
 
-    assert [objs[k] for k in client.batch.results.objs.uuids.keys()] == list(
+    assert [objs[k][0] for k in client.batch.results.objs.uuids.keys()] == list(
         client.batch.results.objs.uuids.values()
     )

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -566,7 +566,10 @@ def test_number_of_stored_results_in_batch(client_factory: ClientFactory) -> Non
     assert len(client.batch.results.objs.all_responses) == 100000
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 100000
-    assert list(client.batch.results.objs.uuids.keys()) == list(range(1, 100001))
+    assert sorted(client.batch.results.objs.uuids.keys()) == list(range(1, 100001))
+    # depending on timings in the event loop, some batches may end before others
+    # as such the keys of the uuids dict may not be in order but they are still unique
+    # and correspond to the original indices within the batch
 
 
 def test_uuids_keys_and_original_index(client_factory: ClientFactory) -> None:

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -557,7 +557,7 @@ def test_number_of_stored_results_in_batch(client_factory: ClientFactory) -> Non
     assert len(client.batch.results.objs.all_responses) == 99999
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 99999
-    assert list(client.batch.results.objs.uuids.keys()) == list(range(99999))
+    assert sorted(client.batch.results.objs.uuids.keys()) == list(range(99999))
 
     with client.batch.dynamic() as batch:
         for i in range(100001):
@@ -567,6 +567,7 @@ def test_number_of_stored_results_in_batch(client_factory: ClientFactory) -> Non
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 100000
     assert sorted(client.batch.results.objs.uuids.keys()) == list(range(1, 100001))
+
     # depending on timings in the event loop, some batches may end before others
     # as such the keys of the uuids dict may not be in order but they are still unique
     # and correspond to the original indices within the batch

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -567,3 +567,18 @@ def test_number_of_stored_results_in_batch(client_factory: ClientFactory) -> Non
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 100000
     assert list(client.batch.results.objs.uuids.keys()) == list(range(1, 100001))
+
+
+def test_uuids_keys_and_original_index(client_factory: ClientFactory) -> None:
+    client, name = client_factory()
+    objs = [(uuid.uuid4(), {"name": str(i)}) for i in range(100)]
+    with client.batch.dynamic() as batch:
+        for obj in objs:
+            batch.add_object(uuid=obj[0], properties=obj[1], collection=name)
+
+    assert len(client.batch.results.objs.all_responses) == 100
+    assert len(client.batch.results.objs.errors) == 0
+    assert len(client.batch.results.objs.uuids) == 100
+
+    for k, v in client.batch.results.objs.uuids.items():
+        assert objs[k][0] == v

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -580,4 +580,6 @@ def test_uuids_keys_and_original_index(client_factory: ClientFactory) -> None:
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 100
 
-    assert [str(obj[0]) for obj in objs] == list(client.batch.results.objs.uuids.keys())
+    assert [objs[k] for k in client.batch.results.objs.uuids.keys()] == list(
+        client.batch.results.objs.uuids.values()
+    )

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -580,7 +580,4 @@ def test_uuids_keys_and_original_index(client_factory: ClientFactory) -> None:
     assert len(client.batch.results.objs.errors) == 0
     assert len(client.batch.results.objs.uuids) == 100
 
-    for k, v in client.batch.results.objs.uuids.items():
-        assert (
-            objs[k][0] == v
-        ), f"Index {k} did not match original uuid {objs[k][0]}. Origs: {[obj[0] for obj in objs]}, uuids: {list(client.batch.results.objs.uuids.values())}"
+    assert [str(obj[0]) for obj in objs] == list(client.batch.results.objs.uuids.keys())

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -581,4 +581,6 @@ def test_uuids_keys_and_original_index(client_factory: ClientFactory) -> None:
     assert len(client.batch.results.objs.uuids) == 100
 
     for k, v in client.batch.results.objs.uuids.items():
-        assert objs[k][0] == v
+        assert (
+            objs[k][0] == v
+        ), f"Index {k} did not match original uuid {objs[k][0]}. Origs: {[obj[0] for obj in objs]}, uuids: {list(client.batch.results.objs.uuids.values())}"

--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -3,7 +3,7 @@ from weaviate.collections.classes.batch import BatchObjectReturn, MAX_STORED_RES
 
 
 def test_batch_object_return_add() -> None:
-    lhs_uuids = [uuid.uuid4() for _ in range(MAX_STORED_RESULTS - 1)]
+    lhs_uuids = [uuid.uuid4() for _ in range(MAX_STORED_RESULTS)]
     lhs = BatchObjectReturn(
         _all_responses=lhs_uuids,
         elapsed_seconds=0.1,
@@ -11,17 +11,19 @@ def test_batch_object_return_add() -> None:
         has_errors=False,
         uuids=dict(e for e in enumerate(lhs_uuids)),
     )
-    rhs_uuids = [uuid.uuid4() for _ in range(2)]
+    rhs_uuids = [uuid.uuid4() for _ in range(1)]
     rhs = BatchObjectReturn(
         _all_responses=rhs_uuids,
         elapsed_seconds=0.1,
         errors={},
         has_errors=False,
-        uuids=dict(e for e in enumerate(rhs_uuids)),
+        uuids={
+            MAX_STORED_RESULTS: rhs_uuids[0],
+        },
     )
     result = lhs + rhs
     assert len(result.all_responses) == MAX_STORED_RESULTS
     assert len(result.uuids) == MAX_STORED_RESULTS
     assert result.uuids == {
-        idx + 1: v for idx, v in enumerate(lhs_uuids[1 : MAX_STORED_RESULTS - 1] + rhs_uuids)
+        idx + 2: v for idx, v in enumerate(lhs_uuids[1:MAX_STORED_RESULTS] + rhs_uuids)
     }

--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -1,5 +1,4 @@
 import uuid
-from collections import OrderedDict
 from weaviate.collections.classes.batch import BatchObjectReturn, MAX_STORED_RESULTS
 
 
@@ -8,21 +7,21 @@ def test_batch_object_return_add() -> None:
     lhs = BatchObjectReturn(
         _all_responses=lhs_uuids,
         elapsed_seconds=0.1,
-        errors=OrderedDict(),
+        errors={},
         has_errors=False,
-        uuids=OrderedDict(e for e in enumerate(lhs_uuids)),
+        uuids=dict(e for e in enumerate(lhs_uuids)),
     )
     rhs_uuids = [uuid.uuid4() for _ in range(2)]
     rhs = BatchObjectReturn(
         _all_responses=rhs_uuids,
         elapsed_seconds=0.1,
-        errors=OrderedDict(),
+        errors={},
         has_errors=False,
-        uuids=OrderedDict(e for e in enumerate(rhs_uuids)),
+        uuids=dict(e for e in enumerate(rhs_uuids)),
     )
     result = lhs + rhs
     assert len(result.all_responses) == MAX_STORED_RESULTS
     assert len(result.uuids) == MAX_STORED_RESULTS
-    assert result.uuids == OrderedDict(
-        (idx + 1, v) for idx, v in enumerate(lhs_uuids[1 : MAX_STORED_RESULTS - 1] + rhs_uuids)
-    )
+    assert result.uuids == {
+        idx + 1: v for idx, v in enumerate(lhs_uuids[1 : MAX_STORED_RESULTS - 1] + rhs_uuids)
+    }

--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import OrderedDict
 from weaviate.collections.classes.batch import BatchObjectReturn, MAX_STORED_RESULTS
 
 
@@ -7,21 +8,21 @@ def test_batch_object_return_add() -> None:
     lhs = BatchObjectReturn(
         _all_responses=lhs_uuids,
         elapsed_seconds=0.1,
-        errors={},
+        errors=OrderedDict(),
         has_errors=False,
-        uuids=dict(e for e in enumerate(lhs_uuids)),
+        uuids=OrderedDict(e for e in enumerate(lhs_uuids)),
     )
     rhs_uuids = [uuid.uuid4() for _ in range(2)]
     rhs = BatchObjectReturn(
         _all_responses=rhs_uuids,
         elapsed_seconds=0.1,
-        errors={},
+        errors=OrderedDict(),
         has_errors=False,
-        uuids=dict(e for e in enumerate(rhs_uuids)),
+        uuids=OrderedDict(e for e in enumerate(rhs_uuids)),
     )
     result = lhs + rhs
     assert len(result.all_responses) == MAX_STORED_RESULTS
     assert len(result.uuids) == MAX_STORED_RESULTS
-    assert result.uuids == {
-        idx + 1: v for idx, v in enumerate(lhs_uuids[1 : MAX_STORED_RESULTS - 1] + rhs_uuids)
-    }
+    assert result.uuids == OrderedDict(
+        (idx + 1, v) for idx, v in enumerate(lhs_uuids[1 : MAX_STORED_RESULTS - 1] + rhs_uuids)
+    )

--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -5,7 +5,7 @@ from weaviate.collections.classes.batch import BatchObjectReturn, MAX_STORED_RES
 def test_batch_object_return_add() -> None:
     lhs_uuids = [uuid.uuid4() for _ in range(MAX_STORED_RESULTS - 1)]
     lhs = BatchObjectReturn(
-        all_responses=lhs_uuids,
+        _all_responses=lhs_uuids,
         elapsed_seconds=0.1,
         errors={},
         has_errors=False,
@@ -13,7 +13,7 @@ def test_batch_object_return_add() -> None:
     )
     rhs_uuids = [uuid.uuid4() for _ in range(2)]
     rhs = BatchObjectReturn(
-        all_responses=rhs_uuids,
+        _all_responses=rhs_uuids,
         elapsed_seconds=0.1,
         errors={},
         has_errors=False,

--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -1,0 +1,27 @@
+import uuid
+from weaviate.collections.classes.batch import BatchObjectReturn, MAX_STORED_RESULTS
+
+
+def test_batch_object_return_add() -> None:
+    lhs_uuids = [uuid.uuid4() for _ in range(MAX_STORED_RESULTS - 1)]
+    lhs = BatchObjectReturn(
+        all_responses=lhs_uuids,
+        elapsed_seconds=0.1,
+        errors={},
+        has_errors=False,
+        uuids={idx: v for idx, v in enumerate(lhs_uuids)},
+    )
+    rhs_uuids = [uuid.uuid4() for _ in range(2)]
+    rhs = BatchObjectReturn(
+        all_responses=rhs_uuids,
+        elapsed_seconds=0.1,
+        errors={},
+        has_errors=False,
+        uuids={idx: v for idx, v in enumerate(rhs_uuids)},
+    )
+    result = lhs + rhs
+    assert len(result.all_responses) == MAX_STORED_RESULTS
+    assert len(result.uuids) == MAX_STORED_RESULTS
+    assert result.uuids == {
+        idx + 1: v for idx, v in enumerate(lhs_uuids[1 : MAX_STORED_RESULTS - 1] + rhs_uuids)
+    }

--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -25,5 +25,5 @@ def test_batch_object_return_add() -> None:
     assert len(result.all_responses) == MAX_STORED_RESULTS
     assert len(result.uuids) == MAX_STORED_RESULTS
     assert result.uuids == {
-        idx + 2: v for idx, v in enumerate(lhs_uuids[1:MAX_STORED_RESULTS] + rhs_uuids)
+        idx + 1: v for idx, v in enumerate(lhs_uuids[1:MAX_STORED_RESULTS] + rhs_uuids)
     }

--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -9,7 +9,7 @@ def test_batch_object_return_add() -> None:
         elapsed_seconds=0.1,
         errors={},
         has_errors=False,
-        uuids={idx: v for idx, v in enumerate(lhs_uuids)},
+        uuids=dict(e for e in enumerate(lhs_uuids)),
     )
     rhs_uuids = [uuid.uuid4() for _ in range(2)]
     rhs = BatchObjectReturn(
@@ -17,7 +17,7 @@ def test_batch_object_return_add() -> None:
         elapsed_seconds=0.1,
         errors={},
         has_errors=False,
-        uuids={idx: v for idx, v in enumerate(rhs_uuids)},
+        uuids=dict(e for e in enumerate(rhs_uuids)),
     )
     result = lhs + rhs
     assert len(result.all_responses) == MAX_STORED_RESULTS

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -500,7 +500,7 @@ class _BatchBase:
                     idx: ErrorObject(message=repr(e), object_=obj) for idx, obj in enumerate(objs)
                 }
                 response_obj = BatchObjectReturn(
-                    all_responses=list(errors_obj.values()),
+                    _all_responses=list(errors_obj.values()),
                     elapsed_seconds=time.time() - start,
                     errors=errors_obj,
                     has_errors=True,
@@ -561,7 +561,7 @@ class _BatchBase:
                     },
                     errors=new_errors,
                     has_errors=len(new_errors) > 0,
-                    all_responses=[
+                    _all_responses=[
                         err
                         for i, err in enumerate(response_obj.all_responses)
                         if i not in readded_objects

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -4,7 +4,7 @@ import threading
 import time
 import uuid as uuid_package
 from abc import ABC
-from collections import deque
+from collections import deque, OrderedDict
 from copy import copy
 from dataclasses import dataclass, field
 from typing import (
@@ -496,9 +496,9 @@ class _BatchBase:
                     objects=objs, timeout=DEFAULT_REQUEST_TIMEOUT
                 )
             except Exception as e:
-                errors_obj = {
-                    idx: ErrorObject(message=repr(e), object_=obj) for idx, obj in enumerate(objs)
-                }
+                errors_obj = OrderedDict(
+                    (idx, ErrorObject(message=repr(e), object_=obj)) for idx, obj in enumerate(objs)
+                )
                 response_obj = BatchObjectReturn(
                     _all_responses=list(errors_obj.values()),
                     elapsed_seconds=time.time() - start,
@@ -551,13 +551,15 @@ class _BatchBase:
 
                 self.__batch_objects.prepend(readd_objects)
 
-                new_errors = {
-                    i: err for i, err in response_obj.errors.items() if i not in readded_objects
-                }
+                new_errors = OrderedDict(
+                    (i, err) for i, err in response_obj.errors.items() if i not in readded_objects
+                )
                 response_obj = BatchObjectReturn(
-                    uuids={
-                        i: uid for i, uid in response_obj.uuids.items() if i not in readded_objects
-                    },
+                    uuids=OrderedDict(
+                        (i, uid)
+                        for i, uid in response_obj.uuids.items()
+                        if i not in readded_objects
+                    ),
                     errors=new_errors,
                     has_errors=len(new_errors) > 0,
                     _all_responses=[

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -502,6 +502,9 @@ class _BatchBase:
                 response_obj = BatchObjectReturn(
                     all_responses=list(errors_obj.values()),
                     elapsed_seconds=time.time() - start,
+                    errors=errors_obj,
+                    has_errors=True,
+                    uuids={},
                 )
 
             readded_uuids = set()
@@ -549,7 +552,15 @@ class _BatchBase:
 
                 self.__batch_objects.prepend(readd_objects)
 
+                new_errors = {
+                    i: err for i, err in response_obj.errors.items() if i not in readded_objects
+                }
                 response_obj = BatchObjectReturn(
+                    uuids={
+                        i: uid for i, uid in response_obj.uuids.items() if i not in readded_objects
+                    },
+                    errors=new_errors,
+                    has_errors=len(new_errors) > 0,
                     all_responses=[
                         err
                         for i, err in enumerate(response_obj.all_responses)

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -504,7 +504,6 @@ class _BatchBase:
                     elapsed_seconds=time.time() - start,
                     errors=errors_obj,
                     has_errors=True,
-                    uuids={},
                 )
 
             readded_uuids = set()

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -190,6 +190,8 @@ class _BatchBase:
         self.__batching_mode: _BatchMode = batch_mode
         self.__max_batch_size: int = 1000
 
+        self.__objs_count = 0
+
         if isinstance(self.__batching_mode, _FixedSizeBatching):
             self.__recommended_num_objects = self.__batching_mode.batch_size
             self.__concurrent_requests = self.__batching_mode.concurrent_requests
@@ -643,7 +645,9 @@ class _BatchBase:
                 uuid=uuid,
                 vector=vector,
                 tenant=tenant,
+                index=self.__objs_count,
             )
+            self.__objs_count += 1
             self.__results_for_wrapper.imported_shards.add(
                 Shard(collection=collection, tenant=tenant)
             )

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -502,9 +502,6 @@ class _BatchBase:
                 response_obj = BatchObjectReturn(
                     all_responses=list(errors_obj.values()),
                     elapsed_seconds=time.time() - start,
-                    errors=errors_obj,
-                    has_errors=True,
-                    uuids={},
                 )
 
             readded_uuids = set()
@@ -552,15 +549,7 @@ class _BatchBase:
 
                 self.__batch_objects.prepend(readd_objects)
 
-                new_errors = {
-                    i: err for i, err in response_obj.errors.items() if i not in readded_objects
-                }
                 response_obj = BatchObjectReturn(
-                    uuids={
-                        i: uid for i, uid in response_obj.uuids.items() if i not in readded_objects
-                    },
-                    errors=new_errors,
-                    has_errors=len(new_errors) > 0,
                     all_responses=[
                         err
                         for i, err in enumerate(response_obj.all_responses)

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -4,7 +4,7 @@ import threading
 import time
 import uuid as uuid_package
 from abc import ABC
-from collections import deque, OrderedDict
+from collections import deque
 from copy import copy
 from dataclasses import dataclass, field
 from typing import (
@@ -496,9 +496,9 @@ class _BatchBase:
                     objects=objs, timeout=DEFAULT_REQUEST_TIMEOUT
                 )
             except Exception as e:
-                errors_obj = OrderedDict(
-                    (idx, ErrorObject(message=repr(e), object_=obj)) for idx, obj in enumerate(objs)
-                )
+                errors_obj = {
+                    idx: ErrorObject(message=repr(e), object_=obj) for idx, obj in enumerate(objs)
+                }
                 response_obj = BatchObjectReturn(
                     _all_responses=list(errors_obj.values()),
                     elapsed_seconds=time.time() - start,
@@ -551,15 +551,13 @@ class _BatchBase:
 
                 self.__batch_objects.prepend(readd_objects)
 
-                new_errors = OrderedDict(
-                    (i, err) for i, err in response_obj.errors.items() if i not in readded_objects
-                )
+                new_errors = {
+                    i: err for i, err in response_obj.errors.items() if i not in readded_objects
+                }
                 response_obj = BatchObjectReturn(
-                    uuids=OrderedDict(
-                        (i, uid)
-                        for i, uid in response_obj.uuids.items()
-                        if i not in readded_objects
-                    ),
+                    uuids={
+                        i: uid for i, uid in response_obj.uuids.items() if i not in readded_objects
+                    },
                     errors=new_errors,
                     has_errors=len(new_errors) > 0,
                     _all_responses=[

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -2,7 +2,7 @@ import datetime
 import struct
 import time
 import uuid as uuid_package
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, cast
 
 import grpc  # type: ignore
 from google.protobuf.struct_pb2 import Struct
@@ -105,27 +105,13 @@ class _BatchGRPC(_BaseGRPC):
                 )
             )
 
-        all_responses: List[Union[uuid_package.UUID, ErrorObject]] = cast(
-            List[Union[uuid_package.UUID, ErrorObject]], list(range(len(weaviate_objs)))
-        )
-        return_success: Dict[int, uuid_package.UUID] = {}
-        return_errors: Dict[int, ErrorObject] = {}
-
-        for idx, obj in enumerate(weaviate_objs):
-            if idx in errors:
-                error = ErrorObject(errors[idx], objects[idx], original_uuid=objects[idx].uuid)
-                return_errors[idx] = error
-                all_responses[idx] = error
-            else:
-                success = uuid_package.UUID(obj.uuid)
-                return_success[idx] = success
-                all_responses[idx] = success
-
         return BatchObjectReturn(
-            uuids=return_success,
-            errors=return_errors,
-            has_errors=len(errors) > 0,
-            all_responses=all_responses,
+            all_responses=[
+                ErrorObject(errors[idx], objects[idx], original_uuid=objects[idx].uuid)
+                if idx in errors
+                else uuid_package.UUID(obj.uuid)
+                for idx, obj in enumerate(weaviate_objs)
+            ],
             elapsed_seconds=elapsed_time,
         )
 
@@ -168,27 +154,13 @@ class _BatchGRPC(_BaseGRPC):
         errors = await self.__send_batch_async(weaviate_objs, timeout=timeout)
         elapsed_time = time.time() - start
 
-        all_responses: List[Union[uuid_package.UUID, ErrorObject]] = cast(
-            List[Union[uuid_package.UUID, ErrorObject]], list(range(len(weaviate_objs)))
-        )
-        return_success: Dict[int, uuid_package.UUID] = {}
-        return_errors: Dict[int, ErrorObject] = {}
-
-        for idx, obj in enumerate(weaviate_objs):
-            if idx in errors:
-                error = ErrorObject(errors[idx], objects[idx], original_uuid=objects[idx].uuid)
-                return_errors[idx] = error
-                all_responses[idx] = error
-            else:
-                success = uuid_package.UUID(obj.uuid)
-                return_success[idx] = success
-                all_responses[idx] = success
-
         return BatchObjectReturn(
-            uuids=return_success,
-            errors=return_errors,
-            has_errors=len(errors) > 0,
-            all_responses=all_responses,
+            all_responses=[
+                ErrorObject(errors[idx], objects[idx], original_uuid=objects[idx].uuid)
+                if idx in errors
+                else uuid_package.UUID(obj.uuid)
+                for idx, obj in enumerate(weaviate_objs)
+            ],
             elapsed_seconds=elapsed_time,
         )
 

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -125,7 +125,7 @@ class _BatchGRPC(_BaseGRPC):
             uuids=return_success,
             errors=return_errors,
             has_errors=len(errors) > 0,
-            all_responses=all_responses,
+            _all_responses=all_responses,
             elapsed_seconds=elapsed_time,
         )
 
@@ -188,7 +188,7 @@ class _BatchGRPC(_BaseGRPC):
             uuids=return_success,
             errors=return_errors,
             has_errors=len(errors) > 0,
-            all_responses=all_responses,
+            _all_responses=all_responses,
             elapsed_seconds=elapsed_time,
         )
 

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -2,6 +2,7 @@ import datetime
 import struct
 import time
 import uuid as uuid_package
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Union, cast
 
 import grpc  # type: ignore
@@ -108,8 +109,8 @@ class _BatchGRPC(_BaseGRPC):
         all_responses: List[Union[uuid_package.UUID, ErrorObject]] = cast(
             List[Union[uuid_package.UUID, ErrorObject]], list(range(len(weaviate_objs)))
         )
-        return_success: Dict[int, uuid_package.UUID] = {}
-        return_errors: Dict[int, ErrorObject] = {}
+        return_success: OrderedDict[int, uuid_package.UUID] = OrderedDict()
+        return_errors: OrderedDict[int, ErrorObject] = OrderedDict()
 
         for idx, obj in enumerate(weaviate_objs):
             if idx in errors:
@@ -171,8 +172,8 @@ class _BatchGRPC(_BaseGRPC):
         all_responses: List[Union[uuid_package.UUID, ErrorObject]] = cast(
             List[Union[uuid_package.UUID, ErrorObject]], list(range(len(weaviate_objs)))
         )
-        return_success: Dict[int, uuid_package.UUID] = {}
-        return_errors: Dict[int, ErrorObject] = {}
+        return_success: OrderedDict[int, uuid_package.UUID] = OrderedDict()
+        return_errors: OrderedDict[int, ErrorObject] = OrderedDict()
 
         for idx, obj in enumerate(weaviate_objs):
             if idx in errors:

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -2,7 +2,6 @@ import datetime
 import struct
 import time
 import uuid as uuid_package
-from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Union, cast
 
 import grpc  # type: ignore
@@ -109,8 +108,8 @@ class _BatchGRPC(_BaseGRPC):
         all_responses: List[Union[uuid_package.UUID, ErrorObject]] = cast(
             List[Union[uuid_package.UUID, ErrorObject]], list(range(len(weaviate_objs)))
         )
-        return_success: OrderedDict[int, uuid_package.UUID] = OrderedDict()
-        return_errors: OrderedDict[int, ErrorObject] = OrderedDict()
+        return_success: Dict[int, uuid_package.UUID] = {}
+        return_errors: Dict[int, ErrorObject] = {}
 
         for idx, obj in enumerate(weaviate_objs):
             if idx in errors:
@@ -172,8 +171,8 @@ class _BatchGRPC(_BaseGRPC):
         all_responses: List[Union[uuid_package.UUID, ErrorObject]] = cast(
             List[Union[uuid_package.UUID, ErrorObject]], list(range(len(weaviate_objs)))
         )
-        return_success: OrderedDict[int, uuid_package.UUID] = OrderedDict()
-        return_errors: OrderedDict[int, ErrorObject] = OrderedDict()
+        return_success: Dict[int, uuid_package.UUID] = {}
+        return_errors: Dict[int, ErrorObject] = {}
 
         for idx, obj in enumerate(weaviate_objs):
             if idx in errors:

--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -111,15 +111,16 @@ class _BatchGRPC(_BaseGRPC):
         return_success: Dict[int, uuid_package.UUID] = {}
         return_errors: Dict[int, ErrorObject] = {}
 
-        for idx, obj in enumerate(weaviate_objs):
+        for idx, weav_obj in enumerate(weaviate_objs):
+            obj = objects[idx]
             if idx in errors:
-                error = ErrorObject(errors[idx], objects[idx], original_uuid=objects[idx].uuid)
-                return_errors[idx] = error
-                all_responses[idx] = error
+                error = ErrorObject(errors[idx], obj, original_uuid=obj.uuid)
+                return_errors[obj.index] = error
+                all_responses[obj.index] = error
             else:
-                success = uuid_package.UUID(obj.uuid)
-                return_success[idx] = success
-                all_responses[idx] = success
+                success = uuid_package.UUID(weav_obj.uuid)
+                return_success[obj.index] = success
+                all_responses[obj.index] = success
 
         return BatchObjectReturn(
             uuids=return_success,
@@ -174,14 +175,15 @@ class _BatchGRPC(_BaseGRPC):
         return_success: Dict[int, uuid_package.UUID] = {}
         return_errors: Dict[int, ErrorObject] = {}
 
-        for idx, obj in enumerate(weaviate_objs):
+        for idx, weav_obj in enumerate(weaviate_objs):
+            obj = objects[idx]
             if idx in errors:
-                error = ErrorObject(errors[idx], objects[idx], original_uuid=objects[idx].uuid)
-                return_errors[idx] = error
+                error = ErrorObject(errors[idx], obj, original_uuid=obj.uuid)
+                return_errors[obj.index] = error
                 all_responses[idx] = error
             else:
-                success = uuid_package.UUID(obj.uuid)
-                return_success[idx] = success
+                success = uuid_package.UUID(weav_obj.uuid)
+                return_success[obj.index] = success
                 all_responses[idx] = success
 
         return BatchObjectReturn(

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -179,9 +179,9 @@ class BatchObjectReturn:
     _all_responses: List[Union[uuid_package.UUID, ErrorObject]] = field(default_factory=list)
     elapsed_seconds: float = 0.0
     """The time taken to perform the batch operation."""
-    errors: Dict[int, ErrorObject] = field(default_factory=OrderedDict)
+    errors: OrderedDict[int, ErrorObject] = field(default_factory=OrderedDict)
     """A dictionary of all the failed responses from the batch operation. The keys are the indices of the objects in the overall batch, and the values are the `Error` objects."""
-    uuids: Dict[int, uuid_package.UUID] = field(default_factory=OrderedDict)
+    uuids: OrderedDict[int, uuid_package.UUID] = field(default_factory=OrderedDict)
     """A dictionary of all the successful responses from the batch operation. The keys are the indices of the objects in the overall batch, and the values are the `uuid_package.UUID` objects."""
     has_errors: bool = False
     """A boolean indicating whether or not any of the objects in the batch failed to be inserted. If this is `True`, then the `errors` dictionary will contain at least one entry."""

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -1,6 +1,7 @@
 import uuid as uuid_package
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from copy import copy
 from heapq import merge
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
@@ -210,7 +211,7 @@ class BatchObjectReturn:
         if len(self.uuids.keys()) > MAX_STORED_RESULTS:
             new_max = max(self.uuids.keys())
             new_uuid_indices = range(new_max - MAX_STORED_RESULTS + 1, new_max + 1)
-            for key in self.uuids.keys():
+            for key in copy(list(self.uuids.keys())):
                 if key not in new_uuid_indices:
                     del self.uuids[key]
             self._all_responses = [

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -1,5 +1,4 @@
 import uuid as uuid_package
-from collections import OrderedDict
 from dataclasses import dataclass, field
 from copy import copy
 from heapq import merge
@@ -179,9 +178,9 @@ class BatchObjectReturn:
     _all_responses: List[Union[uuid_package.UUID, ErrorObject]] = field(default_factory=list)
     elapsed_seconds: float = 0.0
     """The time taken to perform the batch operation."""
-    errors: OrderedDict[int, ErrorObject] = field(default_factory=OrderedDict)
+    errors: Dict[int, ErrorObject] = field(default_factory=dict)
     """A dictionary of all the failed responses from the batch operation. The keys are the indices of the objects in the overall batch, and the values are the `Error` objects."""
-    uuids: OrderedDict[int, uuid_package.UUID] = field(default_factory=OrderedDict)
+    uuids: Dict[int, uuid_package.UUID] = field(default_factory=dict)
     """A dictionary of all the successful responses from the batch operation. The keys are the indices of the objects in the overall batch, and the values are the `uuid_package.UUID` objects."""
     has_errors: bool = False
     """A boolean indicating whether or not any of the objects in the batch failed to be inserted. If this is `True`, then the `errors` dictionary will contain at least one entry."""
@@ -245,7 +244,7 @@ class BatchReferenceReturn:
     """
 
     elapsed_seconds: float = 0.0
-    errors: Dict[int, ErrorReference] = field(default_factory=OrderedDict)
+    errors: Dict[int, ErrorReference] = field(default_factory=dict)
     has_errors: bool = False
 
     def __add__(self, other: "BatchReferenceReturn") -> "BatchReferenceReturn":

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -207,7 +207,9 @@ class BatchObjectReturn:
             old_min = next(iter(self.uuids))
             for k in range(old_min, new_min):
                 del self.uuids[k]
+        if len(self._all_responses) > MAX_STORED_RESULTS:
             self._all_responses = self._all_responses[-MAX_STORED_RESULTS:]
+
         return self
 
 

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -203,8 +203,10 @@ class BatchObjectReturn:
         self.has_errors = self.has_errors or other.has_errors
 
         if len(self.uuids.keys()) > MAX_STORED_RESULTS:
-            new_min = len(self.uuids.keys()) - MAX_STORED_RESULTS
-            self.uuids = {k: v for k, v in self.uuids.items() if k >= new_min}
+            new_min = max(self.uuids.keys()) - MAX_STORED_RESULTS + 1
+            old_min = next(iter(self.uuids))
+            for k in range(old_min, new_min):
+                del self.uuids[k]
         if len(self._all_responses) > MAX_STORED_RESULTS:
             self._all_responses = self._all_responses[-MAX_STORED_RESULTS:]
 

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -203,10 +203,8 @@ class BatchObjectReturn:
         self.has_errors = self.has_errors or other.has_errors
 
         if len(self.uuids.keys()) > MAX_STORED_RESULTS:
-            new_min = max(self.uuids.keys()) - MAX_STORED_RESULTS + 1
-            old_min = next(iter(self.uuids))
-            for k in range(old_min, new_min):
-                del self.uuids[k]
+            new_min = len(self.uuids.keys()) - MAX_STORED_RESULTS
+            self.uuids = {k: v for k, v in self.uuids.items() if k >= new_min}
         if len(self._all_responses) > MAX_STORED_RESULTS:
             self._all_responses = self._all_responses[-MAX_STORED_RESULTS:]
 

--- a/weaviate/collections/data.py
+++ b/weaviate/collections/data.py
@@ -417,6 +417,7 @@ class _DataCollection(Generic[Properties], _Data):
                         properties=cast(dict, obj.properties),
                         tenant=self._tenant,
                         references=obj.references,
+                        index=idx,
                     )
                     if isinstance(obj, DataObject)
                     else _BatchObject(
@@ -426,9 +427,10 @@ class _DataCollection(Generic[Properties], _Data):
                         properties=cast(dict, obj),
                         tenant=self._tenant,
                         references=None,
+                        index=idx,
                     )
                 )
-                for obj in objects
+                for idx, obj in enumerate(objects)
             ],
             timeout=self._connection.timeout_config.insert,
         )

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -198,6 +198,14 @@ class _Warnings:
         )
 
     @staticmethod
+    def batch_results_objects_all_responses_attribute() -> None:
+        warnings.warn(
+            message="""Dep020: The `all_responses` attribute in the `BatchResults` object is deprecated and will be removed by Q4 2024. Please instead use the `errors` and `uuids` attributes.""",
+            category=DeprecationWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
     def datetime_insertion_with_no_specified_timezone(date: datetime) -> None:
         warnings.warn(
             message=f"""Con002: You are inserting the datetime object {date} without a timezone. The timezone will be set to UTC.


### PR DESCRIPTION
- Limits total number of stored results to 100,000. Should this be configurable?

Closes https://github.com/weaviate/weaviate-python-client/issues/1094