### PR TITLE
Palm to google

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -281,7 +281,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             project_id="project",
         ),
         {
-            "text2vec-google": {
+            "text2vec-palm": {
                 "projectId": "project",
                 "vectorizeClassName": True,
             }
@@ -292,7 +292,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             project_id="project",
         ),
         {
-            "text2vec-google": {
+            "text2vec-palm": {
                 "projectId": "project",
                 "vectorizeClassName": True,
             }
@@ -306,7 +306,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             vectorize_collection_name=False,
         ),
         {
-            "text2vec-google": {
+            "text2vec-palm": {
                 "projectId": "project",
                 "apiEndpoint": "api.google.com",
                 "modelId": "model",
@@ -322,7 +322,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             vectorize_collection_name=False,
         ),
         {
-            "text2vec-google": {
+            "text2vec-palm": {
                 "projectId": "project",
                 "apiEndpoint": "api.google.com",
                 "modelId": "model",
@@ -402,7 +402,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             location="us-central1",
         ),
         {
-            "multi2vec-google": {
+            "multi2vec-palm": {
                 "imageFields": ["image"],
                 "textFields": ["text"],
                 "videoFields": ["video"],
@@ -423,7 +423,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             location="us-central1",
         ),
         {
-            "multi2vec-google": {
+            "multi2vec-palm": {
                 "imageFields": ["image"],
                 "textFields": ["text"],
                 "videoFields": ["video"],
@@ -1372,7 +1372,7 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         {
             "test": {
                 "vectorizer": {
-                    "text2vec-google": {
+                    "text2vec-palm": {
                         "projectId": "project",
                         "properties": ["prop"],
                         "vectorizeClassName": True,
@@ -1393,7 +1393,7 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         {
             "test": {
                 "vectorizer": {
-                    "text2vec-google": {
+                    "text2vec-palm": {
                         "projectId": "project",
                         "properties": ["prop"],
                         "vectorizeClassName": True,
@@ -1489,7 +1489,7 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         {
             "test": {
                 "vectorizer": {
-                    "multi2vec-google": {
+                    "multi2vec-palm": {
                         "imageFields": ["image"],
                         "textFields": ["text"],
                         "projectId": "project",
@@ -1514,7 +1514,7 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         {
             "test": {
                 "vectorizer": {
-                    "multi2vec-google": {
+                    "multi2vec-palm": {
                         "imageFields": ["image"],
                         "textFields": ["text"],
                         "projectId": "project",

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -775,7 +775,37 @@ TEST_CONFIG_WITH_GENERATIVE = [
         },
     ),
     (
+        Configure.Generative.google(project_id="project"),
+        {
+            "generative-palm": {
+                "projectId": "project",
+            }
+        },
+    ),
+    (
         Configure.Generative.palm(
+            project_id="project",
+            api_endpoint="https://api.google.com",
+            max_output_tokens=100,
+            model_id="model",
+            temperature=0.5,
+            top_k=10,
+            top_p=0.5,
+        ),
+        {
+            "generative-palm": {
+                "projectId": "project",
+                "apiEndpoint": "https://api.google.com",
+                "maxOutputTokens": 100,
+                "modelId": "model",
+                "temperature": 0.5,
+                "topK": 10,
+                "topP": 0.5,
+            }
+        },
+    ),
+    (
+        Configure.Generative.google(
             project_id="project",
             api_endpoint="https://api.google.com",
             max_output_tokens=100,

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -281,7 +281,18 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             project_id="project",
         ),
         {
-            "text2vec-palm": {
+            "text2vec-google": {
+                "projectId": "project",
+                "vectorizeClassName": True,
+            }
+        },
+    ),
+    (
+        Configure.Vectorizer.text2vec_google(
+            project_id="project",
+        ),
+        {
+            "text2vec-google": {
                 "projectId": "project",
                 "vectorizeClassName": True,
             }
@@ -295,7 +306,23 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             vectorize_collection_name=False,
         ),
         {
-            "text2vec-palm": {
+            "text2vec-google": {
+                "projectId": "project",
+                "apiEndpoint": "api.google.com",
+                "modelId": "model",
+                "vectorizeClassName": False,
+            }
+        },
+    ),
+    (
+        Configure.Vectorizer.text2vec_google(
+            project_id="project",
+            api_endpoint="api.google.com",
+            model_id="model",
+            vectorize_collection_name=False,
+        ),
+        {
+            "text2vec-google": {
                 "projectId": "project",
                 "apiEndpoint": "api.google.com",
                 "modelId": "model",
@@ -375,7 +402,28 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             location="us-central1",
         ),
         {
-            "multi2vec-palm": {
+            "multi2vec-google": {
+                "imageFields": ["image"],
+                "textFields": ["text"],
+                "videoFields": ["video"],
+                "projectId": "project",
+                "location": "us-central1",
+                "videoIntervalSeconds": 1,
+                "vectorizeClassName": True,
+            }
+        },
+    ),
+    (
+        Configure.Vectorizer.multi2vec_google(
+            image_fields=["image"],
+            text_fields=["text"],
+            video_fields=["video"],
+            project_id="project",
+            video_interval_seconds=1,
+            location="us-central1",
+        ),
+        {
+            "multi2vec-google": {
                 "imageFields": ["image"],
                 "textFields": ["text"],
                 "videoFields": ["video"],
@@ -1324,7 +1372,28 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         {
             "test": {
                 "vectorizer": {
-                    "text2vec-palm": {
+                    "text2vec-google": {
+                        "projectId": "project",
+                        "properties": ["prop"],
+                        "vectorizeClassName": True,
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
+        [
+            Configure.NamedVectors.text2vec_google(
+                name="test",
+                project_id="project",
+                source_properties=["prop"],
+            )
+        ],
+        {
+            "test": {
+                "vectorizer": {
+                    "text2vec-google": {
                         "projectId": "project",
                         "properties": ["prop"],
                         "vectorizeClassName": True,
@@ -1420,7 +1489,32 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         {
             "test": {
                 "vectorizer": {
-                    "multi2vec-palm": {
+                    "multi2vec-google": {
+                        "imageFields": ["image"],
+                        "textFields": ["text"],
+                        "projectId": "project",
+                        "location": "us-central1",
+                        "vectorizeClassName": True,
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
+        [
+            Configure.NamedVectors.multi2vec_google(
+                name="test",
+                image_fields=["image"],
+                text_fields=["text"],
+                project_id="project",
+                location="us-central1",
+            )
+        ],
+        {
+            "test": {
+                "vectorizer": {
+                    "multi2vec-google": {
                         "imageFields": ["image"],
                         "textFields": ["text"],
                         "projectId": "project",

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -17,25 +17,24 @@ from weaviate.collections.classes.config_vector_index import (
     VectorIndexType,
 )
 from weaviate.collections.classes.config_vectorizers import (
-    _Img2VecNeuralConfigCreate,
-    _Multi2VecBindConfigCreate,
-    _Multi2VecClipConfigCreate,
+    _Img2VecNeuralConfig,
+    _Multi2VecBindConfig,
+    _Multi2VecClipConfig,
     _Multi2VecPalmConfig,
-    _Ref2VecCentroidConfigCreate,
-    _Text2VecAWSConfigCreate,
-    _Text2VecAzureOpenAIConfigCreate,
-    _Text2VecCohereConfigCreate,
-    _Text2VecContextionaryConfigCreate,
-    _Text2VecGPT4AllConfigCreate,
-    _Text2VecHuggingFaceConfigCreate,
-    _Text2VecJinaConfigCreate,
+    _Ref2VecCentroidConfig,
+    _Text2VecAWSConfig,
+    _Text2VecAzureOpenAIConfig,
+    _Text2VecCohereConfig,
+    _Text2VecContextionaryConfig,
+    _Text2VecGPT4AllConfig,
+    _Text2VecHuggingFaceConfig,
+    _Text2VecJinaConfig,
     _Text2VecMistralConfig,
     _Text2VecOctoConfig,
     _Text2VecOllamaConfig,
-    _Text2VecOpenAIConfigCreate,
-    _Text2VecPalmConfigCreate,
-    _Text2VecTransformersConfigCreate,
-    _Text2VecVoyageConfigCreate,
+    _Text2VecOpenAIConfig,
+    _Text2VecPalmConfig,
+    _Text2VecTransformersConfig,
     _VectorizerConfigCreate,
     AWSModel,
     AWSService,
@@ -50,6 +49,7 @@ from weaviate.collections.classes.config_vectorizers import (
     _map_multi2vec_fields,
     _VectorizerCustomConfig,
     _Text2VecDatabricksConfig,
+    _Text2VecVoyageConfig,
 )
 
 
@@ -186,7 +186,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecCohereConfigCreate(
+            vectorizer=_Text2VecCohereConfig(
                 baseURL=base_url,
                 model=model,
                 truncate=truncate,
@@ -221,7 +221,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecContextionaryConfigCreate(
+            vectorizer=_Text2VecContextionaryConfig(
                 vectorizeClassName=vectorize_collection_name,
             ),
             vector_index_config=vector_index_config,
@@ -436,7 +436,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecOpenAIConfigCreate(
+            vectorizer=_Text2VecOpenAIConfig(
                 baseURL=base_url,
                 model=model,
                 modelVersion=model_version,
@@ -481,7 +481,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecAWSConfigCreate(
+            vectorizer=_Text2VecAWSConfig(
                 model=model,
                 endpoint=endpoint,
                 region=region,
@@ -517,7 +517,7 @@ class _NamedVectors:
         """
         return _NamedVectorConfigCreate(
             name=name,
-            vectorizer=_Img2VecNeuralConfigCreate(imageFields=image_fields),
+            vectorizer=_Img2VecNeuralConfig(imageFields=image_fields),
             vector_index_config=vector_index_config,
         )
 
@@ -565,7 +565,7 @@ class _NamedVectors:
 
         return _NamedVectorConfigCreate(
             name=name,
-            vectorizer=_Multi2VecClipConfigCreate(
+            vectorizer=_Multi2VecClipConfig(
                 imageFields=_map_multi2vec_fields(image_fields),
                 textFields=_map_multi2vec_fields(text_fields),
                 vectorizeClassName=vectorize_collection_name,
@@ -663,7 +663,7 @@ class _NamedVectors:
         """
         return _NamedVectorConfigCreate(
             name=name,
-            vectorizer=_Multi2VecBindConfigCreate(
+            vectorizer=_Multi2VecBindConfig(
                 audioFields=_map_multi2vec_fields(audio_fields),
                 depthFields=_map_multi2vec_fields(depth_fields),
                 imageFields=_map_multi2vec_fields(image_fields),
@@ -701,7 +701,7 @@ class _NamedVectors:
         """
         return _NamedVectorConfigCreate(
             name=name,
-            vectorizer=_Ref2VecCentroidConfigCreate(
+            vectorizer=_Ref2VecCentroidConfig(
                 referenceProperties=reference_properties,
                 method=method,
             ),
@@ -737,7 +737,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecAzureOpenAIConfigCreate(
+            vectorizer=_Text2VecAzureOpenAIConfig(
                 baseURL=base_url,
                 resourceName=resource_name,
                 deploymentId=deployment_id,
@@ -772,7 +772,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecGPT4AllConfigCreate(
+            vectorizer=_Text2VecGPT4AllConfig(
                 vectorizeClassName=vectorize_collection_name,
             ),
             vector_index_config=vector_index_config,
@@ -830,7 +830,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecHuggingFaceConfigCreate(
+            vectorizer=_Text2VecHuggingFaceConfig(
                 model=model,
                 passageModel=passage_model,
                 queryModel=query_model,
@@ -886,7 +886,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecPalmConfigCreate(
+            vectorizer=_Text2VecPalmConfig(
                 projectId=project_id,
                 apiEndpoint=api_endpoint,
                 modelId=model_id,
@@ -934,7 +934,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecTransformersConfigCreate(
+            vectorizer=_Text2VecTransformersConfig(
                 poolingStrategy=pooling_strategy,
                 vectorizeClassName=vectorize_collection_name,
                 inferenceUrl=inference_url,
@@ -981,7 +981,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecJinaConfigCreate(
+            vectorizer=_Text2VecJinaConfig(
                 baseURL=base_url,
                 dimensions=dimensions,
                 model=model,
@@ -1027,7 +1027,7 @@ class _NamedVectors:
         return _NamedVectorConfigCreate(
             name=name,
             source_properties=source_properties,
-            vectorizer=_Text2VecVoyageConfigCreate(
+            vectorizer=_Text2VecVoyageConfig(
                 model=model,
                 vectorizeClassName=vectorize_collection_name,
                 baseURL=base_url,

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -102,21 +102,19 @@ class Vectorizers(str, Enum):
     TEXT2VEC_CONTEXTIONARY = "text2vec-contextionary"
     TEXT2VEC_DATABRICKS = "text2vec-databricks"
     TEXT2VEC_GPT4ALL = "text2vec-gpt4all"
-    TEXT2VEC_GOOGLE = "text2vec-google"
     TEXT2VEC_HUGGINGFACE = "text2vec-huggingface"
     TEXT2VEC_MISTRAL = "text2vec-mistral"
     TEXT2VEC_OCTOAI = "text2vec-octoai"
     TEXT2VEC_OLLAMA = "text2vec-ollama"
     TEXT2VEC_OPENAI = "text2vec-openai"
-    TEXT2VEC_PALM = "text2vec-palm"  # remove when text2vec-palm is removed
+    TEXT2VEC_PALM = "text2vec-palm"  # change to google once 1.27 is the lowest supported version
     TEXT2VEC_TRANSFORMERS = "text2vec-transformers"
     TEXT2VEC_JINAAI = "text2vec-jinaai"
     TEXT2VEC_VOYAGEAI = "text2vec-voyageai"
     IMG2VEC_NEURAL = "img2vec-neural"
     MULTI2VEC_CLIP = "multi2vec-clip"
     MULTI2VEC_BIND = "multi2vec-bind"
-    MULTI2VEC_GOOGLE = "multi2vec-google"
-    MULTI2VEC_PALM = "multi2vec-palm"  # remove when text2vec-palm is removed
+    MULTI2VEC_PALM = "multi2vec-palm"  # change to google once 1.27 is the lowest supported version
     REF2VEC_CENTROID = "ref2vec-centroid"
 
 
@@ -286,7 +284,7 @@ class _Text2VecCohereConfig(_VectorizerConfigCreate):
 
 class _Text2VecGoogleConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
-        default=Vectorizers.TEXT2VEC_GOOGLE, frozen=True, exclude=True
+        default=Vectorizers.TEXT2VEC_PALM, frozen=True, exclude=True
     )
     projectId: str
     apiEndpoint: Optional[str]
@@ -395,7 +393,7 @@ class _Multi2VecClipConfig(_Multi2VecBase):
 
 class _Multi2VecGoogleConfig(_Multi2VecBase, _VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
-        default=Vectorizers.MULTI2VEC_GOOGLE, frozen=True, exclude=True
+        default=Vectorizers.MULTI2VEC_PALM, frozen=True, exclude=True
     )
     videoFields: Optional[List[Multi2VecField]]
     projectId: str

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -147,7 +147,7 @@ class _VectorizerConfigCreate(_ConfigCreateModel):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(default=..., exclude=True)
 
 
-class _Text2VecContextionaryConfig(_ConfigCreateModel):
+class _Text2VecContextionaryConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_CONTEXTIONARY, frozen=True, exclude=True
     )
@@ -161,10 +161,6 @@ class _VectorizerCustomConfig(_VectorizerConfigCreate):
         if self.module_config is None:
             return {}
         return self.module_config
-
-
-class _Text2VecContextionaryConfigCreate(_Text2VecContextionaryConfig, _VectorizerConfigCreate):
-    pass
 
 
 class _Text2VecAWSConfig(_VectorizerConfigCreate):
@@ -184,11 +180,7 @@ class _Text2VecAWSConfig(_VectorizerConfigCreate):
         return r
 
 
-class _Text2VecAWSConfigCreate(_Text2VecAWSConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecAzureOpenAIConfig(_ConfigCreateModel):
+class _Text2VecAzureOpenAIConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_OPENAI, frozen=True, exclude=True
     )
@@ -204,11 +196,7 @@ class _Text2VecAzureOpenAIConfig(_ConfigCreateModel):
         return ret_dict
 
 
-class _Text2VecAzureOpenAIConfigCreate(_Text2VecAzureOpenAIConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecHuggingFaceConfig(_ConfigCreateModel):
+class _Text2VecHuggingFaceConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_HUGGINGFACE, frozen=True, exclude=True
     )
@@ -237,10 +225,6 @@ class _Text2VecHuggingFaceConfig(_ConfigCreateModel):
         return ret_dict
 
 
-class _Text2VecHuggingFaceConfigCreate(_Text2VecHuggingFaceConfig, _VectorizerConfigCreate):
-    pass
-
-
 class _Text2VecMistralConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_MISTRAL, frozen=True, exclude=True
@@ -261,7 +245,7 @@ class _Text2VecDatabricksConfig(_VectorizerConfigCreate):
 OpenAIType = Literal["text", "code"]
 
 
-class _Text2VecOpenAIConfig(_ConfigCreateModel):
+class _Text2VecOpenAIConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_OPENAI, frozen=True, exclude=True
     )
@@ -281,11 +265,7 @@ class _Text2VecOpenAIConfig(_ConfigCreateModel):
         return ret_dict
 
 
-class _Text2VecOpenAIConfigCreate(_Text2VecOpenAIConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecCohereConfig(_ConfigCreateModel):
+class _Text2VecCohereConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_COHERE, frozen=True, exclude=True
     )
@@ -301,11 +281,7 @@ class _Text2VecCohereConfig(_ConfigCreateModel):
         return ret_dict
 
 
-class _Text2VecCohereConfigCreate(_Text2VecCohereConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecPalmConfig(_ConfigCreateModel):
+class _Text2VecPalmConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_PALM, frozen=True, exclude=True
     )
@@ -316,11 +292,7 @@ class _Text2VecPalmConfig(_ConfigCreateModel):
     titleProperty: Optional[str]
 
 
-class _Text2VecPalmConfigCreate(_Text2VecPalmConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecTransformersConfig(_ConfigCreateModel):
+class _Text2VecTransformersConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_TRANSFORMERS, frozen=True, exclude=True
     )
@@ -331,22 +303,14 @@ class _Text2VecTransformersConfig(_ConfigCreateModel):
     queryInferenceUrl: Optional[str]
 
 
-class _Text2VecTransformersConfigCreate(_Text2VecTransformersConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecGPT4AllConfig(_ConfigCreateModel):
+class _Text2VecGPT4AllConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_GPT4ALL, frozen=True, exclude=True
     )
     vectorizeClassName: bool
 
 
-class _Text2VecGPT4AllConfigCreate(_Text2VecGPT4AllConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecJinaConfig(_ConfigCreateModel):
+class _Text2VecJinaConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_JINAAI, frozen=True, exclude=True
     )
@@ -356,11 +320,7 @@ class _Text2VecJinaConfig(_ConfigCreateModel):
     vectorizeClassName: bool
 
 
-class _Text2VecJinaConfigCreate(_Text2VecJinaConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Text2VecVoyageConfig(_ConfigCreateModel):
+class _Text2VecVoyageConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_VOYAGEAI, frozen=True, exclude=True
     )
@@ -368,10 +328,6 @@ class _Text2VecVoyageConfig(_ConfigCreateModel):
     baseURL: Optional[str]
     truncate: Optional[bool]
     vectorizeClassName: bool
-
-
-class _Text2VecVoyageConfigCreate(_Text2VecVoyageConfig, _VectorizerConfigCreate):
-    pass
 
 
 class _Text2VecOctoConfig(_VectorizerConfigCreate):
@@ -392,15 +348,11 @@ class _Text2VecOllamaConfig(_VectorizerConfigCreate):
     vectorizeClassName: bool
 
 
-class _Img2VecNeuralConfig(_ConfigCreateModel):
+class _Img2VecNeuralConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.IMG2VEC_NEURAL, frozen=True, exclude=True
     )
     imageFields: List[str]
-
-
-class _Img2VecNeuralConfigCreate(_Img2VecNeuralConfig, _VectorizerConfigCreate):
-    pass
 
 
 class Multi2VecField(BaseModel):
@@ -410,7 +362,7 @@ class Multi2VecField(BaseModel):
     weight: Optional[float] = Field(default=None, exclude=True)
 
 
-class _Multi2VecBase(_ConfigCreateModel):
+class _Multi2VecBase(_VectorizerConfigCreate):
     imageFields: Optional[List[Multi2VecField]]
     textFields: Optional[List[Multi2VecField]]
     vectorizeClassName: bool
@@ -438,10 +390,6 @@ class _Multi2VecClipConfig(_Multi2VecBase):
     inferenceUrl: Optional[str]
 
 
-class _Multi2VecClipConfigCreate(_Multi2VecClipConfig, _VectorizerConfigCreate):
-    pass
-
-
 class _Multi2VecPalmConfig(_Multi2VecBase, _VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.MULTI2VEC_PALM, frozen=True, exclude=True
@@ -466,20 +414,12 @@ class _Multi2VecBindConfig(_Multi2VecBase):
     videoFields: Optional[List[Multi2VecField]]
 
 
-class _Multi2VecBindConfigCreate(_Multi2VecBindConfig, _VectorizerConfigCreate):
-    pass
-
-
-class _Ref2VecCentroidConfig(_ConfigCreateModel):
+class _Ref2VecCentroidConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.REF2VEC_CENTROID, frozen=True, exclude=True
     )
     referenceProperties: List[str]
     method: Literal["mean"]
-
-
-class _Ref2VecCentroidConfigCreate(_Ref2VecCentroidConfig, _VectorizerConfigCreate):
-    pass
 
 
 def _map_multi2vec_fields(
@@ -519,7 +459,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `image_fields` is not a `list`.
         """
-        return _Img2VecNeuralConfigCreate(imageFields=image_fields)
+        return _Img2VecNeuralConfig(imageFields=image_fields)
 
     @staticmethod
     def multi2vec_clip(
@@ -559,7 +499,7 @@ class _Vectorizer:
                     stacklevel=1,
                 )
 
-        return _Multi2VecClipConfigCreate(
+        return _Multi2VecClipConfig(
             imageFields=_map_multi2vec_fields(image_fields),
             textFields=_map_multi2vec_fields(text_fields),
             vectorizeClassName=vectorize_collection_name,
@@ -603,7 +543,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if any of the `*_fields` are not `None` or a `list`.
         """
-        return _Multi2VecBindConfigCreate(
+        return _Multi2VecBindConfig(
             audioFields=_map_multi2vec_fields(audio_fields),
             depthFields=_map_multi2vec_fields(depth_fields),
             imageFields=_map_multi2vec_fields(image_fields),
@@ -633,7 +573,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `reference_properties` is not a `list`.
         """
-        return _Ref2VecCentroidConfigCreate(
+        return _Ref2VecCentroidConfig(
             referenceProperties=reference_properties,
             method=method,
         )
@@ -663,7 +603,7 @@ class _Vectorizer:
             `vectorize_collection_name`
                 Whether to vectorize the collection name. Defaults to `True`.
         """
-        return _Text2VecAWSConfigCreate(
+        return _Text2VecAWSConfig(
             model=model,
             region=region,
             vectorizeClassName=vectorize_collection_name,
@@ -696,7 +636,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `resource_name` or `deployment_id` are not `str`.
         """
-        return _Text2VecAzureOpenAIConfigCreate(
+        return _Text2VecAzureOpenAIConfig(
             baseURL=base_url,
             resourceName=resource_name,
             deploymentId=deployment_id,
@@ -717,7 +657,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError`` if `vectorize_collection_name` is not a `bool`.
         """
-        return _Text2VecContextionaryConfigCreate(vectorizeClassName=vectorize_collection_name)
+        return _Text2VecContextionaryConfig(vectorizeClassName=vectorize_collection_name)
 
     @staticmethod
     def custom(
@@ -760,7 +700,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `truncate` is not a valid value from the `CohereModel` type.
         """
-        return _Text2VecCohereConfigCreate(
+        return _Text2VecCohereConfig(
             baseURL=base_url,
             model=model,
             truncate=truncate,
@@ -812,7 +752,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `vectorize_collection_name` is not a `bool`.
         """
-        return _Text2VecGPT4AllConfigCreate(vectorizeClassName=vectorize_collection_name)
+        return _Text2VecGPT4AllConfig(vectorizeClassName=vectorize_collection_name)
 
     @staticmethod
     def text2vec_huggingface(
@@ -853,7 +793,7 @@ class _Vectorizer:
                 It is important to note that some of these variables are mutually exclusive.
                     See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface) for more details.
         """
-        return _Text2VecHuggingFaceConfigCreate(
+        return _Text2VecHuggingFaceConfig(
             model=model,
             passageModel=passage_model,
             queryModel=query_model,
@@ -967,7 +907,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `type_` is not a valid value from the `OpenAIType` type.
         """
-        return _Text2VecOpenAIConfigCreate(
+        return _Text2VecOpenAIConfig(
             baseURL=base_url,
             model=model,
             modelVersion=model_version,
@@ -1004,7 +944,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `api_endpoint` is not a valid URL.
         """
-        return _Text2VecPalmConfigCreate(
+        return _Text2VecPalmConfig(
             projectId=project_id,
             apiEndpoint=api_endpoint,
             modelId=model_id,
@@ -1093,7 +1033,7 @@ class _Vectorizer:
         Raises:
             `pydantic.ValidationError` if `pooling_strategy` is not a valid value from the `PoolingStrategy` type.
         """
-        return _Text2VecTransformersConfigCreate(
+        return _Text2VecTransformersConfig(
             poolingStrategy=pooling_strategy,
             vectorizeClassName=vectorize_collection_name,
             inferenceUrl=inference_url,
@@ -1125,7 +1065,7 @@ class _Vectorizer:
             `dimensions`
                 The number of dimensions for the generated embeddings. Defaults to `None`, which uses the server-defined default.
         """
-        return _Text2VecJinaConfigCreate(
+        return _Text2VecJinaConfig(
             model=model,
             vectorizeClassName=vectorize_collection_name,
             baseURL=base_url,
@@ -1157,7 +1097,7 @@ class _Vectorizer:
             `vectorize_collection_name`
                 Whether to vectorize the collection name. Defaults to `True`.
         """
-        return _Text2VecVoyageConfigCreate(
+        return _Text2VecVoyageConfig(
             model=model,
             baseURL=base_url,
             truncate=truncate,

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -158,6 +158,22 @@ class _Warnings:
         )
 
     @staticmethod
+    def palm_to_google_t2v() -> None:
+        warnings.warn(
+            "Dep011: text2vec-palm is deprecated and will be removed in Q2 25. Use text2vec-google instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
+    def palm_to_google_m2v() -> None:
+        warnings.warn(
+            "Dep012: text2vec-palm is deprecated and will be removed in Q2 25. Use multi2vec-google instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
     def weaviate_v3_client_is_deprecated() -> None:
         warnings.warn(
             message="""Dep016: Python client v3 `weaviate.Client(...)` connections and methods are deprecated and will

--- a/weaviate/warnings.py
+++ b/weaviate/warnings.py
@@ -168,7 +168,15 @@ class _Warnings:
     @staticmethod
     def palm_to_google_m2v() -> None:
         warnings.warn(
-            "Dep012: text2vec-palm is deprecated and will be removed in Q2 25. Use multi2vec-google instead.",
+            "Dep012: multi2vec-palm is deprecated and will be removed in Q2 25. Use multi2vec-google instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+    @staticmethod
+    def palm_to_google_gen() -> None:
+        warnings.warn(
+            "Dep013: generative.palm is deprecated and will be removed in Q2 25. Use generative.google instead.",
             DeprecationWarning,
             stacklevel=1,
         )


### PR DESCRIPTION
- deprecates *-palm methods
- adds *-google methods instead
- warnings for everything
- still sends "*-palm" to weaviate as older versions do not support *-google (everything pre-1.27)
- removes some unneeded classes that we added during the named vectors introduction