### PR TITLE
Suppress outdated warning emitted by auto-gened protobuf code

### DIFF
--- a/weaviate/proto/v1/__init__.py
+++ b/weaviate/proto/v1/__init__.py
@@ -1,0 +1,3 @@
+import warnings
+warnings.filterwarnings("ignore", ".*obsolete", UserWarning, "google.protobuf.runtime_version")
+# copied from https://github.com/grpc/grpc/issues/37609#issuecomment-2328376837 to handle https://github.com/protocolbuffers/protobuf/pull/17241


### PR DESCRIPTION
Removes the warning as documented in https://github.com/grpc/grpc/issues from appearing during client usage