### PR TITLE
feature: allow 1D numpy array

### DIFF
--- a/weaviate/collections/batch/grpc_batch_objects.py
+++ b/weaviate/collections/batch/grpc_batch_objects.py
@@ -57,7 +57,7 @@ class _BatchGRPC(_BaseGRPC):
                 collection=obj.collection,
                 vector_bytes=(
                     pack_vector(obj.vector)
-                    if obj.vector is not None and isinstance(obj.vector, list)
+                    if obj.vector is not None
                     else None
                 ),
                 uuid=str(obj.uuid) if obj.uuid is not None else str(uuid_package.uuid4()),


### PR DESCRIPTION
Fixes #1002

This is the simplest fix which allows a 1d numpy array to be passed in (additionally, anything which can be converted in the function `util.get_vector`). This will raise a `TypeError` if the input is incorrect, which is converted later to `WeaviateInvalidInputError`.

Note that passing in something else then `types.VECTOR`, e.g. a numpy array, will raise a mypy error.