### PR TITLE
Add missing `tenant` and `consistency_level` to `collection/base.pyi`

### DIFF
--- a/weaviate/collections/collection/base.pyi
+++ b/weaviate/collections/collection/base.pyi
@@ -65,3 +65,13 @@ class _CollectionBase(Generic[Properties, References]):
                 The consistency level to use.
         """
         ...
+
+    @property
+    def tenant(self) -> Optional[str]:
+        """The tenant of this collection object."""
+        ...
+
+    @property
+    def consistency_level(self) -> Optional[ConsistencyLevel]:
+        """The consistency level of this collection object."""
+        ...


### PR DESCRIPTION
Fixes missing type information for:
```python
collection = client.collections.get(name)
tenant = collection.tenant
```
that would previously return `Any` for `collection.tenant`