### PR TITLE
Update grpcio dependencies to avoid warnings

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -2,9 +2,9 @@ requests>=2.30.0,<3.0.0
 httpx>=0.25.2,<=0.27.0
 validators==0.28.3
 authlib>=1.2.1,<2.0.0
-grpcio>=1.57.0,<2.0.0
-grpcio-tools>=1.57.0,<2.0.0
-grpcio-health-checking>=1.57.0,<2.0.0
+grpcio>=1.64.1,<2.0.0
+grpcio-tools>=1.64.1,<2.0.0
+grpcio-health-checking>=1.64.1,<2.0.0
 pydantic>=2.5.0,<3.0.0
 
 build

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,9 +42,9 @@ install_requires =
     validators==0.28.3
     authlib>=1.2.1,<2.0.0
     pydantic>=2.5.0,<3.0.0
-    grpcio>=1.57.0,<2.0.0
-    grpcio-tools>=1.57.0,<2.0.0
-    grpcio-health-checking>=1.57.0,<2.0.0
+    grpcio>=1.64.1,<2.0.0
+    grpcio-tools>=1.64.1,<2.0.0
+    grpcio-health-checking>=1.64.1,<2.0.0
 python_requires = >=3.8
 
 


### PR DESCRIPTION
```
RuntimeWarning: The grpc package installed is at version 1.60.0, but the generated code in v1/weaviate_pb2_grpc.py depends on grpcio>=1.64.1. Please upgrade your grpc module to grpcio>=1.64.1 or downgrade your generated code using grpcio-tools<=1.60.0. This warning will become an error in 1.65.0, scheduled for release on June 25, 2024.
```
updated to 1.64.1 minimum