### PR TITLE
Fix: Update (soon to be) deprecated model_fields access to use class reference

### DIFF
--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1163,7 +1163,7 @@ class _CollectionConfigCreateBase(_ConfigCreateModel):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict: Dict[str, Any] = {}
 
-        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:
             val = getattr(self, cls_field)
             if cls_field in ["name", "model", "properties", "references"] or val is None:
                 continue
@@ -1972,7 +1972,7 @@ class _CollectionConfigCreate(_ConfigCreateModel):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict: Dict[str, Any] = {}
 
-        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:
             val = getattr(self, cls_field)
             if cls_field in ["name", "model", "properties", "references"] or val is None:
                 continue

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1163,7 +1163,7 @@ class _CollectionConfigCreateBase(_ConfigCreateModel):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict: Dict[str, Any] = {}
 
-        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if cls_field in ["name", "model", "properties", "references"] or val is None:
                 continue
@@ -1972,7 +1972,7 @@ class _CollectionConfigCreate(_ConfigCreateModel):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict: Dict[str, Any] = {}
 
-        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if cls_field in ["name", "model", "properties", "references"] or val is None:
                 continue

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1163,7 +1163,7 @@ class _CollectionConfigCreateBase(_ConfigCreateModel):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict: Dict[str, Any] = {}
 
-        for cls_field in self.model_fields:
+        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if cls_field in ["name", "model", "properties", "references"] or val is None:
                 continue
@@ -1972,7 +1972,7 @@ class _CollectionConfigCreate(_ConfigCreateModel):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict: Dict[str, Any] = {}
 
-        for cls_field in self.model_fields:
+        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if cls_field in ["name", "model", "properties", "references"] or val is None:
                 continue

--- a/weaviate/collections/classes/config_base.py
+++ b/weaviate/collections/classes/config_base.py
@@ -22,7 +22,7 @@ class _ConfigUpdateModel(BaseModel):
     model_config = ConfigDict(strict=True)
 
     def merge_with_existing(self, schema: Dict[str, Any]) -> Dict[str, Any]:
-        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if val is None:
                 continue

--- a/weaviate/collections/classes/config_base.py
+++ b/weaviate/collections/classes/config_base.py
@@ -22,7 +22,7 @@ class _ConfigUpdateModel(BaseModel):
     model_config = ConfigDict(strict=True)
 
     def merge_with_existing(self, schema: Dict[str, Any]) -> Dict[str, Any]:
-        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:
             val = getattr(self, cls_field)
             if val is None:
                 continue

--- a/weaviate/collections/classes/config_base.py
+++ b/weaviate/collections/classes/config_base.py
@@ -22,7 +22,7 @@ class _ConfigUpdateModel(BaseModel):
     model_config = ConfigDict(strict=True)
 
     def merge_with_existing(self, schema: Dict[str, Any]) -> Dict[str, Any]:
-        for cls_field in self.model_fields:
+        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if val is None:
                 continue

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -413,7 +413,7 @@ class _Multi2VecBase(_VectorizerConfigCreate):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict = super()._to_dict()
         ret_dict["weights"] = {}
-        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if "Fields" in cls_field and val is not None:
                 val = cast(List[Multi2VecField], val)

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -413,7 +413,7 @@ class _Multi2VecBase(_VectorizerConfigCreate):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict = super()._to_dict()
         ret_dict["weights"] = {}
-        for cls_field in self.model_fields:
+        for cls_field in type(self).model_fields: # pydantic 2.x -> pydantic 3.x
             val = getattr(self, cls_field)
             if "Fields" in cls_field and val is not None:
                 val = cast(List[Multi2VecField], val)

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -413,7 +413,7 @@ class _Multi2VecBase(_VectorizerConfigCreate):
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict = super()._to_dict()
         ret_dict["weights"] = {}
-        for cls_field in type(self).model_fields:  # pydantic 2.x -> pydantic 3.x
+        for cls_field in type(self).model_fields:
             val = getattr(self, cls_field)
             if "Fields" in cls_field and val is not None:
                 val = cast(List[Multi2VecField], val)


### PR DESCRIPTION
### Summary

Update usage of `self.model_fields` to `type(self).model_fields` to comply with the [deprecation notice in Pydantic v2](https://docs.pydantic.dev/2.11/api/base_model/#pydantic.BaseModel.model_config). This will break in v3.

### Test
`./ci/start_weaviate.sh latest`

All tests passed with:
`pytest integration` 
`pytest mock_tests`
`pytest test`