### PR TITLE
Add validation for types that are not installed

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -297,7 +297,7 @@ jobs:
           name: weaviate-python-client-wheel
       - run: |
           pip install weaviate_client-*.whl
-          pip install -r requirement-devel.txt  # install test dependencies
+          pip install -r requirements-devel.txt  # install test dependencies
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -297,7 +297,7 @@ jobs:
           name: weaviate-python-client-wheel
       - run: |
           pip install weaviate_client-*.whl
-          pip install pytest pytest-benchmark pytest-profiling grpcio grpcio-tools pytest-xdist
+          pip install -r requirement-devel.txt  # install test dependencies
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -291,6 +291,10 @@ jobs:
           $WEAVIATE_126
         ]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Download build artifact to append to release
         uses: actions/download-artifact@v4
         with:
@@ -298,10 +302,6 @@ jobs:
       - run: |
           pip install weaviate_client-*.whl
           pip install -r requirements-devel.txt  # install test dependencies
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: free space
         run: sudo rm -rf /usr/local/lib/android
       - run: rm -r weaviate

--- a/integration/test_collection_near_vector.py
+++ b/integration/test_collection_near_vector.py
@@ -146,14 +146,15 @@ def test_near_vector_with_other_input(
         {"first": np.array([1, 0]), "second": [1, 0, 0]},
         [np.array([1, 0]), [1, 0, 0]],
         {"first": [1.0, 0.0], "second": [1.0, 0.0, 0.0]},
-        {"first": np.array([1.0, 0]), "second": [1.0, 0, 0]},
-        {"first": np.array([1.0, 0]), "second": [1.0, 0, 0]},
-        [np.array([1.0, 0]), [1.0, 0, 0]],
     ],
 )
 def test_near_vector_with_named_vector_other_input(
     collection_factory: CollectionFactory, near_vector: Any
 ) -> None:
+    dummy = collection_factory("dummy")
+    if not dummy._connection._weaviate_version.is_lower_than(1, 26, 0):
+        pytest.skip("Named vectors are supported in versions higher than 1.26.0")
+
     collection = collection_factory(
         vectorizer_config=[
             Configure.NamedVectors.none("first"),

--- a/integration/test_collection_near_vector.py
+++ b/integration/test_collection_near_vector.py
@@ -2,6 +2,8 @@ import uuid
 from typing import Any
 
 import numpy as np
+import pandas as pd
+import polars as pl
 import pytest
 
 from integration.conftest import CollectionFactory
@@ -121,7 +123,9 @@ def test_near_vector_group_by_argument(collection_factory: CollectionFactory) ->
     assert ret.objects[3].belongs_to_group == "Mountain"
 
 
-@pytest.mark.parametrize("near_vector", [[1, 0], [1.0, 0.0], np.array([1, 0])])
+@pytest.mark.parametrize(
+    "near_vector", [[1, 0], [1.0, 0.0], np.array([1, 0]), pl.Series([1, 0]), pd.Series([1, 0])]
+)
 def test_near_vector_with_other_input(
     collection_factory: CollectionFactory, near_vector: Any
 ) -> None:
@@ -143,8 +147,11 @@ def test_near_vector_with_other_input(
     [
         {"first": [1, 0], "second": [1, 0, 0]},
         {"first": np.array([1, 0]), "second": [1, 0, 0]},
-        {"first": np.array([1, 0]), "second": [1, 0, 0]},
+        {"first": pl.Series([1, 0]), "second": [1, 0, 0]},
+        {"first": pd.Series([1, 0]), "second": [1, 0, 0]},
         [np.array([1, 0]), [1, 0, 0]],
+        [pl.Series([1, 0]), [1, 0, 0]],
+        [pd.Series([1, 0]), [1, 0, 0]],
         {"first": [1.0, 0.0], "second": [1.0, 0.0, 0.0]},
     ],
 )

--- a/integration/test_collection_near_vector.py
+++ b/integration/test_collection_near_vector.py
@@ -152,8 +152,8 @@ def test_near_vector_with_named_vector_other_input(
     collection_factory: CollectionFactory, near_vector: Any
 ) -> None:
     dummy = collection_factory("dummy")
-    if not dummy._connection._weaviate_version.is_lower_than(1, 24, 0):
-        pytest.skip("Named vectors are supported in versions higher than 1.24.0")
+    if not dummy._connection._weaviate_version.is_lower_than(1, 26, 0):
+        pytest.skip("Named vectors are supported in versions higher than 1.26.0")
 
     collection = collection_factory(
         vectorizer_config=[

--- a/integration/test_collection_near_vector.py
+++ b/integration/test_collection_near_vector.py
@@ -152,7 +152,7 @@ def test_near_vector_with_named_vector_other_input(
     collection_factory: CollectionFactory, near_vector: Any
 ) -> None:
     dummy = collection_factory("dummy")
-    if not dummy._connection._weaviate_version.is_lower_than(1, 26, 0):
+    if dummy._connection._weaviate_version.is_lower_than(1, 26, 0):
         pytest.skip("Named vectors are supported in versions higher than 1.26.0")
 
     collection = collection_factory(

--- a/integration/test_collection_near_vector.py
+++ b/integration/test_collection_near_vector.py
@@ -152,8 +152,8 @@ def test_near_vector_with_named_vector_other_input(
     collection_factory: CollectionFactory, near_vector: Any
 ) -> None:
     dummy = collection_factory("dummy")
-    if not dummy._connection._weaviate_version.is_lower_than(1, 26, 0):
-        pytest.skip("Named vectors are supported in versions higher than 1.26.0")
+    if not dummy._connection._weaviate_version.is_lower_than(1, 24, 0):
+        pytest.skip("Named vectors are supported in versions higher than 1.24.0")
 
     collection = collection_factory(
         vectorizer_config=[

--- a/integration/test_collection_near_vector.py
+++ b/integration/test_collection_near_vector.py
@@ -1,0 +1,169 @@
+import uuid
+from typing import Any
+
+import numpy as np
+import pytest
+
+from integration.conftest import CollectionFactory
+from weaviate.collections.classes.config import (
+    Configure,
+    DataType,
+    Property,
+)
+from weaviate.collections.classes.grpc import (
+    GroupBy,
+    MetadataQuery,
+)
+
+UUID1 = uuid.UUID("806827e0-2b31-43ca-9269-24fa95a221f9")
+UUID2 = uuid.UUID("8ad0d33c-8db1-4437-87f3-72161ca2a51a")
+UUID3 = uuid.UUID("83d99755-9deb-4b16-8431-d1dff4ab0a75")
+
+
+def test_near_vector(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana = collection.data.insert({"Name": "Banana"})
+    collection.data.insert({"Name": "Fruit"})
+    collection.data.insert({"Name": "car"})
+    collection.data.insert({"Name": "Mountain"})
+
+    banana = collection.query.fetch_object_by_id(uuid_banana, include_vector=True)
+
+    full_objects = collection.query.near_vector(
+        banana.vector["default"], return_metadata=MetadataQuery(distance=True, certainty=True)
+    ).objects
+    assert len(full_objects) == 4
+
+    objects_distance = collection.query.near_vector(
+        banana.vector["default"], distance=full_objects[2].metadata.distance
+    ).objects
+    assert len(objects_distance) == 3
+
+    objects_distance = collection.query.near_vector(
+        banana.vector["default"], certainty=full_objects[2].metadata.certainty
+    ).objects
+    assert len(objects_distance) == 3
+
+
+def test_near_vector_limit(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana = collection.data.insert({"Name": "Banana"})
+    collection.data.insert({"Name": "Fruit"})
+    collection.data.insert({"Name": "car"})
+    collection.data.insert({"Name": "Mountain"})
+
+    banana = collection.query.fetch_object_by_id(uuid_banana, include_vector=True)
+
+    objs = collection.query.near_vector(banana.vector["default"], limit=2).objects
+    assert len(objs) == 2
+
+
+def test_near_vector_offset(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[Property(name="Name", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana = collection.data.insert({"Name": "Banana"})
+    uuid_fruit = collection.data.insert({"Name": "Fruit"})
+    collection.data.insert({"Name": "car"})
+    collection.data.insert({"Name": "Mountain"})
+
+    banana = collection.query.fetch_object_by_id(uuid_banana, include_vector=True)
+
+    objs = collection.query.near_vector(banana.vector["default"], offset=1).objects
+    assert len(objs) == 3
+    assert objs[0].uuid == uuid_fruit
+
+
+def test_near_vector_group_by_argument(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[
+            Property(name="Name", data_type=DataType.TEXT),
+            Property(name="Count", data_type=DataType.INT),
+        ],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    uuid_banana1 = collection.data.insert({"Name": "Banana", "Count": 51})
+    collection.data.insert({"Name": "Banana", "Count": 72})
+    collection.data.insert({"Name": "car", "Count": 12})
+    collection.data.insert({"Name": "Mountain", "Count": 1})
+
+    banana1 = collection.query.fetch_object_by_id(uuid_banana1, include_vector=True)
+
+    ret = collection.query.near_vector(
+        banana1.vector["default"],
+        group_by=GroupBy(
+            prop="name",
+            number_of_groups=4,
+            objects_per_group=10,
+        ),
+        return_metadata=MetadataQuery(distance=True, certainty=True),
+    )
+
+    assert len(ret.objects) == 4
+    assert ret.objects[0].belongs_to_group == "Banana"
+    assert ret.objects[1].belongs_to_group == "Banana"
+    assert ret.objects[2].belongs_to_group == "car"
+    assert ret.objects[3].belongs_to_group == "Mountain"
+
+
+@pytest.mark.parametrize("near_vector", [[1, 0], [1.0, 0.0], np.array([1, 0])])
+def test_near_vector_with_other_input(
+    collection_factory: CollectionFactory, near_vector: Any
+) -> None:
+    collection = collection_factory(vectorizer_config=Configure.Vectorizer.none())
+
+    uuid1 = collection.data.insert({}, vector=[1, 0])
+    collection.data.insert({}, vector=[0, 1])
+
+    ret = collection.query.near_vector(
+        near_vector,
+        distance=0.1,
+    )
+    assert len(ret.objects) == 1
+    assert ret.objects[0].uuid == uuid1
+
+
+@pytest.mark.parametrize(
+    "near_vector",
+    [
+        {"first": [1, 0], "second": [1, 0, 0]},
+        {"first": np.array([1, 0]), "second": [1, 0, 0]},
+        {"first": np.array([1, 0]), "second": [1, 0, 0]},
+        [np.array([1, 0]), [1, 0, 0]],
+        {"first": [1.0, 0.0], "second": [1.0, 0.0, 0.0]},
+        {"first": np.array([1.0, 0]), "second": [1.0, 0, 0]},
+        {"first": np.array([1.0, 0]), "second": [1.0, 0, 0]},
+        [np.array([1.0, 0]), [1.0, 0, 0]],
+    ],
+)
+def test_near_vector_with_named_vector_other_input(
+    collection_factory: CollectionFactory, near_vector: Any
+) -> None:
+    collection = collection_factory(
+        vectorizer_config=[
+            Configure.NamedVectors.none("first"),
+            Configure.NamedVectors.none("second"),
+        ]
+    )
+
+    uuid1 = collection.data.insert({}, vector={"first": [1, 0], "second": [1, 0, 0]})
+    collection.data.insert({}, vector={"first": [0, 1], "second": [0, 0, 1]})
+
+    ret = collection.query.near_vector(near_vector, distance=0.1, target_vector=["first", "second"])
+    assert len(ret.objects) == 1
+    assert ret.objects[0].uuid == uuid1

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -29,6 +29,7 @@ pytest-httpserver>=1.0.8
 
 numpy>=1.24.4,<2.0.0
 pandas>=2.0.3,<3.0.0
+pandas-stubs>=2.0.3,<3.0.0
 polars>=0.20.26,<0.21.0
 
 mypy>=1.9.0,<2.0.0

--- a/test/collection/test_validator.py
+++ b/test/collection/test_validator.py
@@ -1,0 +1,38 @@
+from typing import Any, List
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+from weaviate.exceptions import WeaviateInvalidInputError
+from weaviate.validator import _validate_input, _ValidateArgument, _ExtraTypes
+
+
+@pytest.mark.parametrize(
+    "inputs,expected,error",
+    [
+        (1, [int], False),
+        (1.0, [int], True),
+        ([1, 1], [List], False),
+        (np.array([1, 2, 3]), [_ExtraTypes.NUMPY], False),
+        (np.array([1, 2, 3]), [_ExtraTypes.NUMPY, List], False),
+        (np.array([1, 2, 3]), [List], True),
+        ([1, 1], [List, _ExtraTypes.NUMPY], False),
+        (pd.array([1, 1]), [_ExtraTypes.PANDAS, List], False),
+        (pd.Series([1, 1]), [_ExtraTypes.PANDAS, List], False),
+        (pl.Series([1, 1]), [_ExtraTypes.POLARS, List], False),
+        (
+            pl.Series([1, 1]),
+            [_ExtraTypes.POLARS, _ExtraTypes.PANDAS, _ExtraTypes.NUMPY, List],
+            False,
+        ),
+        (pl.Series([1, 1]), [_ExtraTypes.PANDAS, _ExtraTypes.NUMPY, List], True),
+    ],
+)
+def test_validator(inputs: Any, expected: List[Any], error: bool) -> None:
+    if error:
+        with pytest.raises(WeaviateInvalidInputError):
+            _validate_input(_ValidateArgument(expected=expected, name="test", value=inputs))
+    else:
+        _validate_input(_ValidateArgument(expected=expected, name="test", value=inputs))

--- a/weaviate/collections/classes/grpc.py
+++ b/weaviate/collections/classes/grpc.py
@@ -6,8 +6,8 @@ from pydantic import ConfigDict, Field
 
 from weaviate.collections.classes.types import _WeaviateInput
 from weaviate.proto.v1 import search_get_pb2
+from weaviate.str_enum import BaseEnum
 from weaviate.types import INCLUDE_VECTOR, UUID
-from weaviate.util import BaseEnum
 
 
 class HybridFusion(str, BaseEnum):

--- a/weaviate/collections/grpc/query.py
+++ b/weaviate/collections/grpc/query.py
@@ -56,7 +56,7 @@ from weaviate.exceptions import (
 from weaviate.proto.v1 import search_get_pb2
 from weaviate.types import NUMBER, UUID
 from weaviate.util import _get_vector_v4
-from weaviate.validator import _ValidateArgument, _validate_input
+from weaviate.validator import _ValidateArgument, _validate_input, _ExtraTypes
 
 # Can be found in the google.protobuf.internal.well_known_types.pyi stub file but is defined explicitly here for clarity.
 _PyValue: TypeAlias = Union[
@@ -330,7 +330,18 @@ class _QueryGRPC(_BaseGRPC):
         if self._validate_arguments:
             _validate_input(
                 [
-                    _ValidateArgument([List, Dict], "near_vector", near_vector),
+                    _ValidateArgument(
+                        [
+                            List,
+                            Dict,
+                            _ExtraTypes.PANDAS,
+                            _ExtraTypes.POLARS,
+                            _ExtraTypes.NUMPY,
+                            _ExtraTypes.TF,
+                        ],
+                        "near_vector",
+                        near_vector,
+                    ),
                     _ValidateArgument(
                         [str, None, List, _MultiTargetVectorJoin], "target_vector", target_vector
                     ),

--- a/weaviate/gql/get.py
+++ b/weaviate/gql/get.py
@@ -7,6 +7,8 @@ from enum import Enum
 from json import dumps
 from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
+import grpc  # type: ignore
+
 from weaviate import util
 from weaviate.connect import Connection
 from weaviate.data.replication import ConsistencyLevel
@@ -28,18 +30,16 @@ from weaviate.gql.filter import (
     MediaType,
     Sort,
 )
+from weaviate.proto.v1 import search_get_pb2
+from weaviate.str_enum import BaseEnum
+from weaviate.types import UUID
 from weaviate.util import (
     image_encoder_b64,
     _capitalize_first_letter,
     get_valid_uuid,
     file_encoder_b64,
-    BaseEnum,
 )
 from weaviate.warnings import _Warnings
-from weaviate.types import UUID
-
-from weaviate.proto.v1 import search_get_pb2
-import grpc  # type: ignore
 
 
 @dataclass

--- a/weaviate/str_enum.py
+++ b/weaviate/str_enum.py
@@ -1,0 +1,19 @@
+# MetaEnum and BaseEnum are required to support `in` statements:
+#    'ALL' in ConsistencyLevel == True
+#    12345 in ConsistencyLevel == False
+from enum import EnumMeta, Enum
+from typing import Any
+
+
+class MetaEnum(EnumMeta):
+    def __contains__(cls, item: Any) -> bool:
+        try:
+            # when item is type ConsistencyLevel
+            return item.name in cls.__members__.keys()
+        except AttributeError:
+            # when item is type str
+            return item in cls.__members__.keys()
+
+
+class BaseEnum(Enum, metaclass=MetaEnum):
+    pass

--- a/weaviate/validator.py
+++ b/weaviate/validator.py
@@ -37,6 +37,9 @@ def _validate_input(inputs: Union[List[_ValidateArgument], _ValidateArgument]) -
 def _is_valid(expected: Any, value: Any) -> bool:
     if expected is None:
         return value is None
+
+    # check for types that are not installed
+    # https://stackoverflow.com/questions/12569452/how-to-identify-numpy-types-in-python
     if isinstance(expected, _ExtraTypes):
         return expected.value in type(value).__module__
 

--- a/weaviate/validator.py
+++ b/weaviate/validator.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, List, Sequence, Union, get_args, get_origin
 
 from weaviate.exceptions import WeaviateInvalidInputError
+from weaviate.util import BaseEnum
 
 
 @dataclass
@@ -9,6 +10,13 @@ class _ValidateArgument:
     expected: List[Any]
     name: str
     value: Any
+
+
+class _ExtraTypes(str, BaseEnum):
+    NUMPY = "numpy"
+    PANDAS = "pandas"
+    POLARS = "polars"
+    TF = "tensorflow"
 
 
 def _validate_input(inputs: Union[List[_ValidateArgument], _ValidateArgument]) -> None:
@@ -29,6 +37,9 @@ def _validate_input(inputs: Union[List[_ValidateArgument], _ValidateArgument]) -
 def __is_valid(expected: Any, value: Any) -> bool:
     if expected is None:
         return value is None
+    if isinstance(expected, _ExtraTypes):
+        return expected.value in type(value).__module__
+
     expected_origin = get_origin(expected)
     if expected_origin is Union:
         args = get_args(expected)

--- a/weaviate/validator.py
+++ b/weaviate/validator.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, List, Sequence, Union, get_args, get_origin
 
 from weaviate.exceptions import WeaviateInvalidInputError
-from weaviate.util import BaseEnum
+from weaviate.str_enum import BaseEnum
 
 
 @dataclass
@@ -28,13 +28,13 @@ def _validate_input(inputs: Union[List[_ValidateArgument], _ValidateArgument]) -
     if isinstance(inputs, _ValidateArgument):
         inputs = [inputs]
     for validate in inputs:
-        if not any(__is_valid(exp, validate.value) for exp in validate.expected):
+        if not any(_is_valid(exp, validate.value) for exp in validate.expected):
             raise WeaviateInvalidInputError(
                 f"Argument '{validate.name}' must be one of: {validate.expected}, but got {type(validate.value)}"
             )
 
 
-def __is_valid(expected: Any, value: Any) -> bool:
+def _is_valid(expected: Any, value: Any) -> bool:
     if expected is None:
         return value is None
     if isinstance(expected, _ExtraTypes):


### PR DESCRIPTION
We accept numpy etc as vectors and convert them internally into lists. This causes problems with the new multi-vector approach, as we need to do different things depending on the input type.

This adds:
- input-validation for numpy etc without installing these dependencies
- better type checking in near_vector code