### PR TITLE
feat: add support for blobHash property type

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -1341,6 +1341,10 @@ def test_config_create_with_properties(
                 data_type=DataType.BLOB,
             ),
             Property(
+                name="blob_hash",
+                data_type=DataType.BLOB_HASH,
+            ),
+            Property(
                 name="phone_number",
                 data_type=DataType.PHONE_NUMBER,
             ),
@@ -1402,6 +1406,10 @@ def test_config_create_with_properties(
         {
             "dataType": ["blob"],
             "name": "blob",
+        },
+        {
+            "dataType": ["blobHash"],
+            "name": "blob_hash",
         },
         {
             "dataType": ["phoneNumber"],

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -148,6 +148,7 @@ class DataType(str, BaseEnum):
         UUID_ARRAY: UUID array data type.
         GEO_COORDINATES: Geo coordinates data type.
         BLOB: Blob data type.
+        BLOB_HASH: Blob hash data type.
         PHONE_NUMBER: Phone number data type.
         OBJECT: Object data type.
         OBJECT_ARRAY: Object array data type.
@@ -167,6 +168,7 @@ class DataType(str, BaseEnum):
     UUID_ARRAY = "uuid[]"
     GEO_COORDINATES = "geoCoordinates"
     BLOB = "blob"
+    BLOB_HASH = "blobHash"
     PHONE_NUMBER = "phoneNumber"
     OBJECT = "object"
     OBJECT_ARRAY = "object[]"


### PR DESCRIPTION
## Summary
- Add `DataType.BLOB_HASH` (`"blobHash"`) to the `DataType` enum, mirroring the existing `BLOB` type
- Add test coverage for the new property type in `test_config_create_with_properties`

Closes #2014

## Test plan
- [x] `test_config_create_with_properties` passes with the new `BLOB_HASH` data type across all vectorizer parameterizations