### PR TITLE
docs: fix grammar and copy-paste typos in aggregate/filter docstrings

### DIFF
--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -67,7 +67,7 @@ GCP_STREAM_TIMEOUT = (
 
 
 class BatchRequest(ABC, Generic[TBatchInput, TBatchReturn]):
-    """`BatchRequest` abstract class used as a interface for batch requests."""
+    """`BatchRequest` abstract class used as an interface for batch requests."""
 
     def __init__(self) -> None:
         self._items: List[TBatchInput] = []

--- a/weaviate/gql/aggregate.py
+++ b/weaviate/gql/aggregate.py
@@ -307,7 +307,7 @@ class AggregateBuilder(GraphQL):
         Args:
             content: The content of the `nearVideo` filter to set. See examples below.
             encode: Whether to encode the `content["video"]` to base64 and convert to string. If True, the
-                `content["video"]` can be an video path or a file opened in binary read mode. If False,
+                `content["video"]` can be a video path or a file opened in binary read mode. If False,
                 the `content["video"]` MUST be a base64 encoded string (NOT bytes, i.e. NOT binary
                 string that looks like this: b'BASE64ENCODED' but simple 'BASE64ENCODED').
                 By default True.
@@ -337,7 +337,7 @@ class AggregateBuilder(GraphQL):
         Args:
             content: The content of the `nearDepth` filter to set. See examples below.
             encode: Whether to encode the `content["depth"]` to base64 and convert to string. If True, the
-                `content["depth"]` can be an depth path or a file opened in binary read mode. If False,
+                `content["depth"]` can be a depth path or a file opened in binary read mode. If False,
                 the `content["depth"]` MUST be a base64 encoded string (NOT bytes, i.e. NOT binary
                 string that looks like this: b'BASE64ENCODED' but simple 'BASE64ENCODED').
                 By default True.
@@ -367,7 +367,7 @@ class AggregateBuilder(GraphQL):
         Args:
             content: The content of the `nearThermal` filter to set. See examples below.
             encode: Whether to encode the `content["thermal"]` to base64 and convert to string. If True, the
-                `content["thermal"]` can be an thermal path or a file opened in binary read mode. If False,
+                `content["thermal"]` can be a thermal path or a file opened in binary read mode. If False,
                 the `content["thermal"]` MUST be a base64 encoded string (NOT bytes, i.e. NOT binary
                 string that looks like this: b'BASE64ENCODED' but simple 'BASE64ENCODED').
                 By default True.
@@ -396,9 +396,9 @@ class AggregateBuilder(GraphQL):
 
         Args:
             content: The content of the `nearIMU` filter to set. See examples below.
-            encode: Whether to encode the `content["thermal"]` to base64 and convert to string. If True, the
-                `content["thermal"]` can be an thermal path or a file opened in binary read mode. If False,
-                the `content["thermal"]` MUST be a base64 encoded string (NOT bytes, i.e. NOT binary
+            encode: Whether to encode the `content["imu"]` to base64 and convert to string. If True, the
+                `content["imu"]` can be an IMU path or a file opened in binary read mode. If False,
+                the `content["imu"]` MUST be a base64 encoded string (NOT bytes, i.e. NOT binary
                 string that looks like this: b'BASE64ENCODED' but simple 'BASE64ENCODED').
                 By default True.
 

--- a/weaviate/gql/filter.py
+++ b/weaviate/gql/filter.py
@@ -520,7 +520,7 @@ class Sort(Filter):
             TypeError: If 'content' is not of type dict.
             ValueError: If a mandatory key is missing in the filter content.
         """
-        # content is a empty list because it is going to the the list with sort clauses.
+        # content is an empty list because it is going to be the list with sort clauses.
 
         super().__init__(content={"sort": []})
 


### PR DESCRIPTION
## Summary

Fixes ungrammatical articles and one copy-paste bug in user-facing docstrings under `weaviate/gql/` and `weaviate/collections/batch/`.

## Why

The `with_near_imu()` docstring is the actual blocker — it was copy-pasted from `with_near_thermal()` and never adjusted. Today, a user who tab-completes or hovers `with_near_imu` is told to set `content[\"thermal\"]`, which is the wrong dict key for IMU media. They have to read the source to find the correct `content[\"imu\"]`.

The other changes (\"an video\", \"an depth\", \"an thermal\", \"a interface\", \"a empty\", \"the the list\") are pure grammar/duplicated-word fixes that show up in IDE tool-tips and the published docstrings.

## Changes

### `weaviate/gql/aggregate.py`
- `with_near_video`: \"an video path\" -> \"a video path\"
- `with_near_depth`: \"an depth path\" -> \"a depth path\"
- `with_near_thermal`: \"an thermal path\" -> \"a thermal path\"
- `with_near_imu`: docstring referenced `content[\"thermal\"]` everywhere instead of `content[\"imu\"]`, and said \"an thermal path\" instead of \"an IMU path\". This is the only non-cosmetic fix.

### `weaviate/gql/filter.py`
- `Sort.__init__` comment: \"content is a empty list because it is going to the the list with sort clauses\" -> \"an empty list ... going to be the list ...\"

### `weaviate/collections/batch/base.py`
- `BatchRequest` class docstring: \"a interface\" -> \"an interface\"

## How to test

- `python -c \"from weaviate.gql.aggregate import AggregateBuilder; help(AggregateBuilder.with_near_imu)\"` and confirm the docstring now references `content[\"imu\"]` and \"an IMU path\".
- No runtime behavior changes — diff is docstring/comment-only.