### PR TITLE
chore: Fix the version check for alias to v1.32

### DIFF
--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -578,7 +578,7 @@ class _ServerVersion:
 
     def check_is_at_least_1_32_0(self, feature: str) -> None:
         if not self >= _ServerVersion(1, 32, 0):
-            raise WeaviateUnsupportedFeatureError(feature, str(self), "1.25.0")
+            raise WeaviateUnsupportedFeatureError(feature, str(self), "1.32.0")
 
     @property
     def supports_tenants_get_grpc(self) -> bool:


### PR DESCRIPTION
[This PR](https://github.com/weaviate/weaviate-python-client/pull/1719/files) added this helper, but looks like failed to update the version from v1.25 -> v1.32