### PR TITLE
feat: add optional location parameter to text2vec-google vectorizer

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -2431,6 +2431,31 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
     ),
     (
         [
+            Configure.Vectors.text2vec_google_vertex(
+                name="test",
+                project_id="project",
+                source_properties=["prop"],
+                dimensions=768,
+                location="europe-west1",
+            )
+        ],
+        {
+            "test": {
+                "vectorizer": {
+                    "text2vec-palm": {
+                        "projectId": "project",
+                        "location": "europe-west1",
+                        "properties": ["prop"],
+                        "vectorizeClassName": True,
+                        "dimensions": 768,
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
+        [
             Configure.Vectors.text2vec_google_gemini(
                 name="test",
                 source_properties=["prop"],

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -991,6 +991,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
                 vectorizeClassName=vectorize_collection_name,
                 titleProperty=title_property,
                 taskType=None,
+                location=None,
             ),
             vector_index_config=vector_index_config,
         )
@@ -1006,6 +1007,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
+        location: Optional[str] = None,
     ) -> _NamedVectorConfigCreate:
         """Create a named vector using the `text2vec_palm` model.
 
@@ -1022,6 +1024,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
             api_endpoint: The API endpoint to use without a leading scheme such as `http://`. Defaults to `None`, which uses the server-defined default
             model_id: The model ID to use. Defaults to `None`, which uses the server-defined default.
             title_property: The Weaviate property name for the `gecko-002` or `gecko-003` model to use as the title.
+            location: The Google Vertex AI region to run the model in. Defaults to `None`, which uses the server-defined default.
 
         Raises:
             pydantic.ValidationError: If `api_endpoint` is not a valid URL.
@@ -1037,6 +1040,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
                 vectorizeClassName=vectorize_collection_name,
                 titleProperty=title_property,
                 taskType=None,
+                location=location,
             ),
             vector_index_config=vector_index_config,
         )
@@ -1079,6 +1083,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
                 vectorizeClassName=vectorize_collection_name,
                 titleProperty=title_property,
                 taskType=None,
+                location=None,
             ),
             vector_index_config=vector_index_config,
         )

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -378,6 +378,7 @@ class _Text2VecGoogleConfig(_VectorizerConfigCreate):
     vectorizeClassName: bool
     titleProperty: Optional[str]
     taskType: Optional[str]
+    location: Optional[str]
 
 
 class _Text2VecTransformersConfig(_VectorizerConfigCreate):
@@ -1199,6 +1200,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
             vectorizeClassName=vectorize_collection_name,
             titleProperty=title_property,
             taskType=None,
+            location=None,
         )
 
     @staticmethod
@@ -1228,6 +1230,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
             vectorizeClassName=vectorize_collection_name,
             titleProperty=title_property,
             taskType=None,
+            location=None,
         )
 
     @staticmethod
@@ -1237,6 +1240,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
         model_id: Optional[str] = None,
         title_property: Optional[str] = None,
         vectorize_collection_name: bool = True,
+        location: Optional[str] = None,
     ) -> _VectorizerConfigCreate:
         """Create a `_Text2VecGoogleConfig` object for use when vectorizing using the `text2vec-google` model.
 
@@ -1250,6 +1254,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
             title_property: The Weaviate property name for the `gecko-002` or `gecko-003` model to use as the title.
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
             dimensions: The dimensionality of the vectors. Defaults to `None`, which uses the server-defined default.
+            location: The Google Vertex AI region to run the model in. Defaults to `None`, which uses the server-defined default.
 
         Raises:
             pydantic.ValidationError: If `api_endpoint` is not a valid URL.
@@ -1262,6 +1267,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
             vectorizeClassName=vectorize_collection_name,
             titleProperty=title_property,
             taskType=None,
+            location=location,
         )
 
     @staticmethod

--- a/weaviate/collections/classes/config_vectors.py
+++ b/weaviate/collections/classes/config_vectors.py
@@ -1477,6 +1477,7 @@ class _Vectors:
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
+        location: Optional[str] = None,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-google` model.
 
@@ -1495,6 +1496,7 @@ class _Vectors:
             source_properties: Which properties should be included when vectorizing. By default all text properties are included.
             vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default.
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            location: The Google Vertex AI region to run the model in. Defaults to `None`, which uses the server-defined default.
 
         Raises:
             pydantic.ValidationError: If `api_endpoint` is not a valid URL.
@@ -1510,6 +1512,7 @@ class _Vectors:
                 vectorizeClassName=vectorize_collection_name,
                 titleProperty=title_property,
                 taskType=task_type,
+                location=location,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )
@@ -1560,6 +1563,7 @@ class _Vectors:
                 vectorizeClassName=vectorize_collection_name,
                 titleProperty=title_property,
                 taskType=task_type,
+                location=None,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )
@@ -1607,6 +1611,7 @@ class _Vectors:
                 vectorizeClassName=vectorize_collection_name,
                 titleProperty=title_property,
                 taskType=task_type,
+                location=None,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )
@@ -1625,6 +1630,7 @@ class _Vectors:
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
+        location: Optional[str] = None,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-google` model.
 
@@ -1643,6 +1649,7 @@ class _Vectors:
             source_properties: Which properties should be included when vectorizing. By default all text properties are included.
             vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default.
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            location: The Google Vertex AI region to run the model in. Defaults to `None`, which uses the server-defined default.
 
         Raises:
             pydantic.ValidationError: If `api_endpoint` is not a valid URL.
@@ -1658,6 +1665,7 @@ class _Vectors:
                 vectorizeClassName=vectorize_collection_name,
                 titleProperty=title_property,
                 taskType=task_type,
+                location=location,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )


### PR DESCRIPTION
Adds an optional `location` parameter (Google Vertex AI region) to the `text2vec-google` vectorizer config. When unset it is omitted from the module config, so the server applies its default.

Closes #2070