### PR TITLE
handle date with nanoseconds

### DIFF
--- a/weaviate/collections/queries/base_executor.py
+++ b/weaviate/collections/queries/base_executor.py
@@ -269,15 +269,7 @@ class _BaseExecutor(Generic[ConnectionType]):
         if value.HasField("uuid_value"):
             return uuid_lib.UUID(value.uuid_value)
         if value.HasField("date_value"):
-            try:
-                return _datetime_from_weaviate_str(value.date_value)
-            except ValueError as e:
-                # note that the year 9999 is valid and does not need to be handled. for 5 digit years only the first
-                # 4 digits are considered and it wrapps around
-                if "year 0 is out of range" in str(e):
-                    _Warnings.datetime_year_zero(value.date_value)
-                    return datetime.datetime.min
-
+            return _datetime_from_weaviate_str(value.date_value)
         if value.HasField("string_value"):
             return str(value.string_value)
         if value.HasField("text_value"):

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -712,16 +712,23 @@ def _datetime_to_string(value: TIME) -> str:
 
 
 def _datetime_from_weaviate_str(string: str) -> datetime.datetime:
+    if string[-1] != "Z":
+        string = "".join(string.rsplit(":", 1))
+
+    # Weaviate can return up to 9 digits for milliseconds, but Python datetime only supports 6 digits.
+    string = re.sub(r"(?<=\.\d{6})\d+(?=[Z+-])", "", string)
+    # pick format with or without microseconds
+    date_format = "%Y-%m-%dT%H:%M:%S.%f%z" if "." in string else "%Y-%m-%dT%H:%M:%S%z"
+
     try:
-        return datetime.datetime.strptime(
-            "".join(string.rsplit(":", 1) if string[-1] != "Z" else string),
-            "%Y-%m-%dT%H:%M:%S.%f%z",
-        )
-    except ValueError:  # if the string does not have microseconds
-        return datetime.datetime.strptime(
-            "".join(string.rsplit(":", 1) if string[-1] != "Z" else string),
-            "%Y-%m-%dT%H:%M:%S%z",
-        )
+        return datetime.datetime.strptime(string, date_format)
+    except ValueError as e:
+        # note that the year 9999 is valid and does not need to be handled. for 5 digit years only the first
+        # 4 digits are considered and it wrapps around
+        if "year 0 is out of range" in str(e):
+            _Warnings.datetime_year_zero(string)
+            return datetime.datetime.min
+        raise e
 
 
 class _WeaviateUUIDInt(uuid_lib.UUID):


### PR DESCRIPTION
### Issue
`Weaviate` and `RFC3339` can return more than 6 digits milliseconds precision, while Python's `datetime` supports only 6.
When that happens, on retrieval original exception is swallowed and following is raised:
`ValueError: Protocol message Value has no "value" field.` from [here](https://github.com/weaviate/weaviate-python-client/blob/0e409b986973c7245cea4b40b5be563e3990b049/weaviate/collections/queries/base_executor.py#L310).

### Changes
1. Strip any other digits following 6 microsecond digits.
2. Move 0 year handling to `_datetime_from_weaviate_str` so it's aligned between `date` and `date_array` properties.
3. Re-raise original exception so the cause is clear.
4. Add unit tests for date parsing util.