### PR TITLE
fix: reject ragged multi-vector embeddings

### DIFF
--- a/test/collection/test_byteops.py
+++ b/test/collection/test_byteops.py
@@ -1,4 +1,9 @@
-from weaviate.collections.grpc.shared import _ByteOps
+import pytest
+
+from weaviate.collections.grpc.query import _QueryGRPC
+from weaviate.collections.grpc.shared import _ByteOps, _Pack, _Unpack
+from weaviate.exceptions import WeaviateInvalidInputError
+from weaviate.util import _ServerVersion
 
 
 def test_decode_float32s():
@@ -22,3 +27,29 @@ def test_decode_int64s():
     assert _ByteOps.decode_int64s(
         b"\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00"
     ) == [1, 2]
+
+
+def test_multi_vector_pack_round_trip():
+    vector = [[1.0, 2.0], [3.0, 4.0]]
+
+    assert _Unpack.multi(_Pack.multi(vector)) == vector
+
+
+def test_multi_vector_pack_rejects_ragged_vectors():
+    with pytest.raises(WeaviateInvalidInputError, match="consistent dimensions"):
+        _Pack.multi([[1.0, 2.0], [3.0]])
+
+
+def test_near_vector_request_rejects_ragged_multi_vector():
+    query = _QueryGRPC(
+        _ServerVersion.from_string("1.29.0"),
+        "TestCollection",
+        None,
+        None,
+        True,
+        True,
+        True,
+    )
+
+    with pytest.raises(WeaviateInvalidInputError, match="consistent dimensions"):
+        query.near_vector(near_vector=[[1.0, 2.0], [3.0]])

--- a/weaviate/collections/grpc/shared.py
+++ b/weaviate/collections/grpc/shared.py
@@ -802,8 +802,27 @@ class _Pack:
 
     @staticmethod
     def multi(vector: TwoDimensionalVectorType) -> bytes:
-        vector_list = [item for sublist in vector for item in sublist]
-        return struct.pack("<H", len(vector[0])) + struct.pack(
+        if len(vector) == 0:
+            raise WeaviateInvalidInputError("Multi-vector embeddings must not be empty.")
+
+        first_vector = _get_vector_v4(vector[0])
+        dimension = len(first_vector)
+        if dimension == 0:
+            raise WeaviateInvalidInputError(
+                "Multi-vector embeddings must not contain empty vectors."
+            )
+
+        vector_list: List[float] = []
+        for subvector in vector:
+            subvector_list = _get_vector_v4(subvector)
+            if len(subvector_list) != dimension:
+                raise WeaviateInvalidInputError(
+                    "Multi-vector embeddings must have consistent dimensions. "
+                    f"Expected dimension {dimension}, got {len(subvector_list)}."
+                )
+            vector_list.extend(subvector_list)
+
+        return struct.pack("<H", dimension) + struct.pack(
             "{}f".format(len(vector_list)), *vector_list
         )
 


### PR DESCRIPTION
## Summary
- validate multi-vector embeddings before gRPC byte packing
- reject empty/ragged multi-vectors with `WeaviateInvalidInputError` instead of silently producing malformed bytes
- add byte packing and query construction regression coverage

## Validation
- `.venv/bin/pytest test/collection/test_byteops.py -q`
- `.venv/bin/pytest test/test_get_vector_v4.py test/collection/test_queries.py -q`
- `.venv/bin/ruff format --check weaviate/collections/grpc/shared.py test/collection/test_byteops.py`
- `.venv/bin/flake8 weaviate/collections/grpc/shared.py test/collection/test_byteops.py`
- `git diff --check`