### PR TITLE
Fix year zero in dates

### DIFF
--- a/mock_tests/test_collection.py
+++ b/mock_tests/test_collection.py
@@ -1,6 +1,7 @@
+import datetime
 import json
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 import grpc
 import pytest
@@ -27,6 +28,7 @@ from weaviate.collections.classes.config import (
 from weaviate.connect.base import ConnectionParams, ProtocolParams
 from weaviate.connect.integrations import _IntegrationConfig
 from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateStartUpError
+from weaviate.proto.v1 import weaviate_pb2_grpc, search_get_pb2, properties_pb2
 
 ACCESS_TOKEN = "HELLO!IamAnAccessToken"
 REFRESH_TOKEN = "UseMeToRefreshYourAccessToken"
@@ -339,3 +341,45 @@ def test_integration_config(
 
     client.collections.list_all()  # return is irrelevant
     weaviate_no_auth_mock.check_assertions()
+
+
+def test_year_zero(weaviate_no_auth_mock: HTTPServer, start_grpc_server: grpc.Server) -> None:
+    zero_date: properties_pb2.Value.date_value = properties_pb2.Value(
+        date_value="0000-01-30T00:00:00Z"
+    )
+    date_prop: Mapping[str, properties_pb2.Value.date_value] = {"date": zero_date}
+
+    class MockWeaviateService(weaviate_pb2_grpc.WeaviateServicer):
+        def Search(
+            self, request: search_get_pb2.SearchRequest, context: grpc.ServicerContext
+        ) -> search_get_pb2.SearchReply:
+            return search_get_pb2.SearchReply(
+                results=[
+                    search_get_pb2.SearchResult(
+                        properties=search_get_pb2.PropertiesResult(
+                            non_ref_props=properties_pb2.Properties(fields=date_prop)
+                        )
+                    ),
+                ]
+            )
+
+    weaviate_pb2_grpc.add_WeaviateServicer_to_server(MockWeaviateService(), start_grpc_server)
+    schema = {
+        "class": "Test",
+        "properties": [],
+        "vectorizer": "none",
+    }
+    weaviate_no_auth_mock.expect_request("/v1/schema/Test").respond_with_json(
+        response_json=schema, status=200
+    )
+
+    client = weaviate.connect_to_local(
+        port=MOCK_PORT,
+        host=MOCK_IP,
+        grpc_port=MOCK_PORT_GRPC,
+    )
+    with pytest.warns(UserWarning) as recwarn:
+        objs = client.collections.get("Test").query.fetch_objects().objects
+        assert objs[0].properties["date"] == datetime.datetime.min
+
+        assert str(recwarn[0].message).startswith("Con004")

--- a/weaviate/collections/queries/base.py
+++ b/weaviate/collections/queries/base.py
@@ -48,19 +48,18 @@ from weaviate.collections.classes.types import (
     References,
     TReferences,
 )
-from weaviate.collections.queries.byteops import _ByteOps
 from weaviate.collections.grpc.query import _QueryGRPC
+from weaviate.collections.queries.byteops import _ByteOps
 from weaviate.connect import ConnectionV4
 from weaviate.exceptions import WeaviateInvalidInputError
 from weaviate.proto.v1 import search_get_pb2, properties_pb2
+from weaviate.types import INCLUDE_VECTOR
 from weaviate.util import (
     file_encoder_b64,
     _datetime_from_weaviate_str,
 )
 from weaviate.validator import _validate_input, _ValidateArgument
 from weaviate.warnings import _Warnings
-
-from weaviate.types import INCLUDE_VECTOR
 
 
 class _WeaviateUUIDInt(uuid_lib.UUID):
@@ -200,7 +199,15 @@ class _BaseQuery(Generic[Properties, References]):
         if value.HasField("uuid_value"):
             return uuid_lib.UUID(value.uuid_value)
         if value.HasField("date_value"):
-            return _datetime_from_weaviate_str(value.date_value)
+            try:
+                return _datetime_from_weaviate_str(value.date_value)
+            except ValueError as e:
+                # note that the year 9999 is valid and does not need to be handled. for 5 digit years only the first
+                # 4 digits are considered and it wrapps around
+                if "year 0 is out of range" in str(e):
+                    _Warnings.datetime_year_zero(value.date_value)
+                    return datetime.datetime.min
+
         if value.HasField("string_value"):
             return str(value.string_value)
         if value.HasField("text_value"):

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -228,6 +228,16 @@ class _Warnings:
         )
 
     @staticmethod
+    def datetime_year_zero(date: str) -> None:
+        warnings.warn(
+            message=f"""Con004: Received a date {date} with year 0. The year 0 does not exist in the Gregorian calendar.
+            and cannot be parsed by the datetime library. The year will be set to {datetime.min}.
+            See https://en.wikipedia.org/wiki/Year_zero for more information.""",
+            category=UserWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
     def batch_executor_is_shutdown() -> None:
         warnings.warn(
             message="""Bat001: The BatchExecutor was shutdown, most probably when it exited the `with` statement.


### PR DESCRIPTION
Closes https://github.com/weaviate/weaviate-python-client/issues/1093

Weaviate accepts dates based on RFC3339 which allows the year zero ("0000-01-30T00:00:00Z"). However the datetime library is based on the gregorian calendar which [does not have a year zero](https://en.wikipedia.org/wiki/Year_zero).

To fix parsing problems we will return years with 0 as the minimum date that is possibel in datetime (`datetime.datetime(1, 1, 1, 0, 0)`) and emit a warning.

