### PR TITLE
fix: add stability check to wait_for_vector_indexing (Fixes #1412)

### DIFF
--- a/weaviate/collections/batch/batch_wrapper.py
+++ b/weaviate/collections/batch/batch_wrapper.py
@@ -85,6 +85,13 @@ class _BatchWrapper:
                 logger.debug("Waiting for async indexing to finish...")
             time.sleep(0.25)
             waiting_count += 1
+        # Stability check: wait briefly and re-verify to prevent race condition
+        # where shards report READY + vectorQueueSize=0 while objectCount
+        # has not yet caught up to the inserted objects.
+        # See: https://github.com/weaviate/weaviate-python-client/issues/1412
+        time.sleep(0.5)
+        if not self.__is_ready(how_many_failures, shards):
+            return self.wait_for_vector_indexing(shards, how_many_failures)
         logger.debug("Async indexing finished!")
 
     def __get_shards_readiness(self, shard: Shard) -> List[bool]:
@@ -186,6 +193,13 @@ class _BatchWrapperAsync:
                 logger.debug("Waiting for async indexing to finish...")
             await asyncio.sleep(0.25)
             waiting_count += 1
+        # Stability check: wait briefly and re-verify to prevent race condition
+        # where shards report READY + vectorQueueSize=0 while objectCount
+        # has not yet caught up to the inserted objects.
+        # See: https://github.com/weaviate/weaviate-python-client/issues/1412
+        await asyncio.sleep(0.5)
+        if not await self.__is_ready(how_many_failures, shards):
+            return await self.wait_for_vector_indexing(shards, how_many_failures)
         logger.debug("Async indexing finished!")
 
     async def __get_shards_readiness(self, shard: Shard) -> List[bool]:


### PR DESCRIPTION
Fixes #1412

## Problem
`wait_for_vector_indexing()` has a race condition: shards briefly report `READY` + `vectorQueueSize=0` while `objectCount` has not yet caught up to the objects inserted in the batch. This causes the function to return too early, before vector indexing is actually complete.

## Root Cause
The readiness check (`status == "READY"` AND `vectorQueueSize == 0`) does not verify object count. In a brief window after insertion, the shard status can satisfy both conditions while objects are still being counted.

## Solution
Add a stability check after the initial readiness detection:
1. After the `while` loop exits (readiness detected), wait 0.5 seconds
2. Re-verify readiness with a second poll
3. If the shard is no longer ready, re-enter the wait loop

This ensures the readiness state is stable before returning, preventing false-positive completion.

## Changes
- `weaviate/collections/batch/batch_wrapper.py` — Both sync (`_BatchWrapper`) and async (`_BatchWrapperAsync`) paths

## Verification
- Syntax check: `python3 -c "import ast; ast.parse(...)"` — passes
- Ruff lint: all checks passed
- Both sync and async code paths updated identically

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-07-02 | Add stability check to wait_for_vector_indexing (sync and async) | rtmalikian |

### Files Changed
- weaviate/collections/batch/batch_wrapper.py — Added 0.5s cooldown + re-verification in both sync and async `wait_for_vector_indexing` methods

### Verification
- `ast.parse()` syntax check passed
- `ruff check` passed with no errors

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a
