### PR TITLE
test: adapt integration tests to Weaviate 1.37.5

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,7 @@ env:
   WEAVIATE_134: 1.34.19
   WEAVIATE_135: 1.35.18
   WEAVIATE_136: 1.36.12
-  WEAVIATE_137: 1.37.1-4e61e26.amd64
+  WEAVIATE_137: 1.37.5
 
 jobs:
   lint-and-format:

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -1026,7 +1026,7 @@ def test_config_export_and_recreate_from_dict(collection_factory: CollectionFact
             Property(name="geo", data_type=DataType.GEO_COORDINATES),
             Property(name="phone", data_type=DataType.PHONE_NUMBER),
             Property(
-                name="field_index_searchable", data_type=DataType.TEXT, index_searchable=False
+                name="field_searchable_index", data_type=DataType.TEXT, index_searchable=False
             ),
             Property(
                 name="field_index_range_filters_false",
@@ -1054,7 +1054,9 @@ def test_config_export_and_recreate_from_dict(collection_factory: CollectionFact
                         tokenization=Tokenization.FIELD,
                     ),
                     Property(
-                        name="nested_searchable", data_type=DataType.TEXT, index_searchable=False
+                        name="nested_searchable_index",
+                        data_type=DataType.TEXT,
+                        index_searchable=False,
                     ),
                     Property(
                         name="nested_filterable", data_type=DataType.TEXT, index_filterable=False
@@ -1598,7 +1600,6 @@ def test_replication_config_with_async_config(collection_factory: CollectionFact
             factor=1,
             async_enabled=True,
             async_config=Configure.Replication.async_config(
-                max_workers=8,
                 hashtree_height=20,
             ),
         ),
@@ -1608,7 +1609,6 @@ def test_replication_config_with_async_config(collection_factory: CollectionFact
     assert config.replication_config.async_enabled is True
     assert config.replication_config.async_config is not None
     ac = config.replication_config.async_config
-    assert ac.max_workers == 8
     assert ac.hashtree_height == 20
 
 
@@ -1624,14 +1624,13 @@ def test_replication_config_remove_async_config_by_disabling_async_replication(
             factor=1,
             async_enabled=True,
             async_config=Configure.Replication.async_config(
-                max_workers=8,
                 hashtree_height=20,
             ),
         ),
     )
     config = collection.config.get()
     assert config.replication_config.async_config is not None
-    assert config.replication_config.async_config.max_workers == 8
+    assert config.replication_config.async_config.hashtree_height == 20
 
     collection.config.update(
         replication_config=Reconfigure.replication(
@@ -1653,14 +1652,13 @@ def test_replication_config_remove_async_config(collection_factory: CollectionFa
             factor=1,
             async_enabled=True,
             async_config=Configure.Replication.async_config(
-                max_workers=8,
                 hashtree_height=20,
             ),
         ),
     )
     config = collection.config.get()
     assert config.replication_config.async_config is not None
-    assert config.replication_config.async_config.max_workers == 8
+    assert config.replication_config.async_config.hashtree_height == 20
 
     collection.config.update(
         replication_config=Reconfigure.replication(
@@ -1677,38 +1675,41 @@ def test_replication_config_unset_single_async_field(
     collection_factory: CollectionFactory,
 ) -> None:
     collection_dummy = collection_factory("dummy")
-    if collection_dummy._connection._weaviate_version.is_lower_than(1, 36, 0):
-        pytest.skip("async replication config requires Weaviate >= 1.36.0")
+    if collection_dummy._connection._weaviate_version.is_lower_than(1, 37, 3):
+        pytest.skip(
+            "per-field async replication config (after max_workers removal) requires Weaviate >= 1.37.3"
+        )
 
     collection = collection_factory(
         replication_config=Configure.replication(
             factor=1,
             async_enabled=True,
             async_config=Configure.Replication.async_config(
-                max_workers=8,
-                hashtree_height=20,
+                hashtree_height=16,
+                propagation_concurrency=4,
             ),
         ),
     )
     config = collection.config.get()
     ac = config.replication_config.async_config
     assert ac is not None
-    assert ac.max_workers == 8
-    assert ac.hashtree_height == 20
+    assert ac.hashtree_height == 16
+    assert ac.propagation_concurrency == 4
 
-    # Update with only max_workers — hashtree_height reverts to server default
+    # Update with only propagation_concurrency — the async config is replaced, so the
+    # unspecified hashtree_height reverts to the server default.
     collection.config.update(
         replication_config=Reconfigure.replication(
             async_config=Reconfigure.Replication.async_config(
-                max_workers=8,
+                propagation_concurrency=7,
             ),
         ),
     )
     config = collection.config.get()
     ac = config.replication_config.async_config
     assert ac is not None
-    assert ac.max_workers == 8
-    assert ac.hashtree_height != 20
+    assert ac.propagation_concurrency == 7
+    assert ac.hashtree_height != 16
 
 
 def test_replication_config_add_async_config_to_existing_collection(
@@ -1734,16 +1735,14 @@ def test_replication_config_add_async_config_to_existing_collection(
     collection.config.update(
         replication_config=Reconfigure.replication(
             async_config=Reconfigure.Replication.async_config(
-                max_workers=8,
-                propagation_concurrency=4,
+                hashtree_height=20,
             ),
         ),
     )
     config = collection.config.get()
     assert config.replication_config.async_config is not None
     ac = config.replication_config.async_config
-    assert ac.max_workers == 8
-    assert ac.propagation_concurrency == 4
+    assert ac.hashtree_height == 20
 
 
 def test_update_property_descriptions(collection_factory: CollectionFactory) -> None:


### PR DESCRIPTION
## Motivation

Weaviate `1.37.5` introduces two intentional server-side behavior changes that break existing integration tests. This PR bumps the pinned `WEAVIATE_137` version in CI from `1.37.1-4e61e26.amd64` to the released `1.37.5` and adapts the affected tests. Both failures stem from deliberate server changes (verified against the Weaviate source), not client bugs — the tests were asserting behavior the server no longer provides.

## Approach

Two unrelated server changes drive the test updates:

1. **`maxWorkers` removed from async replication config** (server commit `bb3d157004` "async replication scheduler", shipped in `v1.37.3+`). The server no longer accepts or returns this field, so `max_workers` now reads back as `None`. Rather than asserting on a field the server has dropped, the async replication tests now round-trip through `hashtree_height` (and `propagation_concurrency`), which are available on all async-capable versions. The client still exposes `max_workers` for backward compatibility with older servers — it's just silently ignored on `1.37.3+`, so no client code changed.

2. **Property name suffix `_searchable` is now reserved** for internal indices (`entities/schema/validation.go`). Properties named `field_index_searchable` / `nested_searchable` are rejected by validation, so they're renamed to `field_searchable_index` / `nested_searchable_index`. The `index_searchable=False` behavior under test is unchanged — only the property names move.

The one test with a real semantic shift is `test_replication_config_unset_single_async_field`: after the `maxWorkers` removal, a single-field partial update now *replaces* the whole async config (unspecified fields revert to server defaults). The test is re-gated to `>= 1.37.3` and rewritten with `hashtree_height` + `propagation_concurrency` to still exercise that "unspecified field reverts to default" invariant.

## Key areas for review

- `test_collection_config.py:test_replication_config_unset_single_async_field` — the only test with changed semantics (config replacement on partial update); verify the version gate and the revert-to-default assertion still capture the intended behavior
- `.github/workflows/main.yaml` — version pin moves from a pre-release build hash to released `1.37.5`
- The remaining async tests are mechanical `max_workers` → `hashtree_height` substitutions; safe to skim

## Risks and mitigations

Low risk — this is test maintenance, no production client code changes.

- **Older-server coverage**: dropping `max_workers` assertions means we no longer verify `max_workers` round-trips on servers `< 1.37.3` where it's still honored. Mitigated by the fact that the field is still exposed by the client and the substituted assertions (`hashtree_height`) cover the same async-config round-trip path across all supported versions.
- **Version gate correctness**: `test_replication_config_unset_single_async_field` is gated to `>= 1.37.3` rather than `1.37.5` because the config-replacement behavior lands with the `maxWorkers` removal; running it on `1.37.3`/`1.37.4` is intended.

## Testing

Full integration suite run against a live `1.37.5` cluster: **1162 passed, 88 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)