### PR TITLE
Order return of collections.list_all() alphabetically by key

### DIFF
--- a/integration/test_collections_sorting.py
+++ b/integration/test_collections_sorting.py
@@ -1,0 +1,38 @@
+import pytest
+from integration.conftest import ClientFactory
+
+
+@pytest.fixture(scope="module")
+def client(client_factory: ClientFactory):
+    client = client_factory()
+    client.collections.delete_all()
+    yield client
+    client.collections.delete_all()
+    client.close()
+
+
+def test_collections_list_all_sorting(client):
+    """Test that collections.list_all() returns collections sorted alphabetically by key."""
+    # Create collections with names in non-alphabetical order
+    client.collections.create(name="TestCollectionC")
+    client.collections.create(name="TestCollectionA")
+    client.collections.create(name="TestCollectionB")
+
+    # Get all collections
+    collections = client.collections.list_all()
+    
+    # Get the keys and filter only our test collections
+    collection_keys = list(collections.keys())
+    test_collections = [k for k in collection_keys if k.startswith("TestCollection")]
+    
+    # Verify they are in alphabetical order
+    assert test_collections == sorted(test_collections)
+    
+    # Test with simple=False as well
+    collections = client.collections.list_all(simple=False)
+    collection_keys = list(collections.keys())
+    test_collections = [k for k in collection_keys if k.startswith("TestCollection")]
+    assert test_collections == sorted(test_collections)
+    
+    # Clean up
+    client.collections.delete(["TestCollectionA", "TestCollectionB", "TestCollectionC"])

--- a/integration/test_collections_sorting.py
+++ b/integration/test_collections_sorting.py
@@ -13,7 +13,6 @@ def sorting_test_client(client_factory: ClientFactory):
 
 def test_collections_list_all_sorting(sorting_test_client):
     """Test that collections.list_all() returns collections sorted alphabetically by key."""
-
     client = sorting_test_client
 
     try:

--- a/integration/test_collections_sorting.py
+++ b/integration/test_collections_sorting.py
@@ -2,8 +2,8 @@ import pytest
 from integration.conftest import ClientFactory
 
 
-@pytest.fixture(scope="module")
-def client(client_factory: ClientFactory):
+@pytest.fixture
+def sorting_test_client(client_factory: ClientFactory):
     client = client_factory()
     client.collections.delete_all()
     yield client
@@ -11,8 +11,11 @@ def client(client_factory: ClientFactory):
     client.close()
 
 
-def test_collections_list_all_sorting(client):
+def test_collections_list_all_sorting(sorting_test_client):
     """Test that collections.list_all() returns collections sorted alphabetically by key."""
+
+    client = sorting_test_client
+
     # Create collections with names in non-alphabetical order
     client.collections.create(name="TestCollectionC")
     client.collections.create(name="TestCollectionA")
@@ -20,19 +23,19 @@ def test_collections_list_all_sorting(client):
 
     # Get all collections
     collections = client.collections.list_all()
-    
+
     # Get the keys and filter only our test collections
     collection_keys = list(collections.keys())
     test_collections = [k for k in collection_keys if k.startswith("TestCollection")]
-    
+
     # Verify they are in alphabetical order
     assert test_collections == sorted(test_collections)
-    
+
     # Test with simple=False as well
     collections = client.collections.list_all(simple=False)
     collection_keys = list(collections.keys())
     test_collections = [k for k in collection_keys if k.startswith("TestCollection")]
     assert test_collections == sorted(test_collections)
-    
+
     # Clean up
     client.collections.delete(["TestCollectionA", "TestCollectionB", "TestCollectionC"])

--- a/integration/test_collections_sorting.py
+++ b/integration/test_collections_sorting.py
@@ -5,10 +5,10 @@ from integration.conftest import ClientFactory
 @pytest.fixture
 def sorting_test_client(client_factory: ClientFactory):
     client = client_factory()
-    client.collections.delete_all()
-    yield client
-    client.collections.delete_all()
-    client.close()
+    try:
+        yield client
+    finally:
+        client.close()
 
 
 def test_collections_list_all_sorting(sorting_test_client):
@@ -16,26 +16,30 @@ def test_collections_list_all_sorting(sorting_test_client):
 
     client = sorting_test_client
 
-    # Create collections with names in non-alphabetical order
-    client.collections.create(name="TestCollectionC")
-    client.collections.create(name="TestCollectionA")
-    client.collections.create(name="TestCollectionB")
+    try:
+        # Create collections with names in non-alphabetical order
+        client.collections.create(name="SortingTestCollectionC")
+        client.collections.create(name="SortingTestCollectionA")
+        client.collections.create(name="SortingTestCollectionB")
 
-    # Get all collections
-    collections = client.collections.list_all()
+        # Get all collections
+        collections = client.collections.list_all()
 
-    # Get the keys and filter only our test collections
-    collection_keys = list(collections.keys())
-    test_collections = [k for k in collection_keys if k.startswith("TestCollection")]
+        # Get the keys and filter only our test collections
+        collection_keys = list(collections.keys())
+        test_collections = [k for k in collection_keys if k.startswith("SortingTestCollection")]
 
-    # Verify they are in alphabetical order
-    assert test_collections == sorted(test_collections)
+        # Verify they are in alphabetical order
+        assert test_collections == sorted(test_collections)
 
-    # Test with simple=False as well
-    collections = client.collections.list_all(simple=False)
-    collection_keys = list(collections.keys())
-    test_collections = [k for k in collection_keys if k.startswith("TestCollection")]
-    assert test_collections == sorted(test_collections)
+        # Test with simple=False as well
+        collections = client.collections.list_all(simple=False)
+        collection_keys = list(collections.keys())
+        test_collections = [k for k in collection_keys if k.startswith("SortingTestCollection")]
+        assert test_collections == sorted(test_collections)
 
-    # Clean up
-    client.collections.delete(["TestCollectionA", "TestCollectionB", "TestCollectionC"])
+    finally:
+        # Clean up
+        client.collections.delete(
+            ["SortingTestCollectionA", "SortingTestCollectionB", "SortingTestCollectionC"]
+        )

--- a/test/collection/test_collections_sorting.py
+++ b/test/collection/test_collections_sorting.py
@@ -24,7 +24,7 @@ def test_collection_configs_from_json_sorting():
     ):
         # Call the function
         result = _collection_configs_from_json(mock_schema)
-        
+
         # Check that the keys are in alphabetical order
         assert list(result.keys()) == ["CollectionA", "CollectionB", "CollectionC"]
 
@@ -47,6 +47,6 @@ def test_collection_configs_simple_from_json_sorting():
     ):
         # Call the function
         result = _collection_configs_simple_from_json(mock_schema)
-        
+
         # Check that the keys are in alphabetical order
         assert list(result.keys()) == ["CollectionA", "CollectionB", "CollectionC"]

--- a/test/collection/test_collections_sorting.py
+++ b/test/collection/test_collections_sorting.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import MagicMock, patch
 from weaviate.collections.classes.config_methods import (
     _collection_configs_from_json,

--- a/test/collection/test_collections_sorting.py
+++ b/test/collection/test_collections_sorting.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from weaviate.collections.classes.config_methods import (
+    _collection_configs_from_json,
+    _collection_configs_simple_from_json,
+)
+
+
+def test_collection_configs_from_json_sorting():
+    """Test that _collection_configs_from_json returns collections sorted by key."""
+    # Mock schema with collections in non-alphabetical order
+    mock_schema = {
+        "classes": [
+            {"class": "CollectionC", "description": "Collection C"},
+            {"class": "CollectionA", "description": "Collection A"},
+            {"class": "CollectionB", "description": "Collection B"},
+        ]
+    }
+
+    # Mock the _collection_config_from_json function to return a simple object
+    with patch(
+        "weaviate.collections.classes.config_methods._collection_config_from_json",
+        return_value=MagicMock(),
+    ):
+        # Call the function
+        result = _collection_configs_from_json(mock_schema)
+        
+        # Check that the keys are in alphabetical order
+        assert list(result.keys()) == ["CollectionA", "CollectionB", "CollectionC"]
+
+
+def test_collection_configs_simple_from_json_sorting():
+    """Test that _collection_configs_simple_from_json returns collections sorted by key."""
+    # Mock schema with collections in non-alphabetical order
+    mock_schema = {
+        "classes": [
+            {"class": "CollectionC", "description": "Collection C"},
+            {"class": "CollectionA", "description": "Collection A"},
+            {"class": "CollectionB", "description": "Collection B"},
+        ]
+    }
+
+    # Mock the _collection_config_simple_from_json function to return a simple object
+    with patch(
+        "weaviate.collections.classes.config_methods._collection_config_simple_from_json",
+        return_value=MagicMock(),
+    ):
+        # Call the function
+        result = _collection_configs_simple_from_json(mock_schema)
+        
+        # Check that the keys are in alphabetical order
+        assert list(result.keys()) == ["CollectionA", "CollectionB", "CollectionC"]

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -343,15 +343,17 @@ def _collection_config_from_json(schema: Dict[str, Any]) -> _CollectionConfig:
 
 
 def _collection_configs_from_json(schema: Dict[str, Any]) -> Dict[str, _CollectionConfig]:
-    return {schema["class"]: _collection_config_from_json(schema) for schema in schema["classes"]}
+    configs = {schema["class"]: _collection_config_from_json(schema) for schema in schema["classes"]}
+    return dict(sorted(configs.items()))
 
 
 def _collection_configs_simple_from_json(
     schema: Dict[str, Any]
 ) -> Dict[str, _CollectionConfigSimple]:
-    return {
+    configs = {
         schema["class"]: _collection_config_simple_from_json(schema) for schema in schema["classes"]
     }
+    return dict(sorted(configs.items()))
 
 
 def _nested_properties_from_config(props: List[Dict[str, Any]]) -> List[_NestedProperty]:

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -343,7 +343,9 @@ def _collection_config_from_json(schema: Dict[str, Any]) -> _CollectionConfig:
 
 
 def _collection_configs_from_json(schema: Dict[str, Any]) -> Dict[str, _CollectionConfig]:
-    configs = {schema["class"]: _collection_config_from_json(schema) for schema in schema["classes"]}
+    configs = {
+        schema["class"]: _collection_config_from_json(schema) for schema in schema["classes"]
+    }
     return dict(sorted(configs.items()))
 
 


### PR DESCRIPTION
1. Modified the _collection_configs_from_json and _collection_configs_simple_from_json functions in weaviate/collections/classes/config_methods.py to sort the dictionaries by key before returning them.

2. Added unit tests in test/collection/test_collections_sorting.py to verify the sorting functionality.

3. Added integration tests in integration/test_collections_sorting.py to verify the sorting in a real environment.

