### PR TITLE
Ignore `BlockingIOError` error logs emitted by `aio.grpc` in event loops

### DIFF
--- a/weaviate/client.py
+++ b/weaviate/client.py
@@ -39,7 +39,7 @@ from .exceptions import (
 )
 from .gql import Query
 from .schema import Schema
-from weaviate.event_loop import _EventLoopSingleton
+from weaviate.event_loop import _EventLoopSingleton, _EventLoop
 from .types import NUMBER
 from .util import _get_valid_timeout_config, _type_request_response
 from .warnings import _Warnings
@@ -83,6 +83,7 @@ class WeaviateClient(_WeaviateClientBase):
         self._event_loop = _EventLoopSingleton.get_instance()
         assert self._event_loop.loop is not None
         self._loop = self._event_loop.loop
+        _EventLoop.patch_exception_handler(self._loop)
 
         super().__init__(
             connection_params=connection_params,
@@ -144,6 +145,8 @@ class WeaviateAsyncClient(_WeaviateClientBase):
         skip_init_checks: bool = False,
     ) -> None:
         self._loop = asyncio.get_event_loop()
+        _EventLoop.patch_exception_handler(self._loop)
+
         super().__init__(
             connection_params=connection_params,
             embedded_options=embedded_options,

--- a/weaviate/connect/base.py
+++ b/weaviate/connect/base.py
@@ -111,14 +111,6 @@ class ConnectionParams(BaseModel):
     def _grpc_target(self) -> str:
         return f"{self.grpc.host}:{self.grpc.port}"
 
-    # @overload
-    # def _grpc_channel(self, async_channel: Literal[False], proxies: Dict[str, str]) -> Channel:
-    #     ...
-
-    # @overload
-    # def _grpc_channel(self, async_channel: Literal[True], proxies: Dict[str, str]) -> AsyncChannel:
-    #     ...
-
     def _grpc_channel(self, proxies: Dict[str, str]) -> Channel:
         if (p := proxies.get("grpc")) is not None:
             options: list = [*GRPC_DEFAULT_OPTIONS, ("grpc.http_proxy", p)]
@@ -135,18 +127,6 @@ class ConnectionParams(BaseModel):
                 target=self._grpc_target,
                 options=options,
             )
-
-    # def _grpc_channel(self, proxies: Dict[str, str]) -> Channel:
-    #     # if (p := proxies.get("grpc")) is not None:
-    #     #     options: list = [*GRPC_DEFAULT_OPTIONS, ("grpc.http_proxy", p)]
-    #     # else:
-    #     #     options = GRPC_DEFAULT_OPTIONS
-    #     return Channel(
-    #         host=self._grpc_address[0],
-    #         port=self._grpc_address[1],
-    #         # options=options,
-    #         ssl=self.grpc.secure,
-    #     )
 
     @property
     def _http_scheme(self) -> str:

--- a/weaviate/event_loop.py
+++ b/weaviate/event_loop.py
@@ -2,7 +2,7 @@ import asyncio
 import threading
 import time
 from concurrent.futures import Future
-from typing import Any, Callable, Coroutine, Generic, Optional, TypeVar, cast
+from typing import Any, Callable, Coroutine, Dict, Generic, Optional, TypeVar, cast
 
 from typing_extensions import ParamSpec
 
@@ -96,7 +96,7 @@ class _EventLoop:
             - https://github.com/grpc/grpc/pull/36096
         """
 
-        def exception_handler(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        def exception_handler(loop: asyncio.AbstractEventLoop, context: Dict[str, Any]) -> None:
             if "exception" in context:
                 err = f"{type(context['exception']).__name__}: {context['exception']}"
                 if "BlockingIOError: [Errno 35] Resource temporarily unavailable" == err:

--- a/weaviate/event_loop.py
+++ b/weaviate/event_loop.py
@@ -81,6 +81,30 @@ class _EventLoop:
 
         return loop
 
+    @staticmethod
+    def patch_exception_handler(loop: asyncio.AbstractEventLoop) -> None:
+        """
+        This patches the asyncio exception handler to ignore the `BlockingIOError: [Errno 35] Resource temporarily unavailable` error
+        that is emitted by `aio.grpc` when multiple event loops are used in separate threads. This error is not actually an implementation/call error,
+        it's just a problem with grpc's cython implementation of `aio.Channel.__init__` whereby a `socket.recv(1)` call only works on the first call with
+        all subsequent calls to `aio.Channel.__init__` throwing the above error.
+
+        This call within the `aio.Channel.__init__` method does not affect the functionality of the library and can be safely ignored.
+
+        Context:
+            - https://github.com/grpc/grpc/issues/25364
+            - https://github.com/grpc/grpc/pull/36096
+        """
+
+        def exception_handler(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+            if "exception" in context:
+                err = f"{type(context['exception']).__name__}: {context['exception']}"
+                if "BlockingIOError: [Errno 35] Resource temporarily unavailable" == err:
+                    return
+            loop.default_exception_handler(context)
+
+        loop.set_exception_handler(exception_handler)
+
     def __del__(self) -> None:
         self.shutdown()
 
@@ -95,3 +119,8 @@ class _EventLoopSingleton:
         cls._instance = _EventLoop()
         cls._instance.start()
         return cls._instance
+
+    def __del__(self) -> None:
+        if self._instance is not None:
+            self._instance.shutdown()
+            self._instance = None


### PR DESCRIPTION
Due to [issues](https://github.com/grpc/grpc/issues/25364) surrounding the core grpc cython implementation of `aio.grpc.Channel.__init__`, false positive error messages are emitted of the form `BlockingIOError: [Errno 35] Resource temporarily unavailable` when channels are used in multi-threading environments. Since such errors only occur at channel initialisation and do not affect the actual I/O requests themselves, we can safely ignore them, as is proposed to be done in https://github.com/grpc/grpc/pull/36096

For now, we can here follow the same logic and implement our own custom exception handling so that the previous `grpcio` versions we support can continue to be supported into the future