### PR TITLE
Custom vectorizers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 100
 exclude = .git, venv, .venv, .pytest_cache, dist, .idea, docs/conf.py, weaviate/collections/orm.py, weaviate/collections/classes/orm.py, weaviate/proto/**/*.py
-ignore = D100, D104, D105, D107, E203, E266, E501, E731, W503
+ignore = D100, D104, D105, D107, E203, E266, E501, E704, E731, W503
 per-file-ignores =
     weaviate/cluster/types.py:A005
     weaviate/collections/classes/types.py:A005
@@ -14,4 +14,5 @@ per-file-ignores =
 # D104: Missing docstring in public package
 # D105: Missing docstring in magic method
 # D107: Missing docstring in __init__
+# E704: Multiple statements on one line (def)
 

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -947,6 +947,10 @@ def test_create_custom_vectorizer(collection_factory: CollectionFactory) -> None
 
 
 def test_create_custom_vectorizer_named(collection_factory: CollectionFactory) -> None:
+    collection_dummy = collection_factory("dummy")
+    if collection_dummy._connection._weaviate_version.is_lower_than(1, 24, 0):
+        pytest.skip("Named index is not supported in Weaviate versions lower than 1.24.0")
+
     collection = collection_factory(
         properties=[Property(name="text", data_type=DataType.TEXT)],
         vectorizer_config=[

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -871,8 +871,8 @@ def test_config_unknown_module(request: SubRequest) -> None:
 
         client.collections.delete(name=collection_name)
 
-        collection = client.collections.create_from_config(config)
-        config2 = collection.config.get()
+        collection2 = client.collections.create_from_config(config)
+        config2 = collection2.config.get()
         assert config == config2
         assert config2.generative_config is not None
         assert isinstance(config2.generative_config.generative, str)
@@ -883,3 +883,89 @@ def test_config_unknown_module(request: SubRequest) -> None:
         assert config2.reranker_config.reranker == "reranker-dummy"
 
         client.collections.delete(name=collection_name)
+
+
+def test_create_custom_module(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        generative_config=Configure.Generative.custom(
+            "generative-anyscale", module_config={"temperature": 0.5}
+        )
+    )
+    config = collection.config.get()
+
+    collection2 = collection_factory(
+        generative_config=Configure.Generative.anyscale(temperature=0.5)
+    )
+    config2 = collection2.config.get()
+
+    assert config.generative_config == config2.generative_config
+    assert isinstance(config.generative_config.generative, str)
+    assert config.generative_config.generative == "generative-anyscale"
+    assert config.generative_config.model == {"temperature": 0.5}
+
+
+def test_create_custom_reranker(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        reranker_config=Configure.Reranker.custom(
+            "reranker-cohere", module_config={"model": "rerank-english-v2.0"}
+        )
+    )
+    config = collection.config.get()
+
+    collection2 = collection_factory(
+        reranker_config=Configure.Reranker.cohere(model="rerank-english-v2.0")
+    )
+    config2 = collection2.config.get()
+
+    assert config.reranker_config == config2.reranker_config
+    assert isinstance(config.reranker_config.reranker, str)
+    assert config.reranker_config.reranker == "reranker-cohere"
+    assert config.reranker_config.model == {"model": "rerank-english-v2.0"}
+
+
+def test_create_custom_vectorizer(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[Property(name="text", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.custom(
+            "text2vec-contextionary", module_config={"vectorizeClassName": False}
+        ),
+    )
+    config = collection.config.get()
+
+    collection2 = collection_factory(
+        properties=[Property(name="text", data_type=DataType.TEXT)],
+        vectorizer_config=Configure.Vectorizer.text2vec_contextionary(
+            vectorize_collection_name=False
+        ),
+    )
+    config2 = collection2.config.get()
+
+    assert config.vectorizer_config == config2.vectorizer_config
+    assert isinstance(config.vectorizer_config.vectorizer, str)
+    assert config.vectorizer_config.vectorizer == "text2vec-contextionary"
+    assert not config.vectorizer_config.vectorize_collection_name
+
+
+def test_create_custom_vectorizer_named(collection_factory: CollectionFactory) -> None:
+    collection = collection_factory(
+        properties=[Property(name="text", data_type=DataType.TEXT)],
+        vectorizer_config=[
+            Configure.NamedVectors.custom(
+                "name", "text2vec-contextionary", module_config={"vectorizeClassName": False}
+            )
+        ],
+    )
+    config = collection.config.get()
+
+    collection2 = collection_factory(
+        properties=[Property(name="text", data_type=DataType.TEXT)],
+        vectorizer_config=[
+            Configure.NamedVectors.text2vec_contextionary("name", vectorize_collection_name=False)
+        ],
+    )
+    config2 = collection2.config.get()
+
+    assert config.vector_config == config2.vector_config
+    assert len(config.vector_config) == 1
+    assert config.vector_config["name"].vectorizer.vectorizer == "text2vec-contextionary"
+    assert config.vector_config["name"].vectorizer.model == {"vectorizeClassName": False}

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -951,7 +951,9 @@ def test_create_custom_vectorizer_named(collection_factory: CollectionFactory) -
         properties=[Property(name="text", data_type=DataType.TEXT)],
         vectorizer_config=[
             Configure.NamedVectors.custom(
-                "name", "text2vec-contextionary", module_config={"vectorizeClassName": False}
+                "name",
+                module_name="text2vec-contextionary",
+                module_config={"vectorizeClassName": False},
             )
         ],
     )

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -899,9 +899,9 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
     vectorIndexConfig: Optional[_VectorIndexConfigUpdate] = Field(
         default=None, alias="vector_index_config"
     )
-    vectorizerConfig: Optional[Union[_VectorIndexConfigUpdate, List[_NamedVectorConfigUpdate]]] = (
-        Field(default=None, alias="vectorizer_config")
-    )
+    vectorizerConfig: Optional[
+        Union[_VectorIndexConfigUpdate, List[_NamedVectorConfigUpdate]]
+    ] = Field(default=None, alias="vectorizer_config")
     multiTenancyConfig: Optional[_MultiTenancyConfigUpdate] = Field(
         default=None, alias="multi_tenancy_config"
     )
@@ -948,10 +948,10 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
                         raise WeaviateInvalidInputError(
                             f"Cannot update vector index config with name {vc.name} to change its quantizer"
                         )
-                    schema["vectorConfig"][vc.name]["vectorIndexConfig"] = (
-                        vc.vectorIndexConfig.merge_with_existing(
-                            schema["vectorConfig"][vc.name]["vectorIndexConfig"]
-                        )
+                    schema["vectorConfig"][vc.name][
+                        "vectorIndexConfig"
+                    ] = vc.vectorIndexConfig.merge_with_existing(
+                        schema["vectorConfig"][vc.name]["vectorIndexConfig"]
                     )
                     schema["vectorConfig"][vc.name][
                         "vectorIndexType"
@@ -1521,9 +1521,9 @@ class _CollectionConfigCreate(_ConfigCreateModel):
     vectorIndexConfig: Optional[_VectorIndexConfigCreate] = Field(
         default=None, alias="vector_index_config"
     )
-    vectorizerConfig: Optional[Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]] = (
-        Field(default=_Vectorizer.none(), alias="vectorizer_config")
-    )
+    vectorizerConfig: Optional[
+        Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
+    ] = Field(default=_Vectorizer.none(), alias="vectorizer_config")
     generativeSearch: Optional[_GenerativeConfigCreate] = Field(
         default=None, alias="generative_config"
     )

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -153,14 +153,14 @@ class GenerativeSearches(str, Enum):
     See the [docs](https://weaviate.io/developers/weaviate/modules/reader-generator-modules) for more details.
 
     Attributes:
+        `AWS`
+            Weaviate module backed by AWS Bedrock generative models.
         `OPENAI`
             Weaviate module backed by OpenAI and Azure-OpenAI generative models.
         `COHERE`
             Weaviate module backed by Cohere generative models.
         `PALM`
             Weaviate module backed by PaLM generative models.
-        `AWS`
-            Weaviate module backed by AWS Bedrock generative models.
     """
 
     AWS = "generative-aws"
@@ -864,9 +864,9 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
     vectorIndexConfig: Optional[_VectorIndexConfigUpdate] = Field(
         default=None, alias="vector_index_config"
     )
-    vectorizerConfig: Optional[
-        Union[_VectorIndexConfigUpdate, List[_NamedVectorConfigUpdate]]
-    ] = Field(default=None, alias="vectorizer_config")
+    vectorizerConfig: Optional[Union[_VectorIndexConfigUpdate, List[_NamedVectorConfigUpdate]]] = (
+        Field(default=None, alias="vectorizer_config")
+    )
     multiTenancyConfig: Optional[_MultiTenancyConfigUpdate] = Field(
         default=None, alias="multi_tenancy_config"
     )
@@ -913,10 +913,10 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
                         raise WeaviateInvalidInputError(
                             f"Cannot update vector index config with name {vc.name} to change its quantizer"
                         )
-                    schema["vectorConfig"][vc.name][
-                        "vectorIndexConfig"
-                    ] = vc.vectorIndexConfig.merge_with_existing(
-                        schema["vectorConfig"][vc.name]["vectorIndexConfig"]
+                    schema["vectorConfig"][vc.name]["vectorIndexConfig"] = (
+                        vc.vectorIndexConfig.merge_with_existing(
+                            schema["vectorConfig"][vc.name]["vectorIndexConfig"]
+                        )
                     )
                     schema["vectorConfig"][vc.name][
                         "vectorIndexType"
@@ -1179,7 +1179,7 @@ VectorIndexConfigDynamic = _VectorIndexConfigDynamic
 
 @dataclass
 class _GenerativeConfig(_ConfigBase):
-    generative: GenerativeSearches
+    generative: Union[GenerativeSearches, str]
     model: Dict[str, Any]
 
 
@@ -1188,7 +1188,7 @@ GenerativeConfig = _GenerativeConfig
 
 @dataclass
 class _VectorizerConfig(_ConfigBase):
-    vectorizer: Vectorizers
+    vectorizer: Union[Vectorizers, str]
     model: Dict[str, Any]
     vectorize_collection_name: bool
 
@@ -1199,7 +1199,7 @@ VectorizerConfig = _VectorizerConfig
 @dataclass
 class _RerankerConfig(_ConfigBase):
     model: Dict[str, Any]
-    reranker: Rerankers
+    reranker: Union[Rerankers, str]
 
 
 RerankerConfig = _RerankerConfig
@@ -1207,7 +1207,7 @@ RerankerConfig = _RerankerConfig
 
 @dataclass
 class _NamedVectorizerConfig(_ConfigBase):
-    vectorizer: Vectorizers
+    vectorizer: Union[Vectorizers, str]
     model: Dict[str, Any]
     source_properties: Optional[List[str]]
 
@@ -1250,7 +1250,7 @@ class _CollectionConfig(_ConfigBase):
     ]
     vector_index_type: Optional[VectorIndexType]
     vectorizer_config: Optional[VectorizerConfig]
-    vectorizer: Optional[Vectorizers]
+    vectorizer: Optional[Union[Vectorizers, str]]
     vector_config: Optional[Dict[str, _NamedVectorConfig]]
 
     def to_dict(self) -> dict:
@@ -1308,7 +1308,7 @@ class _CollectionConfigSimple(_ConfigBase):
     references: List[ReferencePropertyConfig]
     reranker_config: Optional[RerankerConfig]
     vectorizer_config: Optional[VectorizerConfig]
-    vectorizer: Optional[Vectorizers]
+    vectorizer: Optional[Union[Vectorizers, str]]
     vector_config: Optional[Dict[str, _NamedVectorConfig]]
 
 
@@ -1484,9 +1484,9 @@ class _CollectionConfigCreate(_ConfigCreateModel):
     vectorIndexConfig: Optional[_VectorIndexConfigCreate] = Field(
         default=None, alias="vector_index_config"
     )
-    vectorizerConfig: Optional[
-        Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]
-    ] = Field(default=_Vectorizer.none(), alias="vectorizer_config")
+    vectorizerConfig: Optional[Union[_VectorizerConfigCreate, List[_NamedVectorConfigCreate]]] = (
+        Field(default=_Vectorizer.none(), alias="vectorizer_config")
+    )
     generativeSearch: Optional[_GenerativeConfigCreate] = Field(
         default=None, alias="generative_config"
     )

--- a/weaviate/collections/classes/config_base.py
+++ b/weaviate/collections/classes/config_base.py
@@ -60,13 +60,15 @@ class _QuantizerConfigCreate(_ConfigCreateModel):
 
     @staticmethod
     @abstractmethod
-    def quantizer_name() -> str: ...
+    def quantizer_name() -> str:
+        ...
 
 
 class _QuantizerConfigUpdate(_ConfigUpdateModel):
     @staticmethod
     @abstractmethod
-    def quantizer_name() -> str: ...
+    def quantizer_name() -> str:
+        ...
 
 
 @dataclass

--- a/weaviate/collections/classes/config_base.py
+++ b/weaviate/collections/classes/config_base.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, cast
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -59,12 +60,19 @@ class _QuantizerConfigCreate(_ConfigCreateModel):
 
     @staticmethod
     @abstractmethod
-    def quantizer_name() -> str:
-        ...
+    def quantizer_name() -> str: ...
 
 
 class _QuantizerConfigUpdate(_ConfigUpdateModel):
     @staticmethod
     @abstractmethod
-    def quantizer_name() -> str:
-        ...
+    def quantizer_name() -> str: ...
+
+
+@dataclass
+class _EnumLikeStr:
+    string: str
+
+    @property
+    def value(self) -> str:
+        return self.string

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -1,11 +1,12 @@
-from typing import Any, Dict, List, Literal, Optional, Union
 import warnings
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import AnyHttpUrl, Field
 
 from weaviate.collections.classes.config_base import (
     _ConfigCreateModel,
     _ConfigUpdateModel,
+    _EnumLikeStr,
 )
 from weaviate.collections.classes.config_vector_index import (
     _VectorIndexConfigCreate,
@@ -46,6 +47,7 @@ from weaviate.collections.classes.config_vectorizers import (
     Vectorizers,
     VoyageModel,
     _map_multi2vec_fields,
+    _VectorizerCustomConfig,
 )
 
 
@@ -107,6 +109,32 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             vectorizer=_VectorizerConfigCreate(vectorizer=Vectorizers.NONE),
+            vector_index_config=vector_index_config,
+        )
+
+    @staticmethod
+    def custom(
+        name: str,
+        module_name: str,
+        *,
+        source_properties: Optional[List[str]] = None,
+        vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+        module_config: Optional[Dict[str, Any]] = None,
+    ) -> _NamedVectorConfigCreate:
+        """Create a named vector using no vectorizer. You will need to provide the vectors yourself.
+
+        Arguments:
+            `name`
+                The name of the named vector.
+            `vector_index_config`
+                The configuration for Weaviate's vector index. Use wvc.config.Configure.VectorIndex to create a vector index configuration. None by default
+        """
+        return _NamedVectorConfigCreate(
+            name=name,
+            source_properties=source_properties,
+            vectorizer=_VectorizerCustomConfig(
+                vectorizer=_EnumLikeStr(module_name), module_config=module_config
+            ),
             vector_index_config=vector_index_config,
         )
 

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -115,8 +115,8 @@ class _NamedVectors:
     @staticmethod
     def custom(
         name: str,
-        module_name: str,
         *,
+        module_name: str,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         module_config: Optional[Dict[str, Any]] = None,
@@ -126,6 +126,12 @@ class _NamedVectors:
         Arguments:
             `name`
                 The name of the named vector.
+            `module_name`
+                The name of the custom module to use.
+            `module_config`
+                The configuration of the custom module to use.
+            `source_properties`
+                Which properties should be included when vectorizing. By default all text properties are included.
             `vector_index_config`
                 The configuration for Weaviate's vector index. Use wvc.config.Configure.VectorIndex to create a vector index configuration. None by default
         """

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -1,6 +1,6 @@
+import warnings
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union, cast
-import warnings
 
 from pydantic import AnyHttpUrl, BaseModel, Field, field_validator
 from typing_extensions import TypeAlias

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -133,7 +133,7 @@ class VectorDistances(str, Enum):
 
 
 class _VectorizerConfigCreate(_ConfigCreateModel):
-    vectorizer: Union[Vectorizers, _EnumLikeStr]
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(default=..., exclude=True)
 
 
 class _Text2VecContextionaryConfig(_ConfigCreateModel):

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast
 from pydantic import AnyHttpUrl, BaseModel, Field, field_validator
 from typing_extensions import TypeAlias
 
-from weaviate.collections.classes.config_base import _ConfigCreateModel
+from weaviate.collections.classes.config_base import _ConfigCreateModel, _EnumLikeStr
 
 CohereModel: TypeAlias = Literal[
     "embed-multilingual-v2.0",
@@ -133,14 +133,23 @@ class VectorDistances(str, Enum):
 
 
 class _VectorizerConfigCreate(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=..., exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr]
 
 
 class _Text2VecContextionaryConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_CONTEXTIONARY, frozen=True, exclude=True
     )
     vectorizeClassName: bool
+
+
+class _VectorizerCustomConfig(_VectorizerConfigCreate):
+    module_config: Optional[Dict[str, Any]]
+
+    def _to_dict(self) -> Dict[str, Any]:
+        if self.module_config is None:
+            return {}
+        return self.module_config
 
 
 class _Text2VecContextionaryConfigCreate(_Text2VecContextionaryConfig, _VectorizerConfigCreate):
@@ -148,7 +157,9 @@ class _Text2VecContextionaryConfigCreate(_Text2VecContextionaryConfig, _Vectoriz
 
 
 class _Text2VecAWSConfig(_VectorizerConfigCreate):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_AWS, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_AWS, frozen=True, exclude=True
+    )
     model: Optional[str]
     endpoint: Optional[str]
     region: str
@@ -167,7 +178,9 @@ class _Text2VecAWSConfigCreate(_Text2VecAWSConfig, _VectorizerConfigCreate):
 
 
 class _Text2VecAzureOpenAIConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_OPENAI, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_OPENAI, frozen=True, exclude=True
+    )
     baseURL: Optional[AnyHttpUrl]
     resourceName: str
     deploymentId: str
@@ -185,7 +198,7 @@ class _Text2VecAzureOpenAIConfigCreate(_Text2VecAzureOpenAIConfig, _VectorizerCo
 
 
 class _Text2VecHuggingFaceConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_HUGGINGFACE, frozen=True, exclude=True
     )
     model: Optional[str]
@@ -221,7 +234,9 @@ OpenAIType = Literal["text", "code"]
 
 
 class _Text2VecOpenAIConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_OPENAI, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_OPENAI, frozen=True, exclude=True
+    )
     baseURL: Optional[AnyHttpUrl]
     dimensions: Optional[int]
     model: Optional[str]
@@ -243,7 +258,9 @@ class _Text2VecOpenAIConfigCreate(_Text2VecOpenAIConfig, _VectorizerConfigCreate
 
 
 class _Text2VecCohereConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_COHERE, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_COHERE, frozen=True, exclude=True
+    )
     baseURL: Optional[AnyHttpUrl]
     model: Optional[str]
     truncate: Optional[CohereTruncation]
@@ -261,7 +278,9 @@ class _Text2VecCohereConfigCreate(_Text2VecCohereConfig, _VectorizerConfigCreate
 
 
 class _Text2VecPalmConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_PALM, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_PALM, frozen=True, exclude=True
+    )
     projectId: str
     apiEndpoint: Optional[str]
     modelId: Optional[str]
@@ -274,7 +293,7 @@ class _Text2VecPalmConfigCreate(_Text2VecPalmConfig, _VectorizerConfigCreate):
 
 
 class _Text2VecTransformersConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_TRANSFORMERS, frozen=True, exclude=True
     )
     poolingStrategy: Literal["masked_mean", "cls"]
@@ -289,7 +308,9 @@ class _Text2VecTransformersConfigCreate(_Text2VecTransformersConfig, _Vectorizer
 
 
 class _Text2VecGPT4AllConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_GPT4ALL, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_GPT4ALL, frozen=True, exclude=True
+    )
     vectorizeClassName: bool
 
 
@@ -298,7 +319,9 @@ class _Text2VecGPT4AllConfigCreate(_Text2VecGPT4AllConfig, _VectorizerConfigCrea
 
 
 class _Text2VecJinaConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_JINAAI, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_JINAAI, frozen=True, exclude=True
+    )
     model: Optional[str]
     vectorizeClassName: bool
 
@@ -308,7 +331,7 @@ class _Text2VecJinaConfigCreate(_Text2VecJinaConfig, _VectorizerConfigCreate):
 
 
 class _Text2VecVoyageConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_VOYAGEAI, frozen=True, exclude=True
     )
     model: Optional[str]
@@ -322,21 +345,27 @@ class _Text2VecVoyageConfigCreate(_Text2VecVoyageConfig, _VectorizerConfigCreate
 
 
 class _Text2VecOctoConfig(_VectorizerConfigCreate):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_OCTOAI, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_OCTOAI, frozen=True, exclude=True
+    )
     model: Optional[str]
     baseURL: Optional[str]
     vectorizeClassName: bool
 
 
 class _Text2VecOllamaConfig(_VectorizerConfigCreate):
-    vectorizer: Vectorizers = Field(default=Vectorizers.TEXT2VEC_OLLAMA, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_OLLAMA, frozen=True, exclude=True
+    )
     model: Optional[str]
     apiEndpoint: Optional[str]
     vectorizeClassName: bool
 
 
 class _Img2VecNeuralConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.IMG2VEC_NEURAL, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.IMG2VEC_NEURAL, frozen=True, exclude=True
+    )
     imageFields: List[str]
 
 
@@ -373,7 +402,9 @@ class _Multi2VecBase(_ConfigCreateModel):
 
 
 class _Multi2VecClipConfig(_Multi2VecBase):
-    vectorizer: Vectorizers = Field(default=Vectorizers.MULTI2VEC_CLIP, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.MULTI2VEC_CLIP, frozen=True, exclude=True
+    )
     inferenceUrl: Optional[str]
 
 
@@ -382,7 +413,9 @@ class _Multi2VecClipConfigCreate(_Multi2VecClipConfig, _VectorizerConfigCreate):
 
 
 class _Multi2VecPalmConfig(_Multi2VecBase, _VectorizerConfigCreate):
-    vectorizer: Vectorizers = Field(default=Vectorizers.MULTI2VEC_PALM, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.MULTI2VEC_PALM, frozen=True, exclude=True
+    )
     videoFields: Optional[List[Multi2VecField]]
     projectId: str
     location: Optional[str]
@@ -393,7 +426,9 @@ class _Multi2VecPalmConfig(_Multi2VecBase, _VectorizerConfigCreate):
 
 
 class _Multi2VecBindConfig(_Multi2VecBase):
-    vectorizer: Vectorizers = Field(default=Vectorizers.MULTI2VEC_BIND, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.MULTI2VEC_BIND, frozen=True, exclude=True
+    )
     audioFields: Optional[List[Multi2VecField]]
     depthFields: Optional[List[Multi2VecField]]
     IMUFields: Optional[List[Multi2VecField]]
@@ -406,7 +441,9 @@ class _Multi2VecBindConfigCreate(_Multi2VecBindConfig, _VectorizerConfigCreate):
 
 
 class _Ref2VecCentroidConfig(_ConfigCreateModel):
-    vectorizer: Vectorizers = Field(default=Vectorizers.REF2VEC_CENTROID, frozen=True, exclude=True)
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.REF2VEC_CENTROID, frozen=True, exclude=True
+    )
     referenceProperties: List[str]
     method: Literal["mean"]
 
@@ -651,6 +688,15 @@ class _Vectorizer:
             `pydantic.ValidationError`` if `vectorize_collection_name` is not a `bool`.
         """
         return _Text2VecContextionaryConfigCreate(vectorizeClassName=vectorize_collection_name)
+
+    @staticmethod
+    def custom(
+        module_name: str, module_config: Optional[Dict[str, Any]] = None
+    ) -> _VectorizerConfigCreate:
+        """Create a `_VectorizerCustomConfig` object for use when vectorizing using a custom model."""
+        return _VectorizerCustomConfig(
+            vectorizer=_EnumLikeStr(module_name), module_config=module_config
+        )
 
     @staticmethod
     def text2vec_cohere(


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-python-client/issues/1138
Closes https://github.com/weaviate/weaviate-python-client/issues/950

This adds the possibility to add custom vectorzers, rerankers and generative modules to the collection config.
The syntax is
```
Configure.Generative.custom(
            "generative-whatever", module_config={"temperature": 0.5}
        )
Configure.Reranker.custom(
            "reranker-whatever", module_config={"model": "whatever"}
        )
Configure.Vectorizer.custom(
            "text2vec-whatever", module_config={"vectorizeClassName": False}
        )
Configure.NamedVectors.custom(
                "name", module_name="text2vec-contextionary", module_config={"vectorizeClassName": False}
            )
```

in addition, the client can now also handle returns with modules that it does not know