### PR TITLE
Add support for extracting nested object array properties from data models

### DIFF
--- a/weaviate/collections/aggregations/hybrid/executor.py
+++ b/weaviate/collections/aggregations/hybrid/executor.py
@@ -12,8 +12,8 @@ from weaviate.collections.filters import _FilterToGRPC
 from weaviate.connect import executor
 from weaviate.connect.v4 import ConnectionType
 from weaviate.exceptions import WeaviateUnsupportedFeatureError
-from weaviate.types import NUMBER
 from weaviate.proto.v1 import aggregate_pb2
+from weaviate.types import NUMBER
 
 
 class _HybridExecutor(Generic[ConnectionType], _BaseExecutor[ConnectionType]):

--- a/weaviate/collections/aggregations/near_image/executor.py
+++ b/weaviate/collections/aggregations/near_image/executor.py
@@ -11,9 +11,9 @@ from weaviate.collections.classes.filters import _Filters
 from weaviate.collections.filters import _FilterToGRPC
 from weaviate.connect import executor
 from weaviate.connect.v4 import ConnectionType
+from weaviate.proto.v1 import aggregate_pb2
 from weaviate.types import BLOB_INPUT, NUMBER
 from weaviate.util import parse_blob
-from weaviate.proto.v1 import aggregate_pb2
 
 
 class _NearImageExecutor(Generic[ConnectionType], _BaseExecutor[ConnectionType]):

--- a/weaviate/collections/aggregations/near_object/executor.py
+++ b/weaviate/collections/aggregations/near_object/executor.py
@@ -11,8 +11,8 @@ from weaviate.collections.classes.filters import _Filters
 from weaviate.collections.filters import _FilterToGRPC
 from weaviate.connect import executor
 from weaviate.connect.v4 import ConnectionType
-from weaviate.types import NUMBER, UUID
 from weaviate.proto.v1 import aggregate_pb2
+from weaviate.types import NUMBER, UUID
 
 
 class _NearObjectExecutor(Generic[ConnectionType], _BaseExecutor[ConnectionType]):

--- a/weaviate/collections/aggregations/near_text/executor.py
+++ b/weaviate/collections/aggregations/near_text/executor.py
@@ -12,8 +12,8 @@ from weaviate.collections.classes.grpc import Move
 from weaviate.collections.filters import _FilterToGRPC
 from weaviate.connect import executor
 from weaviate.connect.v4 import ConnectionType
-from weaviate.types import NUMBER
 from weaviate.proto.v1 import aggregate_pb2
+from weaviate.types import NUMBER
 
 
 class _NearTextExecutor(Generic[ConnectionType], _BaseExecutor[ConnectionType]):

--- a/weaviate/collections/aggregations/near_vector/executor.py
+++ b/weaviate/collections/aggregations/near_vector/executor.py
@@ -16,8 +16,8 @@ from weaviate.collections.filters import _FilterToGRPC
 from weaviate.connect import executor
 from weaviate.connect.v4 import ConnectionType
 from weaviate.exceptions import WeaviateInvalidInputError
-from weaviate.types import NUMBER
 from weaviate.proto.v1 import aggregate_pb2
+from weaviate.types import NUMBER
 
 
 class _NearVectorExecutor(Generic[ConnectionType], _BaseExecutor[ConnectionType]):

--- a/weaviate/collections/classes/internal.py
+++ b/weaviate/collections/classes/internal.py
@@ -438,6 +438,10 @@ def __is_nested(value: Any) -> bool:
 
 def __create_nested_property_from_nested(name: str, value: Any) -> QueryNested:
     inner_type = get_args(value)[0]
+    # If this nested property contains an object array, use the element type
+    if get_origin(inner_type) is list:
+        inner_type = get_args(inner_type)[0]
+
     return QueryNested(
         name=name,
         properties=[


### PR DESCRIPTION
Currently, using `Nested[list[SubObject]` to automatically extract properties from data models isn't supported – only using `Nested[SubObject]` within a `TypedDict` data model type results in automatic marshalling of the property, even though both `object` and `object[]` types can be used for nested properties within a collection. This PR adds support for auto-extracting nested `object[]` properties in addition to nested `object` properties via the `Nested` generic wrapper type.

##### Example

```python
from typing import TypedDict

import weaviate
import weaviate.classes.config as wc
from weaviate.classes.generics import Nested

client = weaviate.connect_to_local()

class Child(TypedDict):
    age: int
    name: str

class Parent(TypedDict):
    age: int
    name: str
    children: Nested[list[Child]]

collection = client.collections.create(
    name="Parent",
    properties=[
        wc.Property(name="age", data_type=wc.DataType.INT),
        wc.Property(name="name", data_type=wc.DataType.TEXT),
        wc.Property(
            name="children", 
            data_type=wc.DataType.OBJECT_ARRAY,
            nested_properties=[
                wc.Property(name="age", data_type=wc.DataType.INT),
                wc.Property(name="name", data_type=wc.DataType.TEXT),
            ]
        )
    ],
    vectorizer_config=wc.Configure.Vectorizer.none(),
    data_model_properties=Parent,
)
    
collection.data.insert({
    "age": 39,
    "name": "Bob Smith",
    "children": [{
        "age": 8,
        "name": "Joe Smith",
    }, {
        "age": 10,
        "name": "Jane Smith",
    }]
})

res = collection.query.fetch_objects()
print(res.objects[0].properties)
```

###### Current State

Prior to this change, running the above snippet resulted in an error. (This was due to the `list[SubObject]` type being passed to `typing.get_type_hints` within the extraction logic, rather than the underlying `SubObject` type.)
```
>>> TypeError: list[Child] is not a module, class, method, or function.
```

###### New State

With this change, the inserted data is now fetched and marshalled back to the `TypedDict` data model.
```
{'age': 39, 'name': 'Bob Smith', 'children': [{'age': 8, 'name': 'Joe Smith'}, {'age': 10, 'name': 'Jane Smith'}]}
```