### PR TITLE
fix type boolean restriction on include vector for _QueryReference

### DIFF
--- a/integration/test_named_vectors.py
+++ b/integration/test_named_vectors.py
@@ -15,6 +15,7 @@ from weaviate.collections.classes.config import (
 from weaviate.collections.classes.data import DataObject
 from weaviate.collections.classes.grpc import _MultiTargetVectorJoin
 from weaviate.exceptions import WeaviateInvalidInputError
+from weaviate.types import INCLUDE_VECTOR
 
 
 def test_create_named_vectors_throws_error_in_old_version(
@@ -758,7 +759,18 @@ def test_deprecated_syntax(collection_factory: CollectionFactory):
     assert "Providing lists of lists has been deprecated" in str(e)
 
 
-def test_fetch_objects_on_reference(client_factory: ClientFactory) -> None:
+@pytest.mark.parametrize(
+    "include_vector, expected",
+    [
+        (False, {}),
+        (["bringYourOwn1"], {"bringYourOwn1": [0, 1, 2]}),
+        # TODO: to be uncommented when https://github.com/weaviate/weaviate/issues/6279 is resolved
+        # (True, {"bringYourOwn1": [0, 1, 2], "bringYourOwn2": [3, 4, 5]})
+    ],
+)
+def test_include_vector_on_references(
+    client_factory: ClientFactory, include_vector: INCLUDE_VECTOR, expected: dict
+) -> None:
     """Test include vector on reference"""
     dummy = client_factory()
     if dummy._connection._weaviate_version.is_lower_than(1, 24, 0):
@@ -786,9 +798,7 @@ def test_fetch_objects_on_reference(client_factory: ClientFactory) -> None:
     source.data.insert({}, references={"hasRef": TO_UUID})
 
     objs = source.query.fetch_objects(
-        return_references=wvc.query.QueryReference(
-            link_on="hasRef", include_vector=["bringYourOwn1"]
-        )
+        return_references=wvc.query.QueryReference(link_on="hasRef", include_vector=include_vector)
     ).objects
 
-    assert objs[0].references["hasRef"].objects[0].vector == {"bringYourOwn1": [0, 1, 2]}
+    assert objs[0].references["hasRef"].objects[0].vector == expected

--- a/integration/test_named_vectors.py
+++ b/integration/test_named_vectors.py
@@ -760,6 +760,9 @@ def test_deprecated_syntax(collection_factory: CollectionFactory):
 
 def test_fetch_objects_on_reference(client_factory: ClientFactory) -> None:
     """Test include vector on reference"""
+    dummy = client_factory()
+    if dummy._connection._weaviate_version.is_lower_than(1, 24, 0):
+        pytest.skip("Named vectorizers are only supported in Weaviate v1.24.0 and higher.")
 
     client = client_factory()
 

--- a/integration/test_named_vectors.py
+++ b/integration/test_named_vectors.py
@@ -15,43 +15,6 @@ from weaviate.collections.classes.config import (
 from weaviate.collections.classes.data import DataObject
 from weaviate.collections.classes.grpc import _MultiTargetVectorJoin
 from weaviate.exceptions import WeaviateInvalidInputError
-import weaviate
-from _pytest.fixtures import SubRequest
-from typing import Generator, List, Optional, Tuple, Callable
-from integration.conftest import _sanitize_collection_name
-
-
-@pytest.fixture
-def client_factory(
-    request: SubRequest,
-) -> Generator[
-    Callable[[str, Tuple[int, int], bool], Tuple[weaviate.WeaviateClient, str]], None, None
-]:
-    name_fixtures: List[str] = []
-    client_fixture: Optional[weaviate.WeaviateClient] = None
-
-    def _factory(
-        name: str = "", ports: Tuple[int, int] = (8080, 50051), multi_tenant: bool = False
-    ) -> Tuple[weaviate.WeaviateClient, str]:
-        nonlocal client_fixture, name_fixtures
-        name_fixture = _sanitize_collection_name(request.node.name) + name
-        name_fixtures.append(name_fixture)
-        if client_fixture is None:
-            client_fixture = weaviate.connect_to_local(grpc_port=ports[1], port=ports[0])
-
-        if client_fixture.collections.exists(name_fixture):
-            client_fixture.collections.delete(name_fixture)
-            
-        return client_fixture, name_fixture
-
-    try:
-        yield _factory
-    finally:
-        if client_fixture is not None and name_fixtures is not None:
-            for name_fixture in name_fixtures:
-                client_fixture.collections.delete(name_fixture)
-        if client_fixture is not None:
-            client_fixture.close()
 
 
 def test_create_named_vectors_throws_error_in_old_version(
@@ -798,11 +761,11 @@ def test_deprecated_syntax(collection_factory: CollectionFactory):
 def test_fetch_objects_on_reference(client_factory: ClientFactory) -> None:
     """Test include vector on reference"""
 
-    client, _ = client_factory()
+    client = client_factory()
 
     client.collections.delete(["target", "source"])
     target = client.collections.create(
-        name="target", 
+        name="target",
         vectorizer_config=[
             wvc.config.Configure.NamedVectors.none(name="bringYourOwn1"),
             wvc.config.Configure.NamedVectors.none(name="bringYourOwn2"),
@@ -811,15 +774,18 @@ def test_fetch_objects_on_reference(client_factory: ClientFactory) -> None:
 
     source = client.collections.create(
         name="source",
-        references=[wvc.config.ReferenceProperty(name="hasRef", target_collection='target')],
+        references=[wvc.config.ReferenceProperty(name="hasRef", target_collection="target")],
     )
 
-    TO_UUID=target.data.insert({}, vector={"bringYourOwn1": [0, 1, 2], "bringYourOwn2": [3, 4, 5]})
+    TO_UUID = target.data.insert(
+        {}, vector={"bringYourOwn1": [0, 1, 2], "bringYourOwn2": [3, 4, 5]}
+    )
     source.data.insert({}, references={"hasRef": TO_UUID})
-    
+
     objs = source.query.fetch_objects(
         return_references=wvc.query.QueryReference(
-            link_on='hasRef', 
-            include_vector=['bringYourOwn1'])).objects
-    
-    assert objs[0].references['hasRef'].objects[0].vector == {"bringYourOwn1": [0, 1, 2]}
+            link_on="hasRef", include_vector=["bringYourOwn1"]
+        )
+    ).objects
+
+    assert objs[0].references["hasRef"].objects[0].vector == {"bringYourOwn1": [0, 1, 2]}

--- a/weaviate/collections/classes/grpc.py
+++ b/weaviate/collections/classes/grpc.py
@@ -433,7 +433,7 @@ class HybridVector:
 
 class _QueryReference(_WeaviateInput):
     link_on: str
-    include_vector: bool = Field(default=False)
+    include_vector: INCLUDE_VECTOR = Field(default=False)
     return_metadata: Optional[MetadataQuery] = Field(default=None)
     return_properties: Union["PROPERTIES", bool, None] = Field(default=None)
     return_references: Optional["REFERENCES"] = Field(default=None)


### PR DESCRIPTION
This pull request is a proposed solution for the issue opened https://github.com/weaviate/weaviate-python-client/issues/1400

This change the type validation on include_vector parameter for _QueryReference that prevents from requesting named vectors using array of string on references as it would force you to pull all vectors with True, which is not convenient if you have a lots of vectors. 

But using True seems like would not work either and is related to another issue I opened here: https://github.com/weaviate/weaviate/issues/6279

This is my first pull request on here, happy to get feedbacks and add more tests.