### PR TITLE
Enable new httpx versions

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,4 +1,4 @@
-httpx==0.25.2
+httpx==0.26.0
 validators==0.34.0
 authlib==1.3.1
 grpcio==1.66.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages =
 platforms = any
 include_package_data = True
 install_requires =
-    httpx>=0.25.0,<=0.27.0
+    httpx>=0.26.0,<0.29.0
     validators==0.34.0
     authlib>=1.2.1,<1.3.2
     pydantic>=2.8.0,<3.0.0

--- a/weaviate/connect/base.py
+++ b/weaviate/connect/base.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import time
-from abc import ABC, abstractmethod
 from typing import Any, Dict, Mapping, Sequence, Tuple, TypeVar, Union, cast, Optional
 from urllib.parse import urlparse
 
@@ -139,17 +138,7 @@ class ConnectionParams(BaseModel):
         return f"{self._http_scheme}://{self.http.host}:{self.http.port}"
 
 
-class _ConnectionBase(ABC):
-    @abstractmethod
-    def get_current_bearer_token(self) -> str:
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_proxies(self) -> dict:
-        raise NotImplementedError
-
-
-def _get_proxies(proxies: Union[dict, str, Proxies, None], trust_env: bool) -> dict:
+def _get_proxies(proxies: Union[dict, str, Proxies, None], trust_env: bool) -> Dict[str, str]:
     """
     Get proxies as dict, compatible with 'requests' library.
     NOTE: 'proxies' has priority over 'trust_env', i.e. if 'proxies' is NOT None, 'trust_env'

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -44,7 +44,6 @@ from weaviate.connect.authentication_async import _Auth
 from weaviate.connect.base import (
     ConnectionParams,
     JSONPayload,
-    _ConnectionBase,
     _get_proxies,
 )
 from weaviate.connect.integrations import _IntegrationConfig
@@ -87,7 +86,7 @@ class _ExpectedStatusCodes:
             self.ok = self.ok_in
 
 
-class ConnectionV4(_ConnectionBase):
+class ConnectionV4:
     """
     Connection class used to communicate to a weaviate instance.
     """
@@ -217,7 +216,7 @@ class ConnectionV4(_ConnectionBase):
             self._headers.update(integration._to_header())
             self.__additional_headers.update(integration._to_header())
 
-    def __make_mounts(self) -> Dict[str, AsyncHTTPTransport]:
+    def _make_mounts(self) -> Dict[str, AsyncHTTPTransport]:
         return {
             f"{key}://" if key == "http" or key == "https" else key: AsyncHTTPTransport(
                 limits=Limits(
@@ -235,7 +234,7 @@ class ConnectionV4(_ConnectionBase):
     def __make_async_client(self) -> AsyncClient:
         return AsyncClient(
             headers=self._headers,
-            mounts=self.__make_mounts(),
+            mounts=self._make_mounts(),
             trust_env=self.__trust_env,
         )
 
@@ -596,7 +595,7 @@ class ConnectionV4(_ConnectionBase):
         """
         return str(self._weaviate_version)
 
-    def get_proxies(self) -> dict:
+    def get_proxies(self) -> Dict[str, str]:
         return self._proxies
 
     @property


### PR DESCRIPTION
`proxies` got removed in 0.28.0 and replaced with a combination of `proxy` (single proxy) and `mounts` (multi proxy). I just replaced everything with mounts. Minimum version with `proxy` is 0.26 which is now our new minimum version.