### PR TITLE
Mark 'ChunkSize' as deprecated & exclude it from export

### DIFF
--- a/integration/test_backup_v4.py
+++ b/integration/test_backup_v4.py
@@ -464,7 +464,6 @@ def test_backup_and_restore_with_collection_and_config_1_24_x(
         wait_for_completion=True,
         config=BackupConfigCreate(
             cpu_percentage=60,
-            chunk_size=256,
             compression_level=BackupCompressionLevel.BEST_SPEED,
         ),
     )

--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -62,7 +62,12 @@ class _BackupConfigBase(BaseModel):
 class BackupConfigCreate(_BackupConfigBase):
     """Options to configure the backup when creating a backup."""
 
-    ChunkSize: Optional[int] = Field(default=None, alias="chunk_size")
+    ChunkSize: Optional[int] = Field(
+        default=None,
+        alias="chunk_size",
+        description="DEPRECATED: This parameter no longer has any effect.",
+        exclude=True,
+    )
     CompressionLevel: Optional[BackupCompressionLevel] = Field(
         default=None, alias="compression_level"
     )


### PR DESCRIPTION
Mark 'ChunkSize' as deprecated & exclude it from export