### PR TITLE
Vector for Target Multidimensional Target Vectors

### DIFF
--- a/integration/test_named_vectors.py
+++ b/integration/test_named_vectors.py
@@ -831,6 +831,9 @@ def test_colbert_vectors_byov(collection_factory: CollectionFactory) -> None:
                     multi_vector=wvc.config.Configure.VectorIndex.MultiVector.multi_vector()
                 ),
             ),
+            wvc.config.Configure.NamedVectors.none(
+                name="regular",
+            ),
         ],
     )
 

--- a/weaviate/collections/grpc/query.py
+++ b/weaviate/collections/grpc/query.py
@@ -1072,6 +1072,7 @@ class _QueryGRPC(_BaseGRPC):
                             ],
                         )
                     )
+                    target_vectors_tmp.append(key)
                 elif isinstance(value, _ListOfVectorsQuery):
                     for vec in value.vectors:
                         add_vector(vec, key)


### PR DESCRIPTION
I was debugging the script below from @rlmanrique  using this commit `bd7db7cb34bf94ece9b1c5f9a56e31afc06e6f0e` on Weaviate main and believe that we should still set the target vectors for "multidimensional vectors" in the same way we do for other vectors. I'm not familiar with the Python client code so please correct me if I'm mistaken.

Also, left a code clarification question as a PR comment.

I hit an issue I haven't had time to fix when trying to run tests locally, so I have not run the test suite locally, curious to see the test results are here.

```py
import weaviate
import weaviate.classes.config as wvc


if __name__ == "__main__":

    client = weaviate.connect_to_local()

    # Delete collection
    client.collections.delete("CollectionMultivector")

    vector_index_config = wvc.Configure.VectorIndex.hnsw(
        ef=512,
        multi_vector=wvc.Configure.VectorIndex.MultiVector.multi_vector(),
    )
    vectorizers = [
        wvc.Configure.NamedVectors.none(
            name="colbert",
            vector_index_config=vector_index_config,
        ),
        wvc.Configure.NamedVectors.none(
            name="regular",
            vector_index_config=vector_index_config,
        )
    ]

    collection = client.collections.create(
        name="CollectionMultivector",
        vectorizer_config=vectorizers,
        replication_config=wvc.Configure.replication(factor=1),
    )

    vector = {
        "colbert": weaviate.classes.query.NearVector.multidimensional([[1, 2], [3, 4]])
    }
    response = collection.query.near_vector(
        near_vector=vector, limit=10, target_vector="colbert"
    )

    client.close()
```

Error from server:
```
E           	details = "extract target vectors: class CollectionRF1 has multiple vectors, but no target vectors were provided"
```