### PR TITLE
feat(config): add optional dimensions to text2vec-aws vectorizer

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -238,6 +238,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
             model="cohere.embed-english-v3",
             region="us-east-1",
             service="bedrock",
+            dimensions=512,
         ),
         {
             "text2vec-aws": {
@@ -245,6 +246,7 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
                 "model": "cohere.embed-english-v3",
                 "region": "us-east-1",
                 "service": "bedrock",
+                "dimensions": 512,
             }
         },
     ),

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -453,6 +453,7 @@ class _NamedVectors:
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
+        dimensions: Optional[int] = None,
     ) -> _NamedVectorConfigCreate:
         """Create a named vector using the `text2vec_aws` model.
 
@@ -468,6 +469,7 @@ class _NamedVectors:
             source_properties: Which properties should be included when vectorizing. By default all text properties are included.
             vector_index_config: The configuration for Weaviate's vector index. Use wvc.config.Configure.VectorIndex to create a vector index configuration. None by default
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            dimensions: The dimensionality of the vectors. Defaults to `None`, which uses the server-defined default.
         """
         return _NamedVectorConfigCreate(
             name=name,
@@ -480,6 +482,7 @@ class _NamedVectors:
                 vectorizeClassName=vectorize_collection_name,
                 targetModel=None,
                 targetVariant=None,
+                dimensions=dimensions,
             ),
             vector_index_config=vector_index_config,
         )

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -215,6 +215,7 @@ class _Text2VecAWSConfig(_VectorizerConfigCreate):
     service: str
     targetModel: Optional[str]
     targetVariant: Optional[str]
+    dimensions: Optional[int]
     vectorizeClassName: bool
 
     @field_validator("region")
@@ -770,6 +771,7 @@ class _Vectorizer:
         endpoint: Optional[str] = None,
         service: Union[AWSService, str] = "bedrock",
         vectorize_collection_name: bool = True,
+        dimensions: Optional[int] = None,
     ) -> _VectorizerConfigCreate:
         """Create a `_Text2VecAWSConfigCreate` object for use when vectorizing using the `text2vec-aws` model.
 
@@ -782,6 +784,7 @@ class _Vectorizer:
             endpoint: The model to use, REQUIRED for service "sagemaker".
             service: The AWS service to use, options are "bedrock" and "sagemaker".
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            dimensions: The dimensionality of the vectors. Defaults to `None`, which uses the server-defined default.
         """
         return _Text2VecAWSConfig(
             model=model,
@@ -791,6 +794,7 @@ class _Vectorizer:
             endpoint=endpoint,
             targetModel=None,
             targetVariant=None,
+            dimensions=dimensions,
         )
 
     @staticmethod

--- a/weaviate/collections/classes/config_vectors.py
+++ b/weaviate/collections/classes/config_vectors.py
@@ -795,6 +795,7 @@ class _Vectors:
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
+        dimensions: Optional[int] = None,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-aws` module.
 
@@ -811,6 +812,7 @@ class _Vectors:
             source_properties: Which properties should be included when vectorizing. By default all text properties are included.
             vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            dimensions: The dimensionality of the vectors. Defaults to `None`, which uses the server-defined default.
         """
         return _VectorConfigCreate(
             name=name,
@@ -823,6 +825,7 @@ class _Vectors:
                 vectorizeClassName=vectorize_collection_name,
                 targetModel=None,
                 targetVariant=None,
+                dimensions=dimensions,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )
@@ -837,6 +840,7 @@ class _Vectors:
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
+        dimensions: Optional[int] = None,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-aws` module.
 
@@ -851,6 +855,7 @@ class _Vectors:
             source_properties: Which properties should be included when vectorizing. By default all text properties are included.
             vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            dimensions: The dimensionality of the vectors. Defaults to `None`, which uses the server-defined default.
         """
         return _VectorConfigCreate(
             name=name,
@@ -863,6 +868,7 @@ class _Vectors:
                 vectorizeClassName=vectorize_collection_name,
                 targetModel=None,
                 targetVariant=None,
+                dimensions=dimensions,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )
@@ -879,6 +885,7 @@ class _Vectors:
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
+        dimensions: Optional[int] = None,
     ) -> _VectorConfigCreate:
         """Create a vector using the `text2vec-aws` module.
 
@@ -895,6 +902,7 @@ class _Vectors:
             source_properties: Which properties should be included when vectorizing. By default all text properties are included.
             vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            dimensions: The dimensionality of the vectors. Defaults to `None`, which uses the server-defined default.
         """
         return _VectorConfigCreate(
             name=name,
@@ -907,6 +915,7 @@ class _Vectors:
                 targetVariant=target_variant,
                 service="sagemaker",
                 vectorizeClassName=vectorize_collection_name,
+                dimensions=dimensions,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )


### PR DESCRIPTION
Adds an optional `dimensions` parameter (output embedding dimensionality) to the `text2vec-aws` vectorizer config. Omitted when unset, so the server applies its default.

Closes #2071