### PR TITLE
Fix updating quantizers between `pq`, `bq`, and `sq` with `hnsw` index

### DIFF
--- a/test/collection/schema.py
+++ b/test/collection/schema.py
@@ -1,0 +1,102 @@
+from typing import Literal, Optional
+
+
+def multi_vector_schema(quantizer: Optional[Literal["pq", "bq", "sq"]] = None) -> dict:
+    return {
+        "class": "Something",
+        "invertedIndexConfig": {
+            "bm25": {"b": 0.75, "k1": 1.2},
+            "cleanupIntervalSeconds": 60,
+            "stopwords": {"additions": None, "preset": "en", "removals": None},
+        },
+        "multiTenancyConfig": {
+            "autoTenantActivation": False,
+            "autoTenantCreation": False,
+            "enabled": False,
+        },
+        "properties": [
+            {
+                "dataType": ["text"],
+                "indexFilterable": True,
+                "indexRangeFilters": False,
+                "indexSearchable": True,
+                "name": "name",
+                "tokenization": "word",
+            }
+        ],
+        "replicationConfig": {"asyncEnabled": False, "factor": 1},
+        "shardingConfig": {
+            "virtualPerPhysical": 128,
+            "desiredCount": 1,
+            "actualCount": 1,
+            "desiredVirtualCount": 128,
+            "actualVirtualCount": 128,
+            "key": "_id",
+            "strategy": "hash",
+            "function": "murmur3",
+        },
+        "vectorConfig": {
+            "boi": {
+                "vectorIndexConfig": {
+                    "skip": False,
+                    "cleanupIntervalSeconds": 300,
+                    "maxConnections": 32,
+                    "efConstruction": 128,
+                    "ef": -1,
+                    "dynamicEfMin": 100,
+                    "dynamicEfMax": 500,
+                    "dynamicEfFactor": 8,
+                    "vectorCacheMaxObjects": 1000000000000,
+                    "flatSearchCutoff": 40000,
+                    "distance": "cosine",
+                    "pq": {
+                        "enabled": quantizer == "pq",
+                        "bitCompression": False,
+                        "segments": 0,
+                        "centroids": 256,
+                        "trainingLimit": 100000,
+                        "encoder": {"type": "kmeans", "distribution": "log-normal"},
+                    },
+                    "bq": {"enabled": quantizer == "bq"},
+                    "sq": {
+                        "enabled": quantizer == "sq",
+                        "trainingLimit": 100000,
+                        "rescoreLimit": 20,
+                    },
+                },
+                "vectorIndexType": "hnsw",
+                "vectorizer": {"none": {}},
+            },
+            "yeh": {
+                "vectorIndexConfig": {
+                    "skip": False,
+                    "cleanupIntervalSeconds": 300,
+                    "maxConnections": 32,
+                    "efConstruction": 128,
+                    "ef": -1,
+                    "dynamicEfMin": 100,
+                    "dynamicEfMax": 500,
+                    "dynamicEfFactor": 8,
+                    "vectorCacheMaxObjects": 1000000000000,
+                    "flatSearchCutoff": 40000,
+                    "distance": "cosine",
+                    "pq": {
+                        "enabled": quantizer == "pq",
+                        "bitCompression": False,
+                        "segments": 0,
+                        "centroids": 256,
+                        "trainingLimit": 100000,
+                        "encoder": {"type": "kmeans", "distribution": "log-normal"},
+                    },
+                    "bq": {"enabled": quantizer == "bq"},
+                    "sq": {
+                        "enabled": quantizer == "sq",
+                        "trainingLimit": 100000,
+                        "rescoreLimit": 20,
+                    },
+                },
+                "vectorIndexType": "hnsw",
+                "vectorizer": {"none": {}},
+            },
+        },
+    }

--- a/test/collection/test_config_update.py
+++ b/test/collection/test_config_update.py
@@ -1,0 +1,73 @@
+import pytest
+
+from weaviate.collections.classes.config import _CollectionConfigUpdate, Reconfigure
+from test.collection.schema import multi_vector_schema
+
+
+@pytest.mark.parametrize(
+    "schema", [multi_vector_schema(), multi_vector_schema("bq"), multi_vector_schema("sq")]
+)
+def test_enabling_pq_multi_vector(schema: dict) -> None:
+    update = _CollectionConfigUpdate(
+        vectorizer_config=[
+            Reconfigure.NamedVectors.update(
+                name="boi",
+                vector_index_config=Reconfigure.VectorIndex.hnsw(
+                    quantizer=Reconfigure.VectorIndex.Quantizer.pq()
+                ),
+            )
+        ]
+    )
+    new_schema = update.merge_with_existing(schema)
+
+    assert new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["pq"]["enabled"]
+    assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["bq"]["enabled"]
+    assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["sq"]["enabled"]
+
+    assert new_schema["vectorConfig"]["yeh"] == schema["vectorConfig"]["yeh"]
+
+
+@pytest.mark.parametrize(
+    "schema", [multi_vector_schema(), multi_vector_schema("pq"), multi_vector_schema("sq")]
+)
+def test_enabling_bq_multi_vector(schema: dict) -> None:
+    update = _CollectionConfigUpdate(
+        vectorizer_config=[
+            Reconfigure.NamedVectors.update(
+                name="boi",
+                vector_index_config=Reconfigure.VectorIndex.hnsw(
+                    quantizer=Reconfigure.VectorIndex.Quantizer.bq()
+                ),
+            )
+        ]
+    )
+    new_schema = update.merge_with_existing(schema)
+
+    assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["pq"]["enabled"]
+    assert new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["bq"]["enabled"]
+    assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["sq"]["enabled"]
+
+    assert new_schema["vectorConfig"]["yeh"] == schema["vectorConfig"]["yeh"]
+
+
+@pytest.mark.parametrize(
+    "schema", [multi_vector_schema(), multi_vector_schema("pq"), multi_vector_schema("bq")]
+)
+def test_enabling_sq_multi_vector(schema: dict) -> None:
+    update = _CollectionConfigUpdate(
+        vectorizer_config=[
+            Reconfigure.NamedVectors.update(
+                name="boi",
+                vector_index_config=Reconfigure.VectorIndex.hnsw(
+                    quantizer=Reconfigure.VectorIndex.Quantizer.sq()
+                ),
+            )
+        ]
+    )
+    new_schema = update.merge_with_existing(schema)
+
+    assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["pq"]["enabled"]
+    assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["bq"]["enabled"]
+    assert new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["sq"]["enabled"]
+
+    assert new_schema["vectorConfig"]["yeh"] == schema["vectorConfig"]["yeh"]

--- a/test/collection/test_config_update.py
+++ b/test/collection/test_config_update.py
@@ -1,13 +1,19 @@
 import pytest
 
-from weaviate.collections.classes.config import _CollectionConfigUpdate, Reconfigure
 from test.collection.schema import multi_vector_schema
+from weaviate.collections.classes.config import _CollectionConfigUpdate, Reconfigure
+from weaviate.exceptions import WeaviateInvalidInputError
 
 
 @pytest.mark.parametrize(
-    "schema", [multi_vector_schema(), multi_vector_schema("bq"), multi_vector_schema("sq")]
+    "schema,should_error",
+    [
+        (multi_vector_schema(), False),
+        (multi_vector_schema("bq"), True),
+        (multi_vector_schema("sq"), True),
+    ],
 )
-def test_enabling_pq_multi_vector(schema: dict) -> None:
+def test_enabling_pq_multi_vector(schema: dict, should_error: bool) -> None:
     update = _CollectionConfigUpdate(
         vectorizer_config=[
             Reconfigure.NamedVectors.update(
@@ -18,6 +24,11 @@ def test_enabling_pq_multi_vector(schema: dict) -> None:
             )
         ]
     )
+    if should_error:
+        with pytest.raises(WeaviateInvalidInputError):
+            update.merge_with_existing(schema)
+        return
+
     new_schema = update.merge_with_existing(schema)
 
     assert new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["pq"]["enabled"]
@@ -28,9 +39,14 @@ def test_enabling_pq_multi_vector(schema: dict) -> None:
 
 
 @pytest.mark.parametrize(
-    "schema", [multi_vector_schema(), multi_vector_schema("pq"), multi_vector_schema("sq")]
+    "schema,should_error",
+    [
+        (multi_vector_schema(), False),
+        (multi_vector_schema("pq"), True),
+        (multi_vector_schema("sq"), True),
+    ],
 )
-def test_enabling_bq_multi_vector(schema: dict) -> None:
+def test_enabling_bq_multi_vector(schema: dict, should_error: bool) -> None:
     update = _CollectionConfigUpdate(
         vectorizer_config=[
             Reconfigure.NamedVectors.update(
@@ -41,6 +57,11 @@ def test_enabling_bq_multi_vector(schema: dict) -> None:
             )
         ]
     )
+    if should_error:
+        with pytest.raises(WeaviateInvalidInputError):
+            update.merge_with_existing(schema)
+        return
+
     new_schema = update.merge_with_existing(schema)
 
     assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["pq"]["enabled"]
@@ -51,9 +72,14 @@ def test_enabling_bq_multi_vector(schema: dict) -> None:
 
 
 @pytest.mark.parametrize(
-    "schema", [multi_vector_schema(), multi_vector_schema("pq"), multi_vector_schema("bq")]
+    "schema,should_error",
+    [
+        (multi_vector_schema(), False),
+        (multi_vector_schema("pq"), True),
+        (multi_vector_schema("bq"), True),
+    ],
 )
-def test_enabling_sq_multi_vector(schema: dict) -> None:
+def test_enabling_sq_multi_vector(schema: dict, should_error: bool) -> None:
     update = _CollectionConfigUpdate(
         vectorizer_config=[
             Reconfigure.NamedVectors.update(
@@ -64,6 +90,11 @@ def test_enabling_sq_multi_vector(schema: dict) -> None:
             )
         ]
     )
+    if should_error:
+        with pytest.raises(WeaviateInvalidInputError):
+            update.merge_with_existing(schema)
+        return
+
     new_schema = update.merge_with_existing(schema)
 
     assert not new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["pq"]["enabled"]

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1005,7 +1005,7 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
             (
                 isinstance(quantizer, _PQConfigUpdate)
                 and (
-                    vector_index_config["bq"]["enabled"]
+                    vector_index_config.get("sq", {"enabled": False})["enabled"]
                     or vector_index_config.get("sq", {"enabled": False})["enabled"]
                 )
             )
@@ -1018,7 +1018,10 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
             )
             or (
                 isinstance(quantizer, _SQConfigUpdate)
-                and (vector_index_config["pq"]["enabled"] or vector_index_config["bq"]["enabled"])
+                and (
+                    vector_index_config["pq"]["enabled"]
+                    or vector_index_config.get("bq", {"enabled": False})["enabled"]
+                )
             )
         ):
             raise WeaviateInvalidInputError(

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1008,7 +1008,6 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
                     vector_index_config["bq"]["enabled"]
                     or vector_index_config.get("sq", {"enabled": False})["enabled"]
                 )
-                is True
             )
             or (
                 isinstance(quantizer, _BQConfigUpdate)
@@ -1016,12 +1015,10 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
                     vector_index_config["pq"]["enabled"]
                     or vector_index_config.get("sq", {"enabled": False})["enabled"]
                 )
-                is True
             )
             or (
                 isinstance(quantizer, _SQConfigUpdate)
                 and (vector_index_config["pq"]["enabled"] or vector_index_config["bq"]["enabled"])
-                is True
             )
         ):
             raise WeaviateInvalidInputError(

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -308,6 +308,7 @@ class _PQConfigUpdate(_QuantizerConfigUpdate):
 
 
 class _BQConfigUpdate(_QuantizerConfigUpdate):
+    enabled: Optional[bool]
     rescoreLimit: Optional[int]
 
     @staticmethod
@@ -1024,18 +1025,6 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
                     if vc.name not in schema["vectorConfig"]:
                         raise WeaviateInvalidInputError(
                             f"Vector config with name {vc.name} does not exist in the existing vector config"
-                        )
-                    if (
-                        isinstance(vc.vectorIndexConfig.quantizer, _PQConfigUpdate)
-                        and schema["vectorConfig"][vc.name]["vectorIndexConfig"]["bq"]["enabled"]
-                        is True
-                    ) or (
-                        isinstance(vc.vectorIndexConfig.quantizer, _BQConfigUpdate)
-                        and schema["vectorConfig"][vc.name]["vectorIndexConfig"]["pq"]["enabled"]
-                        is True
-                    ):
-                        raise WeaviateInvalidInputError(
-                            f"Cannot update vector index config with name {vc.name} to change its quantizer"
                         )
                     schema["vectorConfig"][vc.name][
                         "vectorIndexConfig"
@@ -2035,7 +2024,7 @@ class _VectorIndexQuantizerUpdate:
         )
 
     @staticmethod
-    def bq(rescore_limit: Optional[int] = None) -> _BQConfigUpdate:
+    def bq(rescore_limit: Optional[int] = None, enabled: bool = True) -> _BQConfigUpdate:
         """Create a `_BQConfigUpdate` object to be used when updating the binary quantization (BQ) configuration of Weaviate.
 
         Use this method when defining the `quantizer` argument in the `vector_index` configuration in `collection.update()`.
@@ -2043,7 +2032,7 @@ class _VectorIndexQuantizerUpdate:
         Arguments:
             See [the docs](https://weaviate.io/developers/weaviate/concepts/vector-index#hnsw-with-compression) for a more detailed view!
         """  # noqa: D417 (missing argument descriptions in the docstring)
-        return _BQConfigUpdate(rescoreLimit=rescore_limit)
+        return _BQConfigUpdate(rescoreLimit=rescore_limit, enabled=enabled)
 
     @staticmethod
     def sq(

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1005,7 +1005,7 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
             (
                 isinstance(quantizer, _PQConfigUpdate)
                 and (
-                    vector_index_config.get("sq", {"enabled": False})["enabled"]
+                    vector_index_config.get("bq", {"enabled": False})["enabled"]
                     or vector_index_config.get("sq", {"enabled": False})["enabled"]
                 )
             )

--- a/weaviate/collections/classes/config_base.py
+++ b/weaviate/collections/classes/config_base.py
@@ -26,7 +26,15 @@ class _ConfigUpdateModel(BaseModel):
             elif isinstance(val, (int, float, bool, str, list)):
                 schema[cls_field] = val
             elif isinstance(val, _QuantizerConfigUpdate):
+                quantizers = ["pq", "bq", "sq"]
                 schema[val.quantizer_name()] = val.merge_with_existing(schema[val.quantizer_name()])
+                for quantizer in quantizers:
+                    if quantizer == val.quantizer_name() or quantizer not in schema:
+                        continue
+                    assert (
+                        "enabled" in schema[quantizer]
+                    ), f"Quantizer {quantizer} does not have the enabled field: {schema}"
+                    schema[quantizer]["enabled"] = False
             elif isinstance(val, _ConfigUpdateModel):
                 schema[cls_field] = val.merge_with_existing(schema[cls_field])
             else:


### PR DESCRIPTION
- Forbid updating the quantizer of an index if it already has one configured (should be on the server but adding to client for now)
- Add unit tests for quantizer `merge_with_existing` method
- Any errors with updating quantizers for unsupported indices, e.g. `pq` and `sq` with `flat`, are returned from the server as `UnexpectedStatusCodeError` exceptions

Closes https://github.com/weaviate/weaviate-python-client/issues/1170