### PR TITLE
Client telemetry

### DIFF
--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -150,11 +150,13 @@ class _ConnectionBase:
         self._connected = False
         self._skip_init_checks = skip_init_checks
 
+        client_type = "sync" if isinstance(self, ConnectionSync) else "async"
+        embedded_suffix = "-embedded" if self.embedded_db is not None else ""
+        client_header = f"weaviate-client-python/{client_version}-{client_type}{embedded_suffix}"
+
         self._headers = {
             "content-type": "application/json",
-            "X-Weaviate-Client": f"weaviate-client-python/{client_version}",
-            "X-Weaviate-Client-Type": "sync" if isinstance(self, ConnectionSync) else "async",
-            "X-Weaviate-Client-IsEmbedded": "true" if self.embedded_db is not None else "false",
+            "X-Weaviate-Client": client_header,
         }
         self.__add_weaviate_embedding_service_header(connection_params.http.host)
         if additional_headers is not None:


### PR DESCRIPTION
Adds the `X-Weaviate-Client` header to all HTTP requests to the Weaviate server, as required by the server.

### Changes

- Added `X-Weaviate-Client` header in `_ConnectionBase.__init__` to ensure it's included in all HTTP requests
- Header format: `weaviate-client-python/{version}-{sync|async}[-embedded]`
  - Includes the client version
  - Indicates sync or async connection type
  - Appends `-embedded` suffix when using embedded Weaviate

The header is set during connection initialization and automatically included in all requests made through both `ConnectionSync` and `ConnectionAsync`.