### PR TITLE
Reject bool where a plain int is expected in _is_valid

### DIFF
--- a/test/collection/test_validator.py
+++ b/test/collection/test_validator.py
@@ -14,6 +14,7 @@ from weaviate.validator import _ExtraTypes, _validate_input, _ValidateArgument
     [
         (1, [int], False),
         (1.0, [int], True),
+        (True, [int], True),
         ([1, 1], [List], False),
         (np.array([1, 2, 3]), [_ExtraTypes.NUMPY], False),
         (np.array([1, 2, 3]), [_ExtraTypes.NUMPY, List], False),

--- a/weaviate/validator.py
+++ b/weaviate/validator.py
@@ -59,4 +59,8 @@ def _is_valid(expected: Any, value: Any) -> bool:
                 return any(isinstance(val, union_arg) for val in value for union_arg in union_args)
             else:
                 return all(isinstance(val, args[0]) for val in value)
+    # bool is a subclass of int, so isinstance(True, int) is True. Reject a
+    # bool where a plain int is expected so it is not silently coerced to 0/1.
+    if expected is int and isinstance(value, bool):
+        return False
     return isinstance(value, expected)


### PR DESCRIPTION
## What

`_is_valid` in `weaviate/validator.py` ends with `return isinstance(value, expected)`. Because `bool` is a subclass of `int`, `isinstance(True, int)` is `True`, so a `bool` passes validation wherever a bare `int` is expected:

```python
_is_valid(int, True)   # -> True  (should be False)
```

Real call sites hit this — e.g. `query.py` validates `limit` / `offset` / `autocut` as `[int, None]`. So:

```python
collection.query.fetch_objects(limit=True)
```

silently passes validation and sends `True` (coerced to `1`) instead of raising `WeaviateInvalidInputError`. This is the same class of bug that #2076 reported and #2077 fixed in `config.py` / `util.py` (`... and not isinstance(x, bool)`); this is the unguarded sibling site in the validator.

## Fix

Guard the `int` case at the terminal return, so a `bool` is rejected where a plain `int` is expected:

```python
if expected is int and isinstance(value, bool):
    return False
return isinstance(value, expected)
```

`bool`-typed expectations (`_is_valid(bool, True)`) and all other types are unaffected.

## Testing

Added a case to the existing parametrized `test_validator` in `test/collection/test_validator.py`:

```python
(True, [int], True),   # bool must not validate as int
```

It fails on `main` and passes with the fix (verified). The suite is fully offline (no DB/Docker), and the existing `(1.0, [int], True)` case establishes the same "reject the wrong numeric type" pattern.