### PR TITLE
fix: honor batch rate limit under async indexing (#1542)

### DIFF
--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -2,6 +2,12 @@ import uuid
 
 import pytest
 
+from weaviate.collections.batch.base import (
+    _DynamicBatching,
+    _FixedSizeBatching,
+    _RateLimitedBatching,
+    _async_indexing_batch_params,
+)
 from weaviate.collections.batch.grpc_batch import _validate_props
 from weaviate.collections.classes.batch import MAX_STORED_RESULTS, BatchObjectReturn
 from weaviate.exceptions import WeaviateInsertInvalidPropertyError
@@ -53,3 +59,41 @@ def test_validate_props_raises_for_top_level_vector() -> None:
 def test_validate_props_raises_for_nested_vector() -> None:
     with pytest.raises(WeaviateInsertInvalidPropertyError):
         _validate_props({"vector": [0.1, 0.2]}, nested=True)
+
+
+def test_async_indexing_preserves_rate_limit() -> None:
+    # Async indexing has no server-side queue feedback, but a configured rate limit
+    # must still be honoured rather than replaced by large fixed-size batches (#1542).
+    requested = _RateLimitedBatching(requests_per_minute=100)
+
+    mode, recommended_num_objects, concurrent_requests = _async_indexing_batch_params(
+        requested, max_batch_size=1000
+    )
+
+    assert mode == requested
+    assert concurrent_requests == 1
+    assert recommended_num_objects == 100
+
+
+def test_async_indexing_rate_limit_spans_multiple_batches() -> None:
+    # A rate limit larger than the maximum batch size is split across several batches.
+    requested = _RateLimitedBatching(requests_per_minute=3000)
+
+    mode, recommended_num_objects, concurrent_requests = _async_indexing_batch_params(
+        requested, max_batch_size=1000
+    )
+
+    assert mode == requested
+    assert concurrent_requests == 4
+    assert recommended_num_objects == 750
+
+
+def test_async_indexing_dynamic_falls_back_to_fixed_size() -> None:
+    # Without a configured rate limit, dynamic batching keeps its large-batch fallback.
+    mode, recommended_num_objects, concurrent_requests = _async_indexing_batch_params(
+        _DynamicBatching(), max_batch_size=1000
+    )
+
+    assert mode == _FixedSizeBatching(1000, 10)
+    assert recommended_num_objects == 1000
+    assert concurrent_requests == 10

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -11,7 +11,7 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from copy import copy
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, Optional, Set, Tuple, TypeVar, Union, cast
 
 from pydantic import ValidationError
 from typing_extensions import TypeAlias
@@ -267,6 +267,61 @@ _BatchMode: TypeAlias = Union[
     _DynamicBatching, _FixedSizeBatching, _RateLimitedBatching, _ServerSideBatching
 ]
 
+# When async indexing is enabled the server does not report `batchStats`, so dynamic
+# batching cannot tune itself against the indexing queue and falls back to sending large
+# batches. These are the parameters used for that fallback.
+_ASYNC_INDEXING_FALLBACK_BATCH_SIZE = 1000
+_ASYNC_INDEXING_FALLBACK_CONCURRENT_REQUESTS = 10
+
+
+def _rate_limited_batch_params(mode: _RateLimitedBatching, max_batch_size: int) -> Tuple[int, int]:
+    """Compute (concurrent_requests, recommended_num_objects) for rate-limited batching.
+
+    Args:
+        mode (_RateLimitedBatching): The configured rate-limited batching mode.
+        max_batch_size (int): The maximum number of objects allowed in a single batch.
+
+    Returns:
+        Tuple[int, int]: The number of concurrent requests and the recommended number of
+            objects per batch that together honour the configured requests-per-minute limit.
+    """
+    concurrent_requests = (mode.requests_per_minute + max_batch_size) // max_batch_size
+    recommended_num_objects = mode.requests_per_minute // concurrent_requests
+    return concurrent_requests, recommended_num_objects
+
+
+def _async_indexing_batch_params(
+    requested_mode: _BatchMode, max_batch_size: int
+) -> Tuple[_BatchMode, int, int]:
+    """Determine batching parameters to use when the server runs in async-indexing mode.
+
+    Dynamic batching relies on the server-reported indexing queue to size its batches.
+    Under async indexing that signal is unavailable, so dynamic batching falls back to
+    sending large batches. A configured rate limit must still be honoured in that case,
+    otherwise the limiter is silently ignored (see issue #1542).
+
+    Args:
+        requested_mode (_BatchMode): The batching mode originally requested by the user.
+        max_batch_size (int): The maximum number of objects allowed in a single batch.
+
+    Returns:
+        Tuple[_BatchMode, int, int]: The batching mode to apply, the recommended number
+            of objects per batch, and the number of concurrent requests.
+    """
+    if isinstance(requested_mode, _RateLimitedBatching):
+        concurrent_requests, recommended_num_objects = _rate_limited_batch_params(
+            requested_mode, max_batch_size
+        )
+        return requested_mode, recommended_num_objects, concurrent_requests
+    return (
+        _FixedSizeBatching(
+            _ASYNC_INDEXING_FALLBACK_BATCH_SIZE,
+            _ASYNC_INDEXING_FALLBACK_CONCURRENT_REQUESTS,
+        ),
+        _ASYNC_INDEXING_FALLBACK_BATCH_SIZE,
+        _ASYNC_INDEXING_FALLBACK_CONCURRENT_REQUESTS,
+    )
+
 
 class _BatchBase:
     def __init__(
@@ -302,6 +357,10 @@ class _BatchBase:
         self.__cluster = _ClusterBatch(self.__connection)
 
         self.__batching_mode: _BatchMode = batch_mode
+        # The mode the user originally requested. `__batching_mode` may be reassigned at
+        # runtime (e.g. the async-indexing fallback in `__dynamic_batching`), so we keep
+        # the request separately to know whether a rate limit was configured.
+        self.__requested_batch_mode: _BatchMode = batch_mode
         self.__max_batch_size: int = 1000
 
         self.__executor = executor
@@ -510,10 +569,13 @@ class _BatchBase:
     def __dynamic_batching(self) -> None:
         status = self.__cluster.get_nodes_status()
         if "batchStats" not in status[0] or "queueLength" not in status[0]["batchStats"]:
-            # async indexing - just send a lot
-            self.__batching_mode = _FixedSizeBatching(1000, 10)
-            self.__recommended_num_objects = 1000
-            self.__concurrent_requests = 10
+            # async indexing - send a lot, unless the user configured a rate limit, in
+            # which case it must still be honoured (see issue #1542).
+            (
+                self.__batching_mode,
+                self.__recommended_num_objects,
+                self.__concurrent_requests,
+            ) = _async_indexing_batch_params(self.__requested_batch_mode, self.__max_batch_size)
             return
 
         rate: int = status[0]["batchStats"]["ratePerSecond"]


### PR DESCRIPTION
## What & why

Fixes #1542.

`collection.batch.rate_limit(...)` was not honored when the Weaviate server runs in async-indexing mode. Batches were sent with 1000 objects regardless of the configured requests-per-minute, defeating the rate limiter exactly as reported in the issue.

## Root cause

Dynamic batching sizes its batches from the server-reported indexing queue. Under async indexing the server does not return `batchStats`, so the background loop in `_BatchBase.__dynamic_batching` takes its "no queue feedback" fallback:

```python
# async indexing - just send a lot
self.__batching_mode = _FixedSizeBatching(1000, 10)
self.__recommended_num_objects = 1000
self.__concurrent_requests = 10
```

This fallback overwrote the batching mode unconditionally, so a rate limit that the user had configured was silently dropped and replaced with fixed-size 1000/10 batching — the "1000 objects no matter the rate" behavior in the report.

## The fix

The fallback decision is extracted into a small, side-effect-free helper, `_async_indexing_batch_params`, which:

- preserves a configured `_RateLimitedBatching` mode (reusing the same requests-per-minute math as the constructor), and
- keeps the existing large-batch behavior (`_FixedSizeBatching(1000, 10)`) for dynamic batching when no rate limit was set.

The originally requested batch mode is tracked separately (`__requested_batch_mode`) so the fallback can tell whether a rate limit was configured, since `__batching_mode` is reassigned at runtime. The rate-limited timing path itself in `__batch_send` is unchanged. No public API signatures change.

## Testing

Added unit tests in `test/collection/test_batch.py` that exercise the decision helper directly, so they need no live Weaviate server:

- `test_async_indexing_preserves_rate_limit` — a configured `rate_limit(100)` is preserved (not replaced by 1000/10)
- `test_async_indexing_rate_limit_spans_multiple_batches` — a limit above the max batch size is split across batches (3000/min → 4 × 750)
- `test_async_indexing_dynamic_falls_back_to_fixed_size` — regression guard: dynamic batching without a rate limit keeps the `_FixedSizeBatching(1000, 10)` fallback

The "preserve rate limit" tests fail on `main` (the helper does not exist / the old branch hardcodes 1000/10) and pass with this change.

Ran locally (Python 3.12, fresh venv from `requirements-devel.txt` + `requirements-test.txt`):

- `pytest test/` → 379 passed, 1 skipped
- `ruff format --check` → clean
- `flake8` (incl. flake8-docstrings + pydoclint plugin) → clean
- `pyright` → no errors in `base.py` (the 4 pre-existing `connect/v4.py` authlib errors are present on unmodified `main`)
- `pydoclint` → no findings for the added functions

I could not run the integration/mock suites, which require a live Weaviate instance via Docker; this change is covered by the server-free unit tests above.

## CLA

I understand contributions require a signed Contributor License Agreement per `CONTRIBUTING.md`, and I'll complete the DocuSign step from the link the bot posts on this PR.
