### PR TITLE
Stop waiting for creation when a backup gets cancelled

### DIFF
--- a/integration_v3/test_backup_v4.py
+++ b/integration_v3/test_backup_v4.py
@@ -13,6 +13,7 @@ from weaviate.backup.backup import (
     BackupStorage,
 )
 from weaviate.collections.classes.config import DataType, Property, ReferenceProperty
+import threading
 from weaviate.exceptions import (
     WeaviateUnsupportedFeatureError,
     UnexpectedStatusCodeException,
@@ -484,3 +485,43 @@ def test_cancel_backup(client: weaviate.WeaviateClient) -> None:
         if status_resp.status == BackupStatus.CANCELED:
             break
         time.sleep(0.1)
+    status_resp = client.backup.get_create_status(backup_id=backup_id, backend=BACKEND)
+    assert status_resp.status == BackupStatus.CANCELED
+        
+def test_cancel_backup_with_waiting(client: weaviate.WeaviateClient) -> None:
+    """Cancel a backup while waiting for completion."""
+    backup_id = _create_backup_id()
+    if client._connection._weaviate_version.is_lower_than(1, 24, 25):
+        pytest.skip("Cancel backups is only supported from 1.24.25")
+
+    # Run the backup creation in a separate thread
+
+    def create_backup():
+        nonlocal resp
+        with pytest.raises(BackupFailedException) as excinfo:
+            client.backup.create(
+                backup_id=backup_id,
+                backend=BACKEND,
+                wait_for_completion=True,
+            )
+        assert "Backup was canceled" in str(excinfo.value)
+
+    resp = None
+    backup_thread = threading.Thread(target=create_backup)
+    backup_thread.start()
+
+    # Cancel the backup
+    assert client.backup.cancel_backup(backup_id=backup_id, backend=BACKEND)
+
+    # Wait for the backup thread to finish
+    backup_thread.join()
+
+    # async process
+    start = time.time()
+    while time.time() - start < 5:
+        status_resp = client.backup.get_create_status(backup_id=backup_id, backend=BACKEND)
+        if status_resp.status == BackupStatus.CANCELED:
+            break
+        time.sleep(0.1)
+    status_resp = client.backup.get_create_status(backup_id=backup_id, backend=BACKEND)
+    assert status_resp.status == BackupStatus.CANCELED

--- a/mock_tests/test_collection.py
+++ b/mock_tests/test_collection.py
@@ -30,7 +30,7 @@ from weaviate.connect.integrations import _IntegrationConfig
 from weaviate.exceptions import (
     UnexpectedStatusCodeError,
     WeaviateStartUpError,
-    BackupFailedException,
+    BackupCanceledError,
 )
 
 ACCESS_TOKEN = "HELLO!IamAnAccessToken"
@@ -415,14 +415,14 @@ def test_backup_cancel_while_create_and_restore(
         }
     )
 
-    with pytest.raises(BackupFailedException):
+    with pytest.raises(BackupCanceledError):
         client.backup.create(
             backup_id=backup_id,
             backend="filesystem",
             wait_for_completion=True,
         )
 
-    with pytest.raises(BackupFailedException):
+    with pytest.raises(BackupCanceledError):
         client.backup.restore(
             backup_id=backup_id,
             backend="filesystem",

--- a/mock_tests/test_collection.py
+++ b/mock_tests/test_collection.py
@@ -27,7 +27,11 @@ from weaviate.collections.classes.config import (
 )
 from weaviate.connect.base import ConnectionParams, ProtocolParams
 from weaviate.connect.integrations import _IntegrationConfig
-from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateStartUpError
+from weaviate.exceptions import (
+    UnexpectedStatusCodeError,
+    WeaviateStartUpError,
+    BackupFailedException,
+)
 
 ACCESS_TOKEN = "HELLO!IamAnAccessToken"
 REFRESH_TOKEN = "UseMeToRefreshYourAccessToken"
@@ -370,3 +374,39 @@ def test_node_with_timeout(
 
     nodes = client.cluster.nodes(output=output)
     assert nodes[0].status == "TIMEOUT"
+
+
+def test_backup_cancel_while_create(
+    weaviate_no_auth_mock: HTTPServer, start_grpc_server: grpc.Server
+) -> None:
+    client = weaviate.connect_to_local(
+        port=MOCK_PORT,
+        host=MOCK_IP,
+        grpc_port=MOCK_PORT_GRPC,
+    )
+
+    backup_id = "id"
+
+    weaviate_no_auth_mock.expect_request("/v1/backups/filesystem").respond_with_json(
+        {
+            "collections": ["backupTest"],
+            "status": "CANCELED",
+            "path": "path",
+            "id": backup_id,
+        }
+    )
+    weaviate_no_auth_mock.expect_request("/v1/backups/filesystem/" + backup_id).respond_with_json(
+        {
+            "collections": ["backupTest"],
+            "status": "CANCELED",
+            "path": "path",
+            "id": backup_id,
+        }
+    )
+
+    with pytest.raises(BackupFailedException):
+        client.backup.create(
+            backup_id=backup_id,
+            backend="filesystem",
+            wait_for_completion=True,
+        )

--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -329,6 +329,11 @@ class _BackupAsync:
                     raise BackupFailedException(
                         f"Backup restore failed: {restore_status} with error: {status.error}"
                     )
+                if status.status == BackupStatus.CANCELED:
+                    raise BackupFailedException(
+                        f"Backup restore canceled: {restore_status} with error: {status.error}"
+                    )
+
                 sleep(1)
         return BackupReturn(**restore_status)
 

--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -192,6 +192,10 @@ class _BackupAsync:
                     raise BackupFailedException(
                         f"Backup failed: {create_status} with error: {status.error}"
                     )
+                if status.status == BackupStatus.CANCELED:
+                    raise BackupFailedException(
+                        f"Backup was canceled: {create_status} with error: {status.error}"
+                    )
                 sleep(1)
         return BackupReturn(**create_status)
 

--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -16,6 +16,7 @@ from weaviate.exceptions import (
     WeaviateUnsupportedFeatureError,
     BackupFailedException,
     EmptyResponseException,
+    BackupCanceledError,
 )
 from weaviate.util import (
     _capitalize_first_letter,
@@ -193,7 +194,7 @@ class _BackupAsync:
                         f"Backup failed: {create_status} with error: {status.error}"
                     )
                 if status.status == BackupStatus.CANCELED:
-                    raise BackupFailedException(
+                    raise BackupCanceledError(
                         f"Backup was canceled: {create_status} with error: {status.error}"
                     )
                 sleep(1)
@@ -330,7 +331,7 @@ class _BackupAsync:
                         f"Backup restore failed: {restore_status} with error: {status.error}"
                     )
                 if status.status == BackupStatus.CANCELED:
-                    raise BackupFailedException(
+                    raise BackupCanceledError(
                         f"Backup restore canceled: {restore_status} with error: {status.error}"
                     )
 

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -4,6 +4,7 @@ Weaviate Exceptions.
 
 from json.decoder import JSONDecodeError
 from typing import Union, Tuple
+
 import httpx
 import requests
 
@@ -135,6 +136,12 @@ class BackupFailedError(WeaviateBaseError):
 
 
 BackupFailedException = BackupFailedError
+
+
+class BackupCanceledError(WeaviateBaseError):
+    """
+    Backup canceled Exception.
+    """
 
 
 class EmptyResponseError(WeaviateBaseError):


### PR DESCRIPTION
Since 1.27, the backups can get cancelled. This implies that a new status CANCELLED exists. In the case of a backup creation which is waiting for it to finished, it won't stop if the status is different that SUCCEDED or FAILED. This commit adds a condition for the CANCELED status during creation.
Fixes: weaviate/weaviate-issues#82