### PR TITLE
fix github actions: archived coverage artifact download issue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
         run: pytest -v --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage-integration-embedded.xml integration_embedded
       - name: Archive code coverage results
-        if: matrix.version == '3.10' && (github.ref_name != 'main')
+        if: matrix.version == '3.10' && (github.ref_name != 'main') && !github.event.pull_request.head.repo.fork
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-integration-embedded
@@ -242,7 +242,7 @@ jobs:
   Codecov:
     needs: [Unit-Tests, Integration-Tests]
     runs-on: ubuntu-latest
-    if: github.ref_name != 'main'
+    if: github.ref_name != 'main' && !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@v4
       - name: Download coverage artifacts mock


### PR DESCRIPTION
The integration-tests-embedded job has a test step that is skipped for fork PRs (if: ${{ !github.event.pull_request.head.repo.fork }}), so coverage-integration-embedded.xml is never created.

However, the artifact upload step  does not check for fork PRs, so when it runs, there's no file to upload — the artifact never gets created.

The Codecov job then tries to download coverage-report-integration-embedded and fails.