### PR TITLE
Refactor backup cancellation API surface

### DIFF
--- a/integration_v3/test_backup_v4.py
+++ b/integration_v3/test_backup_v4.py
@@ -475,7 +475,7 @@ def test_cancel_backup(client: weaviate.WeaviateClient) -> None:
     resp = client.backup.create(backup_id=backup_id, backend=BACKEND)
     assert resp.status == BackupStatus.STARTED
 
-    assert client.backup.cancel_backup(backup_id=backup_id, backend=BACKEND)
+    assert client.backup.cancel(backup_id=backup_id, backend=BACKEND)
 
     # async process
     start = time.time()

--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -387,7 +387,7 @@ class _BackupAsync:
                 raise EmptyResponseException()
             return False  # did not exist
 
-    async def cancel_backup(self, backup_id: str, backend: BackupStorage) -> bool:
+    async def cancel(self, backup_id: str, backend: BackupStorage) -> bool:
         """
         Cancels a running backup.
 

--- a/weaviate/backup/sync.pyi
+++ b/weaviate/backup/sync.pyi
@@ -9,6 +9,7 @@ class _Backup:
     def __init__(self, connection: ConnectionV4):
         self._connection = connection
 
+    def cancel(self, backup_id: str, backend: BackupStorage) -> bool: ...
     def create(
         self,
         backup_id: str,


### PR DESCRIPTION
- Rename `backup.cancel_backup` to `backup.cancel`
- Add method to sync client's stubs