### PR TITLE
Allow user-definition of connection pool timeout

### DIFF
--- a/weaviate/config.py
+++ b/weaviate/config.py
@@ -9,6 +9,7 @@ class ConnectionConfig:
     session_pool_connections: int = 20
     session_pool_maxsize: int = 100
     session_pool_max_retries: int = 3
+    session_pool_timeout: int = 5
 
     def __post_init__(self) -> None:
         if not isinstance(self.session_pool_connections, int):
@@ -22,6 +23,10 @@ class ConnectionConfig:
         if not isinstance(self.session_pool_max_retries, int):
             raise TypeError(
                 f"session_pool_max_retries must be {int}, received {type(self.session_pool_max_retries)}"
+            )
+        if not isinstance(self.session_pool_timeout, int):
+            raise TypeError(
+                f"session_pool_timeout must be {int}, received {type(self.session_pool_timeout)}"
             )
 
 

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -426,7 +426,9 @@ class ConnectionV4(_ConnectionBase):
             timeout = self.timeout_config.query
         elif method == "POST" and not is_gql_query:
             timeout = self.timeout_config.insert
-        return Timeout(timeout=5.0, read=timeout)
+        return Timeout(
+            timeout=5.0, read=timeout, pool=self.__connection_config.session_pool_timeout
+        )
 
     async def __send(
         self,


### PR DESCRIPTION
Adds `session_pool_timeout` to `ConnectionConfig`, use it in `pool` arg to `httpx.Timeout`