### PR TITLE
Ignore irrelevant authlib warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     validators>=0.34.0,<1.0.0
     authlib>=1.6.7,<2.0.0
     # When bumping authlib to >=2.0.0, remove the `authlib.jose` deprecation
-    # warning filter at the top of `weaviate/__init__.py`.
+    # warning filter implemented in `weaviate/_authlib_compat.py`.
     pydantic>=2.12.0,<3.0.0
     grpcio>=1.59.5,<1.80.0
     protobuf>=4.21.6,<7.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ install_requires =
     httpx>=0.26.0,<0.29.0
     validators>=0.34.0,<1.0.0
     authlib>=1.6.7,<2.0.0
+    # When bumping authlib to >=2.0.0, remove the `authlib.jose` deprecation
+    # warning filter at the top of `weaviate/__init__.py`.
     pydantic>=2.12.0,<3.0.0
     grpcio>=1.59.5,<1.80.0
     protobuf>=4.21.6,<7.0.0

--- a/weaviate/__init__.py
+++ b/weaviate/__init__.py
@@ -5,6 +5,8 @@ import sys
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
+from . import _authlib_compat  # noqa: F401  # side-effect: silence authlib.jose deprecation
+
 try:
     __version__ = version("weaviate-client")
 except PackageNotFoundError:

--- a/weaviate/_authlib_compat.py
+++ b/weaviate/_authlib_compat.py
@@ -11,4 +11,8 @@ import warnings
 
 from authlib.deprecate import AuthlibDeprecationWarning
 
-warnings.filterwarnings("ignore", category=AuthlibDeprecationWarning)
+warnings.filterwarnings(
+    "ignore",
+    message=r"^authlib\.jose module is deprecated",
+    category=AuthlibDeprecationWarning,
+)

--- a/weaviate/_authlib_compat.py
+++ b/weaviate/_authlib_compat.py
@@ -1,0 +1,14 @@
+"""Suppress the ``authlib.jose`` deprecation warning emitted by authlib >=1.7.0.
+
+authlib registers ``simplefilter("always", AuthlibDeprecationWarning)`` at import time,
+so we must import the category first to insert our filter in front of it.
+
+Remove this module (and its import in ``weaviate/__init__.py``) once the ``authlib``
+pin in ``setup.cfg`` moves to ``>=2.0.0``.
+"""
+
+import warnings
+
+from authlib.deprecate import AuthlibDeprecationWarning
+
+warnings.filterwarnings("ignore", category=AuthlibDeprecationWarning)


### PR DESCRIPTION
Fixes https://github.com/weaviate/weaviate-python-client/issues/2020

Reason is https://github.com/authlib/authlib/issues/880 not a mistake on our side