### PR TITLE
Declare `packaging` as install requirement (fixes #2022)

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -5,6 +5,7 @@ grpcio==1.75.1
 grpcio-tools==1.75.1
 grpcio-health-checking==1.75.1
 pydantic==2.12.0
+packaging==26.2
 
 build
 twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     pydantic>=2.12.0,<3.0.0
     grpcio>=1.59.5,<1.80.0
     protobuf>=4.21.6,<7.0.0
+    packaging>=21.0
 python_requires = >=3.10
 
 [options.extras_require]


### PR DESCRIPTION
Adds `packaging>=21.0` to `install_requires` in `setup.cfg`.

## Why

`weaviate-client` imports `from packaging import version` at module load in two places:
- `weaviate/exceptions.py:9`
- `weaviate/proto/v1/__init__.py:12`

Until v4.20.4 the dependency was satisfied transitively through `deprecation`, which was removed in v4.20.5 (#1999, _"remove unmaintained `deprecation` package, use stdlib instead"_). On environments that don't get `packaging` from somewhere else — slim Python container images are the canonical case — the first `import weaviate` now fails with `ModuleNotFoundError: No module named 'packaging'`. Reproducible on every release from 4.20.5 onwards.

## Reproduction (no longer fails after this PR)

```Dockerfile
FROM python:3.12-slim
RUN pip install --no-cache-dir weaviate-client==4.21.0
RUN python -c "import weaviate"
```

## Version pin

`>=21.0` is conservative — `packaging.version.Version` has been stable since v17.0. Happy to widen or tighten if you have a preferred lower bound.

## Notes

- No code change beyond the dependency declaration; existing imports are unchanged.
- Closes #2022.
- This is my first PR to this repo. Will sign the CLA when prompted.