### PR TITLE
docs: remove outdated deprecation notice from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,6 @@ We currently support the following versions client versions:
 
 - 4.X: actively supported
 - 3.X: deprecated, receives only critical bug fixes and dependency updates
-- copy of the 3.X branch in v4 releases: Will be removed on 2024-11-30
 
 
 Articles


### PR DESCRIPTION
## Description

Removed the outdated deprecation notice from the README that mentioned the v3.X branch would be removed on 2024-11-30.

## Changes
- Removed the line: "copy of the 3.X branch in v4 releases: Will be removed on 2024-11-30"

## Motivation
The mentioned date (2024-11-30) has passed (we are now in March 2026), making this deprecation notice outdated and potentially confusing for users. Since the timeline has expired, this information no longer serves its purpose.

## Type of Change
- [x] Documentation fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change