### PR TITLE
fix(timeout): respect insertion timeout from config for fixed_batch

### DIFF
--- a/mock_tests/conftest.py
+++ b/mock_tests/conftest.py
@@ -281,6 +281,85 @@ def metadata_capture_collection(
     return weaviate_client.collections.use("MetadataCaptureCollection"), service
 
 
+BATCH_INSERT_TIMEOUT = 5
+
+
+class MockBatchDeadlineCaptureWeaviateService(weaviate_pb2_grpc.WeaviateServicer):
+    captured_time_remaining: float = -1.0
+
+    def BatchObjects(
+        self, request: batch_pb2.BatchObjectsRequest, context: grpc.ServicerContext
+    ) -> batch_pb2.BatchObjectsReply:
+        self.captured_time_remaining = context.time_remaining()
+        return batch_pb2.BatchObjectsReply()
+
+
+@pytest.fixture(scope="function")
+def weaviate_batch_insert_timeout_client(
+    weaviate_mock: HTTPServer, start_grpc_server: grpc.Server
+) -> Generator[weaviate.WeaviateClient, None, None]:
+    weaviate_mock.expect_request(f"/v1/schema/{mock_class['class']}").respond_with_json(mock_class)
+    client = weaviate.connect_to_local(
+        host=MOCK_IP,
+        port=MOCK_PORT,
+        grpc_port=MOCK_PORT_GRPC,
+        additional_config=weaviate.classes.init.AdditionalConfig(
+            timeout=weaviate.classes.init.Timeout(insert=BATCH_INSERT_TIMEOUT)
+        ),
+    )
+    yield client
+    client.close()
+
+
+@pytest.fixture(scope="function")
+def batch_deadline_capture_collection(
+    weaviate_batch_insert_timeout_client: weaviate.WeaviateClient,
+    start_grpc_server: grpc.Server,
+) -> tuple[weaviate.collections.Collection, MockBatchDeadlineCaptureWeaviateService]:
+    service = MockBatchDeadlineCaptureWeaviateService()
+    weaviate_pb2_grpc.add_WeaviateServicer_to_server(service, start_grpc_server)
+    return (
+        weaviate_batch_insert_timeout_client.collections.use(mock_class["class"]),
+        service,
+    )
+
+
+BATCH_INSERT_TIMEOUT_SHORT = 0.5
+
+
+@pytest.fixture(scope="function")
+def weaviate_batch_insert_timeout_short_client(
+    weaviate_mock: HTTPServer, start_grpc_server: grpc.Server
+) -> Generator[weaviate.WeaviateClient, None, None]:
+    weaviate_mock.expect_request(f"/v1/schema/{mock_class['class']}").respond_with_json(mock_class)
+    client = weaviate.connect_to_local(
+        host=MOCK_IP,
+        port=MOCK_PORT,
+        grpc_port=MOCK_PORT_GRPC,
+        additional_config=weaviate.classes.init.AdditionalConfig(
+            timeout=weaviate.classes.init.Timeout(insert=BATCH_INSERT_TIMEOUT_SHORT)
+        ),
+    )
+    yield client
+    client.close()
+
+
+@pytest.fixture(scope="function")
+def batch_slow_response_collection(
+    weaviate_batch_insert_timeout_short_client: weaviate.WeaviateClient,
+    start_grpc_server: grpc.Server,
+) -> weaviate.collections.Collection:
+    class MockWeaviateService(weaviate_pb2_grpc.WeaviateServicer):
+        def BatchObjects(
+            self, request: batch_pb2.BatchObjectsRequest, context: grpc.ServicerContext
+        ) -> batch_pb2.BatchObjectsReply:
+            time.sleep(BATCH_INSERT_TIMEOUT_SHORT + 1)
+            return batch_pb2.BatchObjectsReply()
+
+    weaviate_pb2_grpc.add_WeaviateServicer_to_server(MockWeaviateService(), start_grpc_server)
+    return weaviate_batch_insert_timeout_short_client.collections.use(mock_class["class"])
+
+
 class MockRetriesWeaviateService(weaviate_pb2_grpc.WeaviateServicer):
     search_count = 0
     tenants_count = 0

--- a/mock_tests/test_timeouts.py
+++ b/mock_tests/test_timeouts.py
@@ -3,6 +3,8 @@ import pytest
 import weaviate
 from weaviate.exceptions import WeaviateQueryError, WeaviateTimeoutError
 
+from .conftest import BATCH_INSERT_TIMEOUT, MockBatchDeadlineCaptureWeaviateService
+
 
 def test_timeout_rest_query(timeouts_collection: weaviate.collections.Collection):
     with pytest.raises(WeaviateTimeoutError):
@@ -24,3 +26,24 @@ def test_timeout_grpc_insert(timeouts_collection: weaviate.collections.Collectio
     with pytest.raises(WeaviateQueryError) as recwarn:
         timeouts_collection.data.insert_many([{"what": "ever"}])
         assert "DEADLINE_EXCEEDED" in str(recwarn)
+
+
+def test_batch_fixed_size_deadline_uses_insert_timeout(
+    batch_deadline_capture_collection: tuple[
+        weaviate.collections.Collection, MockBatchDeadlineCaptureWeaviateService
+    ],
+):
+    collection, service = batch_deadline_capture_collection
+    with collection.batch.fixed_size(batch_size=1) as batch:
+        batch.add_object({"what": "ever"})
+    assert abs(service.captured_time_remaining - BATCH_INSERT_TIMEOUT) < 1
+
+
+def test_batch_fixed_size_times_out_when_insert_exceeded(
+    batch_slow_response_collection: weaviate.collections.Collection,
+):
+    with batch_slow_response_collection.batch.fixed_size(batch_size=1) as batch:
+        batch.add_object({"what": "ever"})
+    failed = batch_slow_response_collection.batch.failed_objects
+    assert len(failed) == 1
+    assert "Deadline Exceeded" in failed[0].message

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -54,7 +54,6 @@ BatchResponse = List[Dict[str, Any]]
 TBatchInput = TypeVar("TBatchInput")
 TBatchReturn = TypeVar("TBatchReturn")
 MAX_CONCURRENT_REQUESTS = 10
-DEFAULT_REQUEST_TIMEOUT = 180
 CONCURRENT_REQUESTS_DYNAMIC_VECTORIZER = 2
 BATCH_TIME_TARGET = 10
 VECTORIZER_BATCHING_STEP_SIZE = 48  # cohere max batch size is 96
@@ -612,7 +611,7 @@ class _BatchBase:
                     self.__batch_grpc.objects(
                         connection=self.__connection,
                         objects=[obj._to_internal() for obj in objs],
-                        timeout=DEFAULT_REQUEST_TIMEOUT,
+                        timeout=self.__connection.timeout_config.insert,
                         max_retries=MAX_RETRIES,
                     )
                 )


### PR DESCRIPTION
## Summary

There's a bug where the Weaviate Python client SDK doesn't respect the `config.Timeout` for batch insertions. This issue dates back a while.

`_BatchBase.__send_batch` passes a hardcoded `DEFAULT_REQUEST_TIMEOUT = 180` as the gRPC deadline for `BatchObjects` [[src](https://github.com/weaviate/weaviate-python-client/blob/main/weaviate/collections/batch/base.py#L57C1-L57C24)]:

```python
DEFAULT_REQUEST_TIMEOUT = 180

# ... 

self.__batch_grpc.objects(
    connection=self.__connection,
    objects=[obj._to_internal() for obj in objs],
    timeout=DEFAULT_REQUEST_TIMEOUT,  # <-----------------------
    max_retries=MAX_RETRIES,
)
```

This silently ignores set values in config `additional_config.timeout.insert`. Ex:

```python
weaviate.connect_to_custom(
   ...   
   additional_config=weaviate.config.AdditionalConfig(
      timeout=weaviate.config.Timeout(insert=600),  # Values in seconds <-----------------
   ),
)
```

The change in this PR makes it honor the configured `Timeout.insert` config value, matching the sibling code paths (batch deletion, `insert_many`).

## Context

`Timeout.insert` is already honored by other write paths:

- `_DataExecutor.insert_many` — `weaviate/collections/data/executor.py:216`
- `grpc_batch_delete` (sync) — `weaviate/connect/v4.py:1048`
- `grpc_batch_delete` (async) — `weaviate/connect/v4.py:1230`

`__send_batch` in `weaviate/collections/batch/base.py` was the odd one out.

## Behavior change

This PR as-is comes with an important behavioral change in the default case. The default `Timeout.insert` is 90s (`weaviate/config.py:59`). Users on the default configuration will now see a 90s gRPC insertion deadline on `BatchObjects` instead of the previous 180s. This makes the `Timeout.insert` field actually reflect the value used at the call site, at the cost of a tighter default. 

If 90s turns out to be too tight specifically for batch with server-side vectorizers, this requires further discussion by Weaviate maintainers. We could potentially raise this default to 180s to match the previous default, but this comes with additional tradeoffs to consider.