### PR TITLE
Change default to `True` for `vectorize_collection_name` in `_Vectors` and `_MultiVectors`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 4.16.4
+--------------
+This patch version includes:
+  - Changes default value for ``vectorize_collection_name`` to ``True`` in new methods of ``Configure.Vectors`` and ``Configure.MultiVectors``
+    - This is a short-term fix to implicit default behaviour that is caused by an server-side issue
+    - Once that is resolved, then this default will be changed back to ``False`` in a future release
+
 Version 4.16.3
 --------------
 This patch version includes:

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -1910,7 +1910,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
             "test": {
                 "vectorizer": {
                     "text2vec-contextionary": {
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "properties": ["prop"],
                     }
                 },
@@ -1934,7 +1934,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                     "text2vec-openai": {
                         "resourceName": "resource",
                         "deploymentId": "deployment",
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "properties": ["prop"],
                         "dimensions": 512,
                         "isAzure": True,
@@ -1950,7 +1950,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
             "test": {
                 "vectorizer": {
                     "text2vec-cohere": {
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "properties": ["prop"],
                     }
                 },
@@ -2036,7 +2036,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-gpt4all": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                     }
                 },
                 "vectorIndexType": "hnsw",
@@ -2050,7 +2050,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-huggingface": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                     }
                 },
                 "vectorIndexType": "hnsw",
@@ -2068,7 +2068,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-aws": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "region": "us-east-1",
                         "service": "bedrock",
                     }
@@ -2087,7 +2087,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
             "test": {
                 "vectorizer": {
                     "text2vec-databricks": {
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "instruction": "instruction",
                         "endpoint": "http://api.custom.com",
                     }
@@ -2110,7 +2110,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-ollama": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "apiEndpoint": "https://123.0.0.4",
                         "model": "cool-model",
                     }
@@ -2130,7 +2130,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-openai": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "baseURL": "https://api.openai.com/",
                         "isAzure": False,
                     }
@@ -2145,7 +2145,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
             "test": {
                 "vectorizer": {
                     "text2vec-mistral": {
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "properties": ["prop"],
                     }
                 },
@@ -2167,7 +2167,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                     "text2vec-palm": {
                         "projectId": "project",
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                     }
                 },
                 "vectorIndexType": "hnsw",
@@ -2187,7 +2187,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                     "text2vec-palm": {
                         "apiEndpoint": "generativelanguage.googleapis.com",
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                     }
                 },
                 "vectorIndexType": "hnsw",
@@ -2201,7 +2201,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-transformers": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "poolingStrategy": "masked_mean",
                     }
                 },
@@ -2220,7 +2220,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-voyageai": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "truncate": True,
                     }
                 },
@@ -2235,7 +2235,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-nvidia": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "truncate": True,
                     }
                 },
@@ -2257,7 +2257,7 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                 "vectorizer": {
                     "text2vec-weaviate": {
                         "properties": ["prop"],
-                        "vectorizeClassName": False,
+                        "vectorizeClassName": True,
                         "baseURL": "https://api.embedding.weaviate.io",
                         "dimensions": 768,
                     }

--- a/weaviate/collections/classes/config_vectors.py
+++ b/weaviate/collections/classes/config_vectors.py
@@ -209,7 +209,7 @@ class _MultiVectors:
         source_properties: Optional[List[str]] = None,
         multi_vector_config: Optional[_MultiVectorConfigCreate] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a multi-vector using the `text2colbert-jinaai` module.
 
@@ -344,7 +344,7 @@ class _Vectors:
         truncate: Optional[CohereTruncation] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-cohere` module.
 
@@ -387,7 +387,7 @@ class _Vectors:
         text_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
         truncate: Optional[CohereTruncation] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `multi2vec_cohere` module.
 
@@ -426,7 +426,7 @@ class _Vectors:
         quantizer: Optional[_QuantizerConfigCreate] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec_contextionary` module.
 
@@ -458,7 +458,7 @@ class _Vectors:
         instruction: Optional[str] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-databricks` module.
 
@@ -494,7 +494,7 @@ class _Vectors:
         model: Optional[str] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-mistral` module.
 
@@ -530,7 +530,7 @@ class _Vectors:
         model: Optional[str] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-ollama` module.
 
@@ -572,7 +572,7 @@ class _Vectors:
         type_: Optional[OpenAIType] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-openai` module.
 
@@ -619,7 +619,7 @@ class _Vectors:
         service: Union[AWSService, str] = "bedrock",
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-aws` module.
 
@@ -932,7 +932,7 @@ class _Vectors:
         resource_name: str,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-openai` module running with Azure.
 
@@ -972,7 +972,7 @@ class _Vectors:
         quantizer: Optional[_QuantizerConfigCreate] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-gpt4all` module.
 
@@ -1009,7 +1009,7 @@ class _Vectors:
         use_cache: Optional[bool] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-huggingface` module.
 
@@ -1062,7 +1062,7 @@ class _Vectors:
         title_property: Optional[str] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-google` model.
 
@@ -1105,7 +1105,7 @@ class _Vectors:
         title_property: Optional[str] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-google` model.
 
@@ -1148,7 +1148,7 @@ class _Vectors:
         query_inference_url: Optional[str] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-transformers` module.
 
@@ -1189,7 +1189,7 @@ class _Vectors:
         model: Optional[Union[JinaModel, str]] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-jinaai` module.
 
@@ -1269,7 +1269,7 @@ class _Vectors:
         truncate: Optional[bool] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-voyageai` module.
 
@@ -1310,7 +1310,7 @@ class _Vectors:
         model: Optional[Union[WeaviateModel, str]] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         return _VectorConfigCreate(
             name=name,
@@ -1334,7 +1334,7 @@ class _Vectors:
         truncate: Optional[bool] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = False,
+        vectorize_collection_name: bool = True,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-nvidia` module.
 


### PR DESCRIPTION
This change should be reverted once all available patch server versions do not throw the following error when this default is set to `False`:
> UnexpectedStatusCodeError: Collection may not have been created properly.! Unexpected status code: 422, with response body: {'error': [{'message': "module 'text2vec-openai': invalid properties: didn't find a single property which is of type string or text and is not excluded from indexing. In addition the class name is excluded from vectorization as well, meaning that it cannot be used to determine the vector position. To fix this, set 'vectorizeClassName' to true if the class name is contextionary-valid. Alternatively add at least contextionary-valid text/string property which is not excluded from indexing"}]}.