### PR TITLE
ci: pin GitHub Actions to server SHAs and add hidden-unicode lint

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,8 +36,8 @@ jobs:
     name: Run Linter and Formatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: 'pip' # caching pip dependencies
@@ -66,13 +66,13 @@ jobs:
         version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         folder: ["weaviate", "integration", "integration_embedded"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.version }}
           cache: 'pip' # caching pip dependencies
       - run: pip install -r requirements-devel.txt
-      - uses: jakebailey/pyright-action@v2
+      - uses: jakebailey/pyright-action@6cabc0f01c4994be48fd45cd9dbacdd6e1ee6e5e # v2
         with:
           version: 1.1.399
           working-directory: ${{ matrix.folder }}
@@ -86,8 +86,8 @@ jobs:
         version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         folder: ["test", "mock_tests"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.version }}
           cache: 'pip' # caching pip dependencies
@@ -96,7 +96,7 @@ jobs:
         run: pytest --cov -v --cov-report=term-missing --cov=weaviate --cov-report xml:coverage-${{ matrix.folder }}.xml ${{ matrix.folder }}
       - name: Archive code coverage results
         if: matrix.version == '3.10' && (github.ref_name != 'main')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report-${{ matrix.folder }}
           path: coverage-${{ matrix.folder }}.xml
@@ -110,8 +110,8 @@ jobs:
         grpc: ["1.59.5", "1.63.0", "1.65.0", "1.66.0", "1.68.0", "1.72.1", "1.73.0", "1.74.0"]
         protobuf: ["4.25.8", "5.26.0", "5.27.4", "5.28.3", "5.29.0", "6.30.0", "6.31.1", "6.32.0"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: 'pip' # caching pip dependencies
@@ -129,11 +129,11 @@ jobs:
         version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         optional_dependencies: [false]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.version }}
           cache: 'pip' # caching pip dependencies
@@ -145,7 +145,7 @@ jobs:
         run: pytest -v --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage-integration-embedded.xml integration_embedded
       - name: Archive code coverage results
         if: matrix.version == '3.10' && (github.ref_name != 'main') && !github.event.pull_request.head.repo.fork
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report-integration-embedded
           path: coverage-integration-embedded.xml
@@ -165,16 +165,16 @@ jobs:
         ]
         optional_dependencies: [false]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.versions.py }}
           cache: 'pip' # caching pip dependencies
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         if: ${{ !github.event.pull_request.head.repo.fork && github.triggering_actor != 'dependabot[bot]' }}
         with:
           username: ${{secrets.DOCKER_USERNAME}}
@@ -198,7 +198,7 @@ jobs:
         run: pytest -n auto --dist loadgroup -v --cov --cov-report=term-missing --cov=weaviate --cov-report xml:coverage-integration.xml integration
       - name: Archive code coverage results
         if: matrix.versions.py == '3.10' && (github.ref_name != 'main')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report-integration
           path: coverage-integration.xml
@@ -220,13 +220,13 @@ jobs:
         ]
         optional_dependencies: [false]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: 'pip' # caching pip dependencies
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         if: ${{ !github.event.pull_request.head.repo.fork && github.triggering_actor != 'dependabot[bot]' }}
         with:
           username: ${{secrets.DOCKER_USERNAME}}
@@ -245,25 +245,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name != 'main' && !github.event.pull_request.head.repo.fork
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Download coverage artifacts mock
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage-report-mock_tests
       - name: Download coverage artifacts unit
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage-report-test
       - name: Download coverage integration
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage-report-integration
       - name: Download coverage integration embedded
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage-report-integration-embedded
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           fail_ci_if_error: true
           files: ./coverage-integration.xml, ./coverage-integration-embedded.xml, ./coverage-test.xml, ./coverage-mock_tests.xml
@@ -275,11 +275,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: 'pip' # caching pip dependencies
@@ -288,7 +288,7 @@ jobs:
       - name: Build a binary wheel
         run: python -m build
       - name: Create Wheel Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           path: "dist/*.whl"
           name: weaviate-python-client-wheel
@@ -315,17 +315,17 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         if: ${{ !github.event.pull_request.head.repo.fork && github.triggering_actor != 'dependabot[bot]' }}
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Download build artifact to append to release
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: weaviate-python-client-wheel
       - run: |
@@ -343,11 +343,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
           cache: 'pip' # caching pip dependencies
@@ -357,7 +357,7 @@ jobs:
         run: python -m build
       - name: Publish distribution 📦 to PyPI on new tags
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           verbose: true
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -369,12 +369,12 @@ jobs:
     needs: [build-and-publish]
     steps:
       - name: Download build artifact to append to release
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: weaviate-python-client-wheel
           path: dist
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           generate_release_notes: true
           draft: true

--- a/.github/workflows/pr-security-lint.yaml
+++ b/.github/workflows/pr-security-lint.yaml
@@ -1,0 +1,35 @@
+name: PR Security Lint
+
+# SECURITY: This workflow uses pull_request_target intentionally so that the
+# workflow definition runs from the BASE branch (main), not the PR. The
+# composite action it invokes lives at a pinned 40-char SHA in
+# weaviate/weaviate — attackers cannot alter the lint logic via a PR or by
+# tampering with an upstream tag.
+#
+# Rules:
+#   1. Do NOT add `ref: ${{ github.event.pull_request.head.sha }}` or any
+#      reference to PR-controlled refs. The composite uses the GitHub API to
+#      fetch the diff text — no PR code is ever executed.
+#   2. Do NOT add secrets to this workflow. The pull_request_target context
+#      grants a token with write access to the base repo and access to all
+#      repo secrets if any are referenced. We reference none and request
+#      minimal permissions; keep it that way.
+#   3. Keep the composite action pinned to a full-length commit SHA. Tag or
+#      branch refs would let an upstream change alter the lint logic at
+#      execution time.
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  hidden-unicode:
+    name: hidden unicode characters
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read   # required by the composite's `gh pr diff` call
+    steps:
+      - uses: weaviate/weaviate/.github/actions/security-lint@3e52fc80a244f4644d4facc6a4e705ea6eda9039 # PR #11093
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Pin all `uses:` refs in GitHub Actions workflows to the same commit SHAs used by `weaviate/weaviate`, so this client stays in lockstep with the server
- Preserve the tag (e.g. `# v6`) as a trailing comment for readability
- Add `.github/workflows/pr-security-lint.yaml` that scans every PR diff for hidden Unicode / trojan-source characters by delegating to the reusable composite shipped in weaviate/weaviate#11093 (pinned to merge commit `3e52fc80a244f4644d4facc6a4e705ea6eda9039`)

## Context

Two complementary layers of GitHub Actions hardening:

1. **SHA pinning** — going forward, GitHub's repo-level ["Require actions to be pinned to a full-length commit SHA"](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/) policy (shipped 2025-08-15) will enforce this at execution time for every workflow. This commit is the initial consolidation pass.
2. **Hidden-Unicode scan** — the native policy doesn't cover trojan-source attacks. The shared composite in `weaviate/weaviate` is invoked here so all five Weaviate SDKs share one implementation.

### Security notes for the new workflow

- `pull_request_target` runs the workflow definition from the base branch, never from the PR.
- `permissions: {}` at workflow level; `pull-requests: read` is the only grant.
- The composite is pinned to a 40-char SHA — upstream tag retargeting can't alter what runs here.
- No PR-controlled refs are checked out; the composite fetches the diff text via the GitHub API.

## Tradeoffs of delegating to an upstream composite

**Pros**
- Single source of truth for the scan logic — fixes/improvements ship to all 5 SDKs via one SHA bump per repo, not by syncing 5 copies of bash.
- Composite is pinned to a 40-char SHA, so upstream tag retargeting can't change what runs here without a reviewable diff.
- `pull_request_target` runs the workflow definition from the base branch and the composite never checks out PR-controlled refs — a malicious PR can't alter the linter that's checking it.
- Minimal blast radius: `permissions: {}` at workflow level, `pull-requests: read` at job level, no secrets referenced.
- Composable — adding more scanners upstream (shell-script lint, etc.) propagates to every client automatically.

**Cons**
- Cross-repo runtime coupling: deleting or restructuring `weaviate/weaviate/.github/actions/security-lint` breaks all 5 clients until the SHA is bumped.
- `pull_request_target` is a foot-gun — a future editor adding `ref: pull_request.head.sha` or referencing a secret would re-introduce the attack surface this design is built to avoid. The file header warns against it, but the discipline lives in the reviewer.
- SHA-bump treadmill: upstream improvements don't propagate until each client opens a PR to bump the pinned SHA. Dependabot can automate this if we wire it up.
- Failure logs reference a path inside `weaviate/weaviate` rather than this repo, so debugging a false positive requires hopping to another repo to read the script.
- Cold-start adds a small network fetch of the composite per run.
## Test plan

- [ ] CI workflows run and pass on this branch
- [ ] `pr-security-lint` job runs on this PR and passes (clean diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)