### PR TITLE
Ignore package deps in requirements-devel.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "requests"
+      - dependency-name: "httpx"
+      - dependency-name: "validators"
+      - dependency-name: "authlib"
+      - dependency-name: "grpcio"
+      - dependency-name: "grpcio-tools"
+      - dependency-name: "grpcio-health-checking"
+      - dependency-name: "pydantic"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "requests"
-      - dependency-name: "httpx"
-      - dependency-name: "validators"
-      - dependency-name: "authlib"
       - dependency-name: "grpcio"
       - dependency-name: "grpcio-tools"
       - dependency-name: "grpcio-health-checking"


### PR DESCRIPTION
Ignores all the dependencies in `requirements-devel.txt` that are the explicit package dependencies defined in `setup.cfg`. This is so that a consistent development environment can be maintained between developers without potential conflicts. 

These hard-fixed versions in `requirements-devel.txt` must be updated manually when the minimum version defined in `setup.cfg` is bumped.