### PR TITLE
Replace schema/config by collections.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ env:
   WEAVIATE_125: 1.25.24
   WEAVIATE_126: 1.26.8
   WEAVIATE_127: 1.27.1
-  WEAVIATE_128: 1.28.0-dev-eb31615
+  WEAVIATE_128: 1.28.0-dev-f74827f
 
 jobs:
   lint-and-format:


### PR DESCRIPTION
Due to UX reasons, it was decided to rename the schema permissions into _collection. Also, couple of new
permissions were added, manage_data and manage_collections. These two permissions would cover all the other CRUD permissions of its type.
Last but not least, a refactor in the Role's attributes has been done, to keep consistency among all the different Permissions, even though only the action is present for some of them.