### PR TITLE
bug: Include empty string check for permission resource

### DIFF
--- a/integration/test_rbac.py
+++ b/integration/test_rbac.py
@@ -325,6 +325,27 @@ RBAC_AUTH_CREDS = Auth.api_key("admin-key")
             32,
         ),
         (
+            Permissions.alias(alias="", read=True, delete=True),
+            Role(
+                name="AlliasRole",
+                alias_permissions=[
+                    AliasPermissionOutput(
+                        alias="", actions={Actions.Alias.READ, Actions.Alias.DELETE}
+                    )
+                ],
+                cluster_permissions=[],
+                users_permissions=[],
+                collections_permissions=[],
+                roles_permissions=[],
+                data_permissions=[],
+                backups_permissions=[],
+                nodes_permissions=[],
+                tenants_permissions=[],
+                replicate_permissions=[],
+            ),
+            32,  # Minimum version for alias permissions
+        ),
+        (
             Permissions.alias(alias="*", read=True, delete=True),
             Role(
                 name="AlliasRole",

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -407,6 +407,8 @@ def _capitalize_first_letter(string: str) -> str:
     Returns:
         The capitalized string.
     """
+    if len(string) == 0:
+        return ""
     if len(string) == 1:
         return string.capitalize()
     return string[0].capitalize() + string[1:]


### PR DESCRIPTION
Currently, if we pass empty string for resource, the "capitalize_first_letter" check panics, because it misses the empty string check looks like.

```
File "/home/kavi/src/play-weaviate/venv/lib/python3.13/site-packages/weaviate/util.py", line 412, in _capitalize_first_letter
    return string[0].capitalize() + string[1:]
           ~~~~~~^^^
IndexError: string index out of range
```

When doing something like

```
permissions = [Permissions.alias(alias="", collection="TestCollectionRead", create=True)]
    collection_names = ["TestCollectionRead"]
    alias_names = ["Test_alias_read"]

    if permissions:
        root_client.roles.add_permissions(
            role_name=custom_role_name, permissions=permissions)
```

NOTE: `alias` is empty.