### PR TITLE
Add text2vec-digitalocean vectorizer module

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -330,6 +330,20 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
         },
     ),
     (
+        Configure.Vectorizer.text2vec_digitalocean(
+            vectorize_collection_name=False,
+            model="qwen3-embedding-0.6b",
+            base_url="https://inference.do-ai.run",
+        ),
+        {
+            "text2vec-digitalocean": {
+                "vectorizeClassName": False,
+                "model": "qwen3-embedding-0.6b",
+                "baseURL": "https://inference.do-ai.run/",
+            }
+        },
+    ),
+    (
         Configure.Vectorizer.text2vec_palm(
             project_id="project",
         ),
@@ -1772,6 +1786,20 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         },
     ),
     (
+        [Configure.NamedVectors.text2vec_digitalocean(name="test", source_properties=["prop"])],
+        {
+            "test": {
+                "vectorizer": {
+                    "text2vec-digitalocean": {
+                        "vectorizeClassName": True,
+                        "properties": ["prop"],
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
         [
             Configure.NamedVectors.text2vec_palm(
                 name="test",
@@ -2365,6 +2393,20 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
             "test": {
                 "vectorizer": {
                     "text2vec-mistral": {
+                        "vectorizeClassName": True,
+                        "properties": ["prop"],
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
+        [Configure.Vectors.text2vec_digitalocean(name="test", source_properties=["prop"])],
+        {
+            "test": {
+                "vectorizer": {
+                    "text2vec-digitalocean": {
                         "vectorizeClassName": True,
                         "properties": ["prop"],
                     }

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -330,20 +330,6 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
         },
     ),
     (
-        Configure.Vectorizer.text2vec_digitalocean(
-            vectorize_collection_name=False,
-            model="qwen3-embedding-0.6b",
-            base_url="https://inference.do-ai.run",
-        ),
-        {
-            "text2vec-digitalocean": {
-                "vectorizeClassName": False,
-                "model": "qwen3-embedding-0.6b",
-                "baseURL": "https://inference.do-ai.run/",
-            }
-        },
-    ),
-    (
         Configure.Vectorizer.text2vec_palm(
             project_id="project",
         ),
@@ -1786,20 +1772,6 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         },
     ),
     (
-        [Configure.NamedVectors.text2vec_digitalocean(name="test", source_properties=["prop"])],
-        {
-            "test": {
-                "vectorizer": {
-                    "text2vec-digitalocean": {
-                        "vectorizeClassName": True,
-                        "properties": ["prop"],
-                    }
-                },
-                "vectorIndexType": "hnsw",
-            }
-        },
-    ),
-    (
         [
             Configure.NamedVectors.text2vec_palm(
                 name="test",
@@ -2402,13 +2374,18 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
         },
     ),
     (
-        [Configure.Vectors.text2vec_digitalocean(name="test", source_properties=["prop"])],
+        [
+            Configure.Vectors.text2vec_digitalocean(
+                name="test", source_properties=["prop"], model="qwen2"
+            )
+        ],
         {
             "test": {
                 "vectorizer": {
                     "text2vec-digitalocean": {
                         "vectorizeClassName": True,
                         "properties": ["prop"],
+                        "model": "qwen2",
                     }
                 },
                 "vectorIndexType": "hnsw",

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -48,7 +48,6 @@ from weaviate.collections.classes.config_vectorizers import (
     _Text2VecCohereConfig,
     _Text2VecContextionaryConfig,
     _Text2VecDatabricksConfig,
-    _Text2VecDigitalOceanConfig,
     _Text2VecGoogleConfig,
     _Text2VecGPT4AllConfig,
     _Text2VecHuggingFaceConfig,
@@ -352,40 +351,6 @@ class _NamedVectors:
             name=name,
             source_properties=source_properties,
             vectorizer=_Text2VecMistralConfig(
-                baseURL=base_url,
-                model=model,
-                vectorizeClassName=vectorize_collection_name,
-            ),
-            vector_index_config=vector_index_config,
-        )
-
-    @staticmethod
-    def text2vec_digitalocean(
-        name: str,
-        *,
-        base_url: Optional[AnyHttpUrl] = None,
-        model: Optional[str] = None,
-        source_properties: Optional[List[str]] = None,
-        vector_index_config: Optional[_VectorIndexConfigCreate] = None,
-        vectorize_collection_name: bool = True,
-    ) -> _NamedVectorConfigCreate:
-        """Create a named vector using the `text2vec-digitalocean` model.
-
-        See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings)
-        for detailed usage.
-
-        Args:
-            name: The name of the named vector.
-            base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default of `https://inference.do-ai.run`.
-            model: The model to use, e.g. `qwen3-embedding-0.6b`. This is a required field on the server.
-            source_properties: Which properties should be included when vectorizing. By default all text properties are included.
-            vector_index_config: The configuration for Weaviate's vector index. Use wvc.config.Configure.VectorIndex to create a vector index configuration. None by default
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
-        """
-        return _NamedVectorConfigCreate(
-            name=name,
-            source_properties=source_properties,
-            vectorizer=_Text2VecDigitalOceanConfig(
                 baseURL=base_url,
                 model=model,
                 vectorizeClassName=vectorize_collection_name,

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -48,6 +48,7 @@ from weaviate.collections.classes.config_vectorizers import (
     _Text2VecCohereConfig,
     _Text2VecContextionaryConfig,
     _Text2VecDatabricksConfig,
+    _Text2VecDigitalOceanConfig,
     _Text2VecGoogleConfig,
     _Text2VecGPT4AllConfig,
     _Text2VecHuggingFaceConfig,
@@ -351,6 +352,40 @@ class _NamedVectors:
             name=name,
             source_properties=source_properties,
             vectorizer=_Text2VecMistralConfig(
+                baseURL=base_url,
+                model=model,
+                vectorizeClassName=vectorize_collection_name,
+            ),
+            vector_index_config=vector_index_config,
+        )
+
+    @staticmethod
+    def text2vec_digitalocean(
+        name: str,
+        *,
+        base_url: Optional[AnyHttpUrl] = None,
+        model: Optional[str] = None,
+        source_properties: Optional[List[str]] = None,
+        vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+        vectorize_collection_name: bool = True,
+    ) -> _NamedVectorConfigCreate:
+        """Create a named vector using the `text2vec-digitalocean` model.
+
+        See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings)
+        for detailed usage.
+
+        Args:
+            name: The name of the named vector.
+            base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default of `https://inference.do-ai.run`.
+            model: The model to use, e.g. `qwen3-embedding-0.6b`. This is a required field on the server.
+            source_properties: Which properties should be included when vectorizing. By default all text properties are included.
+            vector_index_config: The configuration for Weaviate's vector index. Use wvc.config.Configure.VectorIndex to create a vector index configuration. None by default
+            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+        """
+        return _NamedVectorConfigCreate(
+            name=name,
+            source_properties=source_properties,
+            vectorizer=_Text2VecDigitalOceanConfig(
                 baseURL=base_url,
                 model=model,
                 vectorizeClassName=vectorize_collection_name,

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -291,7 +291,7 @@ class _Text2VecDigitalOceanConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_DIGITALOCEAN, frozen=True, exclude=True
     )
-    model: Optional[str]
+    model: str
     vectorizeClassName: bool
     baseURL: Optional[AnyHttpUrl]
 
@@ -1097,27 +1097,6 @@ class _Vectorizer:
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
         """
         return _Text2VecMistralConfig(
-            baseURL=base_url, model=model, vectorizeClassName=vectorize_collection_name
-        )
-
-    @staticmethod
-    def text2vec_digitalocean(
-        *,
-        base_url: Optional[AnyHttpUrl] = None,
-        model: Optional[str] = None,
-        vectorize_collection_name: bool = True,
-    ) -> _VectorizerConfigCreate:
-        """Create a `_Text2VecDigitalOceanConfig` object for use when vectorizing using the `text2vec-digitalocean` model.
-
-        See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings)
-        for detailed usage.
-
-        Args:
-            base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default of `https://inference.do-ai.run`.
-            model: The model to use, e.g. `qwen3-embedding-0.6b`. This is a required field on the server.
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
-        """
-        return _Text2VecDigitalOceanConfig(
             baseURL=base_url, model=model, vectorizeClassName=vectorize_collection_name
         )
 

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -119,6 +119,7 @@ class Vectorizers(str, Enum):
     TEXT2VEC_COHERE = "text2vec-cohere"
     TEXT2VEC_CONTEXTIONARY = "text2vec-contextionary"
     TEXT2VEC_DATABRICKS = "text2vec-databricks"
+    TEXT2VEC_DIGITALOCEAN = "text2vec-digitalocean"
     TEXT2VEC_GPT4ALL = "text2vec-gpt4all"
     TEXT2VEC_HUGGINGFACE = "text2vec-huggingface"
     TEXT2VEC_MISTRAL = "text2vec-mistral"
@@ -274,6 +275,21 @@ class _Text2VecHuggingFaceConfig(_VectorizerConfigCreate):
 class _Text2VecMistralConfig(_VectorizerConfigCreate):
     vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
         default=Vectorizers.TEXT2VEC_MISTRAL, frozen=True, exclude=True
+    )
+    model: Optional[str]
+    vectorizeClassName: bool
+    baseURL: Optional[AnyHttpUrl]
+
+    def _to_dict(self) -> Dict[str, Any]:
+        ret_dict = super()._to_dict()
+        if self.baseURL is not None:
+            ret_dict["baseURL"] = self.baseURL.unicode_string()
+        return ret_dict
+
+
+class _Text2VecDigitalOceanConfig(_VectorizerConfigCreate):
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.TEXT2VEC_DIGITALOCEAN, frozen=True, exclude=True
     )
     model: Optional[str]
     vectorizeClassName: bool
@@ -1081,6 +1097,27 @@ class _Vectorizer:
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
         """
         return _Text2VecMistralConfig(
+            baseURL=base_url, model=model, vectorizeClassName=vectorize_collection_name
+        )
+
+    @staticmethod
+    def text2vec_digitalocean(
+        *,
+        base_url: Optional[AnyHttpUrl] = None,
+        model: Optional[str] = None,
+        vectorize_collection_name: bool = True,
+    ) -> _VectorizerConfigCreate:
+        """Create a `_Text2VecDigitalOceanConfig` object for use when vectorizing using the `text2vec-digitalocean` model.
+
+        See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings)
+        for detailed usage.
+
+        Args:
+            base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default of `https://inference.do-ai.run`.
+            model: The model to use, e.g. `qwen3-embedding-0.6b`. This is a required field on the server.
+            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+        """
+        return _Text2VecDigitalOceanConfig(
             baseURL=base_url, model=model, vectorizeClassName=vectorize_collection_name
         )
 

--- a/weaviate/collections/classes/config_vectors.py
+++ b/weaviate/collections/classes/config_vectors.py
@@ -627,7 +627,7 @@ class _Vectors:
         name: Optional[str] = None,
         quantizer: Optional[_QuantizerConfigCreate] = None,
         base_url: Optional[AnyHttpUrl] = None,
-        model: Optional[str] = None,
+        model: str,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,

--- a/weaviate/collections/classes/config_vectors.py
+++ b/weaviate/collections/classes/config_vectors.py
@@ -59,6 +59,7 @@ from weaviate.collections.classes.config_vectorizers import (
     _Text2VecCohereConfig,
     _Text2VecContextionaryConfig,
     _Text2VecDatabricksConfig,
+    _Text2VecDigitalOceanConfig,
     _Text2VecGoogleConfig,
     _Text2VecGPT4AllConfig,
     _Text2VecHuggingFaceConfig,
@@ -613,6 +614,42 @@ class _Vectors:
             name=name,
             source_properties=source_properties,
             vectorizer=_Text2VecMistralConfig(
+                baseURL=base_url,
+                model=model,
+                vectorizeClassName=vectorize_collection_name,
+            ),
+            vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
+        )
+
+    @staticmethod
+    def text2vec_digitalocean(
+        *,
+        name: Optional[str] = None,
+        quantizer: Optional[_QuantizerConfigCreate] = None,
+        base_url: Optional[AnyHttpUrl] = None,
+        model: Optional[str] = None,
+        source_properties: Optional[List[str]] = None,
+        vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+        vectorize_collection_name: bool = True,
+    ) -> _VectorConfigCreate:
+        """Create a vector using the `text2vec-digitalocean` module.
+
+        See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings)
+        for detailed usage.
+
+        Args:
+            name: The name of the vector.
+            quantizer: The quantizer to use for the vector index. If not provided, no quantization will be applied.
+            base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default of `https://inference.do-ai.run`.
+            model: The model to use, e.g. `qwen3-embedding-0.6b`. This is a required field on the server.
+            source_properties: Which properties should be included when vectorizing. By default all text properties are included.
+            vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default
+            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+        """
+        return _VectorConfigCreate(
+            name=name,
+            source_properties=source_properties,
+            vectorizer=_Text2VecDigitalOceanConfig(
                 baseURL=base_url,
                 model=model,
                 vectorizeClassName=vectorize_collection_name,


### PR DESCRIPTION
## Summary

Adds support for the new `text2vec-digitalocean` vectorizer module exposed by Weaviate server. The shape mirrors `text2vec-mistral` (`model` + `baseURL` + `vectorizeClassName`), so the existing serialization path and Pydantic URL normalization are reused unchanged.

Following review, only the supported `Configure.Vectors` API surface is extended (matching the precedent set by `text2vec-morph` and other recent additions). `Configure.Vectorizer` and `Configure.NamedVectors` are not touched — they're the deprecated paths.

## API surface added

- `Vectorizers.TEXT2VEC_DIGITALOCEAN` enum entry
- `_Text2VecDigitalOceanConfig` Pydantic config class
- `Configure.Vectors.text2vec_digitalocean(name=..., model=..., ...)` — the only factory entry point

## Parameters

| Python (snake_case) | Wire (camelCase) | Required | Default |
|---|---|---|---|
| `model` | `model` | **yes** (server requires it; client enforces too) | none |
| `base_url` | `baseURL` | no | server default `https://inference.do-ai.run` |
| `vectorize_collection_name` | `vectorizeClassName` | no | `True` |

## Test plan

- [x] Unit test added to `test/collection/test_config.py` (in `TEST_CONFIG_WITH_VECTORS_PARAMETERS`) asserting wire-format serialization, including the trailing-slash URL normalization Pydantic `AnyHttpUrl` applies
- [x] `pytest test/collection/test_config.py` — 185 pass
- [x] `ruff check` + `ruff format --check` clean on all 4 changed files
- [x] Runtime smoke-test via REPL: factory produces the expected wire payload; calling without `model=` raises `TypeError` from Pydantic

## Review-feedback changes

Second commit (`22aa8fce`) addresses @dirkkul's review:
- Make `model` required on the Pydantic class and on the factory parameter
- Remove the `Configure.Vectorizer.text2vec_digitalocean` factory (deprecated API surface; not extended for new modules)
- Remove the `Configure.NamedVectors.text2vec_digitalocean` factory (same reason)
- Drop the now-orphan `_Text2VecDigitalOceanConfig` import from `config_named_vectors.py`
- Remove the two corresponding test cases; update the `Vectors` test to pass the required `model`

Closes #2038

Sibling PRs (same feature, fanned out across SDKs):
- TypeScript: weaviate/typescript-client#430
- Java: weaviate/java-client#569
- Go: weaviate/weaviate-go-client#401
- C#: weaviate/csharp-client#339

🤖 Generated with [Claude Code](https://claude.com/claude-code)