### PR TITLE
[codex] fix batch reference serialization mutation

### DIFF
--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -3,8 +3,9 @@ import uuid
 import pytest
 
 from weaviate.collections.batch.grpc_batch import _validate_props
-from weaviate.collections.classes.batch import MAX_STORED_RESULTS, BatchObjectReturn
+from weaviate.collections.classes.batch import MAX_STORED_RESULTS, BatchObjectReturn, BatchReference
 from weaviate.exceptions import WeaviateInsertInvalidPropertyError
+from weaviate.types import BEACON
 
 
 def test_batch_object_return_add() -> None:
@@ -53,3 +54,30 @@ def test_validate_props_raises_for_top_level_vector() -> None:
 def test_validate_props_raises_for_nested_vector() -> None:
     with pytest.raises(WeaviateInsertInvalidPropertyError):
         _validate_props({"vector": [0.1, 0.2]}, nested=True)
+
+
+@pytest.mark.parametrize(
+    ("to_object_collection", "expected_to"),
+    [
+        (None, f"{BEACON}28f3f61b-b524-45e0-9bbe-2c1550bf73d2"),
+        ("Target", f"{BEACON}Target/28f3f61b-b524-45e0-9bbe-2c1550bf73d2"),
+    ],
+)
+def test_batch_reference_to_internal_is_idempotent(
+    to_object_collection: str | None, expected_to: str
+) -> None:
+    ref = BatchReference(
+        from_object_collection="Source",
+        from_object_uuid="1c9cd584-88fe-5010-83d0-017cb3fcb446",
+        from_property_name="link",
+        to_object_collection=to_object_collection,
+        to_object_uuid="28f3f61b-b524-45e0-9bbe-2c1550bf73d2",
+        index=0,
+    )
+
+    first = ref._to_internal()
+    second = ref._to_internal()
+
+    assert ref.to_object_collection == to_object_collection
+    assert first.to == expected_to
+    assert second.to == expected_to

--- a/weaviate/collections/classes/batch.py
+++ b/weaviate/collections/classes/batch.py
@@ -138,14 +138,13 @@ class BatchReference(BaseModel):
         return get_valid_uuid(v)
 
     def _to_internal(self) -> _BatchReference:
-        if self.to_object_collection is None:
-            self.to_object_collection = ""
-        else:
-            self.to_object_collection = self.to_object_collection + "/"
+        to_object_collection = (
+            "" if self.to_object_collection is None else f"{self.to_object_collection}/"
+        )
         return _BatchReference(
             from_uuid=str(self.from_object_uuid),
             from_=f"{BEACON}{self.from_object_collection}/{self.from_object_uuid}/{self.from_property_name}",
-            to=f"{BEACON}{self.to_object_collection}{str(self.to_object_uuid)}",
+            to=f"{BEACON}{to_object_collection}{str(self.to_object_uuid)}",
             to_uuid=str(self.to_object_uuid),
             tenant=self.tenant,
             index=self.index,


### PR DESCRIPTION
## Summary
- avoid mutating `BatchReference.to_object_collection` while converting references to the internal REST payload
- add coverage that repeated `_to_internal()` calls preserve the model and produce stable beacons for single-target and multi-target references

## Why
`BatchReference._to_internal()` appended `/` directly to `to_object_collection`. Reusing or reserializing the same reference could therefore change `Target` to `Target/` and then emit malformed beacons such as `Target//<uuid>`.

## Validation
- `.venv312/bin/python -m pytest test/collection/test_batch.py -q`
- `.venv312/bin/ruff format --check weaviate/collections/classes/batch.py test/collection/test_batch.py`
- `.venv312/bin/ruff check weaviate/collections/classes/batch.py test/collection/test_batch.py`