### PR TITLE
add OIDC support to tex2vec-weaviate

### DIFF
--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -121,10 +121,8 @@ class ConnectionV4:
         self.__connected = False
         self.__loop = loop
 
-        self._headers = {
-            "content-type": "application/json",
-            "X-Weaviate-Cluster-URL": "https://" + connection_params.http.host,
-        }
+        self._headers = {"content-type": "application/json"}
+        self.__add_weaviate_embedding_service_header(connection_params.http.host)
         if additional_headers is not None:
             _validate_input(_ValidateArgument([dict], "additional_headers", additional_headers))
             self.__additional_headers = additional_headers
@@ -146,10 +144,17 @@ class ConnectionV4:
         # if there are API keys included add them right away to headers
         if auth_client_secret is not None and isinstance(auth_client_secret, AuthApiKey):
             self._headers["authorization"] = "Bearer " + auth_client_secret.api_key
-            # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
-            self._headers["X-Weaviate-Api-Key"] = "Bearer " + auth_client_secret.api_key
 
         self._prepare_grpc_headers()
+
+    def __add_weaviate_embedding_service_header(self, wcd_host: str) -> None:
+        if not is_weaviate_domain(wcd_host):
+            return
+
+        self._headers["X-Weaviate-Cluster-URL"] = "https://" + wcd_host
+        if isinstance(self._auth, AuthApiKey):
+            # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
+            self._headers["X-Weaviate-Api-Key"] = self._auth.api_key
 
     async def connect(self, skip_init_checks: bool) -> None:
         self.__connected = True
@@ -426,9 +431,13 @@ class ConnectionV4:
         # bearer token can change over time (OIDC) so we need to get the current one for each request
         copied_headers = copy(self._headers)
         copied_headers.update({"authorization": self.get_current_bearer_token()})
-        # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
-        copied_headers.update({"x-weaviate-api-key": self.get_current_bearer_token()})
+        self.__refresh_weaviate_embedding_service_auth_header(copied_headers)
         return copied_headers
+
+    def __refresh_weaviate_embedding_service_auth_header(self, headers: dict[str, str]) -> None:
+        if is_weaviate_domain(self._connection_params.http.host):
+            # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
+            headers.update({"x-weaviate-api-key": self.get_current_bearer_token()})
 
     def __get_timeout(
         self, method: Literal["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT"], is_gql_query: bool
@@ -670,19 +679,20 @@ class ConnectionV4:
                     self.__metadata_list.append((key.lower(), val))
 
         if self._auth is not None:
-            self.__metadata_list.append(
-                ("x-weaviate-cluster-url", "https://" + self._connection_params.http.host)
-            )
+            if "X-Weaviate-Cluster-URL" in self._headers:
+                self.__metadata_list.append(
+                    ("x-weaviate-cluster-url", self._headers["X-Weaviate-Cluster-URL"])
+                )
 
             if isinstance(self._auth, AuthApiKey):
-                # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
-                self.__metadata_list.append(("x-weaviate-api-key", "Bearer " + self._auth.api_key))
+                if "X-Weaviate-Api-Key" in self._headers:
+                    # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
+                    self.__metadata_list.append(
+                        ("x-weaviate-api-key", self._headers["X-Weaviate-Api-Key"])
+                    )
                 self.__metadata_list.append(("authorization", "Bearer " + self._auth.api_key))
             else:
-                # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
-                self.__metadata_list.append(
-                    ("x-weaviate-api-key", "dummy_will_be_refreshed_for_each_call")
-                )
+                self.__add_weaviate_embedding_service_auth_grpc_header()
                 self.__metadata_list.append(
                     ("authorization", "dummy_will_be_refreshed_for_each_call")
                 )
@@ -692,17 +702,31 @@ class ConnectionV4:
         else:
             self.__grpc_headers = None
 
+    def __add_weaviate_embedding_service_auth_grpc_header(self) -> None:
+        if is_weaviate_domain(self._connection_params.http.host):
+            # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
+            self.__metadata_list.append(
+                ("x-weaviate-api-key", "dummy_will_be_refreshed_for_each_call")
+            )
+
     def grpc_headers(self) -> Optional[Tuple[Tuple[str, str], ...]]:
         if self._auth is None or isinstance(self._auth, AuthApiKey):
             return self.__grpc_headers
 
         assert self.__grpc_headers is not None
         access_token = self.get_current_bearer_token()
-        # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
-        self.__metadata_list[len(self.__metadata_list) - 2] = ("x-weaviate-api-key", access_token)
+        self.__refresh_weaviate_embedding_service_auth_grpc_header()
         # auth is last entry in list, rest is static
         self.__metadata_list[len(self.__metadata_list) - 1] = ("authorization", access_token)
         return tuple(self.__metadata_list)
+
+    def __refresh_weaviate_embedding_service_auth_grpc_header(self) -> None:
+        if is_weaviate_domain(self._connection_params.http.host):
+            # keeping for backwards compatibility for older clusters for now. On newer clusters, Embedding Service reuses Authorization header.
+            self.__metadata_list[len(self.__metadata_list) - 2] = (
+                "x-weaviate-api-key",
+                self.get_current_bearer_token(),
+            )
 
     async def _ping_grpc(self) -> None:
         """Performs a grpc health check and raises WeaviateGRPCUnavailableError if not."""


### PR DESCRIPTION
Add OIDC support for `tex2vec-weaviate`:
- always pass `X-Weaviate-Cluster-URL` header
- `tex2vec-weaviate` will be reusing `Authorization` header on new clusters.
- always pass `X-Weaviate-Api-Key` for backwards compatibility on older clusters.