### PR TITLE
Remove CI testing and pkg building of Python3.8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        version: ["3.9", "3.10", "3.11", "3.12"]
         folder: ["weaviate"]
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        version: ["3.9", "3.10", "3.11", "3.12"]
         folder: ["test", "mock_tests"]
     steps:
       - uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        version: ["3.9", "3.10", "3.11", "3.12"]
         optional_dependencies: [false]
     steps:
       - uses: actions/checkout@v4
@@ -120,7 +120,6 @@ jobs:
       fail-fast: false
       matrix:
         versions: [
-          { py: "3.8", weaviate: $WEAVIATE_126},
           { py: "3.9", weaviate: $WEAVIATE_126},
           { py: "3.10", weaviate: $WEAVIATE_126},
           { py: "3.11", weaviate: $WEAVIATE_123},
@@ -172,7 +171,6 @@ jobs:
       fail-fast: false
       matrix:
         versions: [
-          { py: "3.8", weaviate: $WEAVIATE_126},
           { py: "3.9", weaviate: $WEAVIATE_126},
           { py: "3.10", weaviate: $WEAVIATE_126},
           { py: "3.11", weaviate: $WEAVIATE_123},
@@ -224,7 +222,6 @@ jobs:
       fail-fast: false
       matrix:
         versions: [
-          { py: "3.8", weaviate: $WEAVIATE_125},
           { py: "3.9", weaviate: $WEAVIATE_125},
           { py: "3.10", weaviate: $WEAVIATE_125},
           { py: "3.11", weaviate: $WEAVIATE_125},

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Weaviate python client
 
 A python native client for easy interaction with a Weaviate instance.
 
-The client is tested for python 3.8 and higher.
+The client is tested for python 3.9 and higher.
 
 Visit the official `Weaviate <https://weaviate.io/>`_ website for more information about the Weaviate and how to use it in production.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     grpcio>=1.57.0,<2.0.0
     grpcio-tools>=1.57.0,<2.0.0
     grpcio-health-checking>=1.57.0,<2.0.0
-python_requires = >=3.8
+python_requires = >=3.9
 
 
 [options.package_data]


### PR DESCRIPTION
Inline with the recent [end-of-life of Python 3.8](https://endoflife.date/python), this PR removes the testing of client in Python3.8 and the building of the package for use in a Python3.8 environment