### PR TITLE
fix: refresh query version metadata

### DIFF
--- a/test/collection/test_queries.py
+++ b/test/collection/test_queries.py
@@ -2,9 +2,11 @@ from typing import Awaitable
 
 import pytest
 
+from weaviate.collections.collection import CollectionAsync
 from weaviate.collections.query import _QueryCollectionAsync
 from weaviate.connect import ConnectionV4
 from weaviate.exceptions import WeaviateInvalidInputError
+from weaviate.util import _ServerVersion
 
 # TODO: re-enable tests once string syntax is re-enabled in the API
 
@@ -130,3 +132,14 @@ async def test_bad_query_inputs(connection: ConnectionV4) -> None:
 
     # near image
     await _test_query(lambda: query.near_image(42))
+
+
+def test_async_collection_query_uses_current_connection_version(connection: ConnectionV4) -> None:
+    collection = CollectionAsync(connection, "dummy", True)
+
+    connection._weaviate_version = _ServerVersion.from_string("1.32.5")
+
+    request = collection.query._query.get()
+
+    assert request.uses_125_api
+    assert request.uses_127_api

--- a/weaviate/collections/grpc/query.py
+++ b/weaviate/collections/grpc/query.py
@@ -82,15 +82,17 @@ class _QueryGRPC(_BaseGRPC):
         tenant: Optional[str],
         consistency_level: Optional[ConsistencyLevel],
         validate_arguments: bool,
-        uses_125_api: bool,
-        uses_127_api: bool,
     ):
         super().__init__(weaviate_version, consistency_level, validate_arguments)
         self._name: str = name
         self._tenant = tenant
         self._validate_arguments = validate_arguments
-        self.__uses_125_api = uses_125_api
-        self.__uses_127_api = uses_127_api
+        self._use_weaviate_version(weaviate_version)
+
+    def _use_weaviate_version(self, weaviate_version: _ServerVersion) -> None:
+        self._weaviate_version = weaviate_version
+        self.__uses_125_api = weaviate_version.is_at_least(1, 25, 0)
+        self.__uses_127_api = weaviate_version.is_at_least(1, 27, 0)
 
     def __parse_near_options(
         self,

--- a/weaviate/collections/queries/base_executor.py
+++ b/weaviate/collections/queries/base_executor.py
@@ -86,17 +86,22 @@ class _BaseExecutor(Generic[ConnectionType]):
         self._references = references
         self._validate_arguments = validate_arguments
 
-        self.__uses_125_api = connection._weaviate_version.is_at_least(1, 25, 0)
-        self.__uses_127_api = connection._weaviate_version.is_at_least(1, 27, 0)
-        self._query = _QueryGRPC(
+        self.__query = _QueryGRPC(
             connection._weaviate_version,
             self._name,
             self.__tenant,
             self.__consistency_level,
             validate_arguments=self._validate_arguments,
-            uses_125_api=self.__uses_125_api,
-            uses_127_api=self.__uses_127_api,
         )
+
+    @property
+    def _query(self) -> _QueryGRPC:
+        self.__query._use_weaviate_version(self._connection._weaviate_version)
+        return self.__query
+
+    @property
+    def __uses_127_api(self) -> bool:
+        return self._connection._weaviate_version.is_at_least(1, 27, 0)
 
     def __retrieve_timestamp(
         self,


### PR DESCRIPTION
## Summary

- Refresh query GRPC version metadata from the live connection before building requests.
- Keep generative response parsing aligned with the current connection version instead of the collection construction-time version.
- Add a regression test for async collections created before the connection learns the server version.

Fixes #1831.

## Validation

- `.venv/bin/python -m pytest test/collection/test_queries.py -q`
- `.venv/bin/python -m pytest test/collection/test_queries.py test/test_server_version.py -q`
- `.venv/bin/ruff format --check weaviate/collections/queries/base_executor.py weaviate/collections/grpc/query.py test/collection/test_queries.py`
- `.venv/bin/ruff check weaviate/collections/queries/base_executor.py weaviate/collections/grpc/query.py test/collection/test_queries.py`
