### PR TITLE
fix: reject bool values in ConnectionConfig int validators (Fixes #2076)

### DIFF
--- a/weaviate/config.py
+++ b/weaviate/config.py
@@ -14,19 +14,27 @@ class ConnectionConfig:
     session_pool_timeout: int = 5
 
     def __post_init__(self) -> None:
-        if not isinstance(self.session_pool_connections, int):
+        if not isinstance(self.session_pool_connections, int) or isinstance(
+            self.session_pool_connections, bool
+        ):
             raise TypeError(
                 f"session_pool_connections must be {int}, received {type(self.session_pool_connections)}"
             )
-        if not isinstance(self.session_pool_maxsize, int):
+        if not isinstance(self.session_pool_maxsize, int) or isinstance(
+            self.session_pool_maxsize, bool
+        ):
             raise TypeError(
                 f"session_pool_maxsize must be {int}, received {type(self.session_pool_maxsize)}"
             )
-        if not isinstance(self.session_pool_max_retries, int):
+        if not isinstance(self.session_pool_max_retries, int) or isinstance(
+            self.session_pool_max_retries, bool
+        ):
             raise TypeError(
                 f"session_pool_max_retries must be {int}, received {type(self.session_pool_max_retries)}"
             )
-        if not isinstance(self.session_pool_timeout, int):
+        if not isinstance(self.session_pool_timeout, int) or isinstance(
+            self.session_pool_timeout, bool
+        ):
             raise TypeError(
                 f"session_pool_timeout must be {int}, received {type(self.session_pool_timeout)}"
             )

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -672,7 +672,7 @@ def _get_valid_timeout_config(
     """
 
     def check_number(num: Union[NUMBER, Tuple[NUMBER, NUMBER], None]) -> bool:
-        return isinstance(num, float) or isinstance(num, int)
+        return isinstance(num, float) or (isinstance(num, int) and not isinstance(num, bool))
 
     if (isinstance(timeout_config, float) or isinstance(timeout_config, int)) and not isinstance(
         timeout_config, bool


### PR DESCRIPTION
Fixes #2076

## Problem

In `weaviate/config.py`, the `ConnectionConfig.__post_init__` method validates that `session_pool_connections`, `session_pool_maxsize`, `session_pool_max_retries`, and `session_pool_timeout` are `int` types using `isinstance(x, int)`.

Since `bool` is a subclass of `int` in Python, `isinstance(True, int)` returns `True`. This means `True` and `False` silently pass validation for these fields:

```python
from weaviate.config import ConnectionConfig
config = ConnectionConfig(session_pool_connections=True)  # No error!
config.session_pool_connections  # True (not a valid connection count)
```

The same pattern exists in `weaviate/util.py`'s `check_number()` helper function.

## Solution

Add `and not isinstance(x, bool)` guard to all four validators in `ConnectionConfig.__post_init__` and to the `check_number()` helper in `util.py`.

## Verification

```python
# Before fix: True passes validation
ConnectionConfig(session_pool_connections=True)  # No error

# After fix: True is rejected
ConnectionConfig(session_pool_connections=True)  # TypeError

# Normal int values still work
ConnectionConfig(session_pool_connections=20)  # OK
```

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-20 | Add bool guard to ConnectionConfig int validators and check_number() | rtmalikian |

### Files Changed
- weaviate/config.py — Add `or isinstance(x, bool)` to all 4 int validators
- weaviate/util.py — Add bool guard to `check_number()` helper

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
