### PR TITLE
flat index: Add support for RQ and include cache param

### DIFF
--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1521,6 +1521,7 @@ class _SQConfig(_ConfigBase):
 
 @dataclass
 class _RQConfig(_ConfigBase):
+    cache: Optional[bool]
     bits: Optional[int]
     rescore_limit: int
 
@@ -2293,7 +2294,7 @@ class _VectorIndexUpdate:
     @staticmethod
     def flat(
         vector_cache_max_objects: Optional[int] = None,
-        quantizer: Optional[_BQConfigUpdate] = None,
+        quantizer: Optional[Union[_BQConfigUpdate, _RQConfigUpdate]] = None,
     ) -> _VectorIndexConfigFlatUpdate:
         """Create an `_VectorIndexConfigFlatUpdate` object to update the configuration of the FLAT vector index.
 

--- a/weaviate/collections/classes/config_methods.py
+++ b/weaviate/collections/classes/config_methods.py
@@ -150,6 +150,7 @@ def __get_quantizer_config(
         )
     elif "rq" in config and config["rq"].get("enabled"):
         quantizer = _RQConfig(
+            cache=config["rq"].get("cache"),
             bits=config["rq"].get("bits"),
             rescore_limit=config["rq"].get("rescoreLimit"),
         )

--- a/weaviate/collections/classes/config_vector_index.py
+++ b/weaviate/collections/classes/config_vector_index.py
@@ -275,6 +275,7 @@ class _SQConfigCreate(_QuantizerConfigCreate):
 
 
 class _RQConfigCreate(_QuantizerConfigCreate):
+    cache: Optional[bool]
     bits: Optional[int]
     rescoreLimit: Optional[int]
 
@@ -443,6 +444,7 @@ class _VectorIndexQuantizer:
 
     @staticmethod
     def rq(
+        cache: Optional[bool] = None,
         bits: Optional[int] = None,
         rescore_limit: Optional[int] = None,
     ) -> _RQConfigCreate:
@@ -454,6 +456,7 @@ class _VectorIndexQuantizer:
             See [the docs](https://weaviate.io/developers/weaviate/concepts/vector-index) for a more detailed view!
         """  # noqa: D417 (missing argument descriptions in the docstring)
         return _RQConfigCreate(
+            cache=cache,
             bits=bits,
             rescoreLimit=rescore_limit,
         )


### PR DESCRIPTION
This PR extends the usage of the client to support RQ with flat index.

To do so, include the cache param and also extend the update functions.

