### PR TITLE
docs: add v4.22.0 changelog entry

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 4.22.0
+--------------
+This minor version includes:
+    - Support for new 1.38 features:
+        - Add support for the new Boost API for fine-grained, query-time relevance tuning — a ``boost`` parameter is now available across the vector, keyword (``bm25``), and ``hybrid`` query and generative-query methods
+        - The ``Boost`` factory (exported from ``weaviate.classes.query`` alongside ``BoostReturn``) provides ``numeric_property``, ``filter``, ``numeric_decay``, ``time_decay``, and ``blend`` boosts, each with optional ``depth`` and ``weight`` controls
+
 Version 4.21.3
 --------------
 This patch version includes:


### PR DESCRIPTION
Changelog entry for the upcoming **v4.22.0** minor release (Weaviate 1.38 support).

The release is the new **Boost API** for query-time relevance tuning:
- A `boost` parameter across the vector, keyword (`bm25`), and `hybrid` query and generative-query methods.
- The `Boost` factory (exported from `weaviate.classes.query` alongside `BoostReturn`) with `numeric_property`, `filter`, `numeric_decay`, `time_decay`, and `blend` boosts.

Lands via PR per RELEASING.md; tag `v4.22.0` to be pushed after this merges and main CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)