### PR TITLE
rq: Add bits to the update method

### DIFF
--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -2223,6 +2223,7 @@ class _VectorIndexQuantizerUpdate:
     def rq(
         rescore_limit: Optional[int] = None,
         enabled: bool = True,
+        bits: Optional[int] = None,
     ) -> _RQConfigUpdate:
         """Create a `_RQConfigUpdate` object to be used when updating the Rotational quantization (RQ) configuration of Weaviate.
 
@@ -2231,7 +2232,7 @@ class _VectorIndexQuantizerUpdate:
         Arguments:
             See [the docs](https://weaviate.io/developers/weaviate/concepts/vector-index#hnsw-with-compression) for a more detailed view!
         """  # noqa: D417 (missing argument descriptions in the docstring)
-        return _RQConfigUpdate(enabled=enabled, rescoreLimit=rescore_limit)
+        return _RQConfigUpdate(enabled=enabled, rescoreLimit=rescore_limit, bits=bits)
 
 
 class _VectorIndexUpdate:

--- a/weaviate/collections/classes/config_vector_index.py
+++ b/weaviate/collections/classes/config_vector_index.py
@@ -305,6 +305,7 @@ class _BQConfigUpdate(_QuantizerConfigUpdate):
 class _RQConfigUpdate(_QuantizerConfigUpdate):
     enabled: Optional[bool]
     rescoreLimit: Optional[int]
+    bits: Optional[int]
 
     @staticmethod
     def quantizer_name() -> str:


### PR DESCRIPTION
If the collection is created without quantization but the user wants to enable it later, it must use the Update method. However, that method didn't support the bits parameter.  This PR adds it.