### PR TITLE
feat: add endpoint setting for text2vec-openai and text2vec-morph

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -320,6 +320,21 @@ TEST_CONFIG_WITH_VECTORIZER_PARAMETERS = [
         },
     ),
     (
+        Configure.Vectorizer.text2vec_openai(
+            vectorize_collection_name=False,
+            model="ada",
+            endpoint="https://api.custom.com/v1/embeddings",
+        ),
+        {
+            "text2vec-openai": {
+                "vectorizeClassName": False,
+                "model": "ada",
+                "endpoint": "https://api.custom.com/v1/embeddings",
+                "isAzure": False,
+            }
+        },
+    ),
+    (
         Configure.Vectorizer.text2vec_mistral(
             vectorize_collection_name=False,
             model="cool-model",
@@ -1760,6 +1775,28 @@ TEST_CONFIG_WITH_NAMED_VECTORIZER_PARAMETERS = [
         },
     ),
     (
+        [
+            Configure.NamedVectors.text2vec_openai(
+                name="test",
+                source_properties=["prop"],
+                endpoint="https://api.custom.com/v1/embeddings",
+            )
+        ],
+        {
+            "test": {
+                "vectorizer": {
+                    "text2vec-openai": {
+                        "properties": ["prop"],
+                        "vectorizeClassName": True,
+                        "endpoint": "https://api.custom.com/v1/embeddings",
+                        "isAzure": False,
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
         [Configure.NamedVectors.text2vec_mistral(name="test", source_properties=["prop"])],
         {
             "test": {
@@ -2362,6 +2399,28 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
         },
     ),
     (
+        [
+            Configure.Vectors.text2vec_openai(
+                name="test",
+                source_properties=["prop"],
+                endpoint="https://api.custom.com/v1/embeddings",
+            )
+        ],
+        {
+            "test": {
+                "vectorizer": {
+                    "text2vec-openai": {
+                        "properties": ["prop"],
+                        "vectorizeClassName": True,
+                        "endpoint": "https://api.custom.com/v1/embeddings",
+                        "isAzure": False,
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
         [Configure.Vectors.text2vec_mistral(name="test", source_properties=["prop"])],
         {
             "test": {
@@ -2402,6 +2461,27 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
                     "text2vec-morph": {
                         "vectorizeClassName": True,
                         "properties": ["prop"],
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
+        [
+            Configure.Vectors.text2vec_morph(
+                name="test",
+                source_properties=["prop"],
+                endpoint="https://api.custom.com/v1/embeddings",
+            )
+        ],
+        {
+            "test": {
+                "vectorizer": {
+                    "text2vec-morph": {
+                        "vectorizeClassName": True,
+                        "properties": ["prop"],
+                        "endpoint": "https://api.custom.com/v1/embeddings",
                     }
                 },
                 "vectorIndexType": "hnsw",

--- a/weaviate/collections/classes/config_named_vectors.py
+++ b/weaviate/collections/classes/config_named_vectors.py
@@ -401,6 +401,7 @@ class _NamedVectors:
         *,
         base_url: Optional[AnyHttpUrl] = None,
         dimensions: Optional[int] = None,
+        endpoint: Optional[str] = None,
         model: Optional[Union[OpenAIModel, str]] = None,
         model_version: Optional[str] = None,
         type_: Optional[OpenAIType] = None,
@@ -424,6 +425,7 @@ class _NamedVectors:
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
             base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default.
             dimensions: Number of dimensions. Applicable to v3 OpenAI models only. Defaults to `None`, which uses the server-defined default.
+            endpoint: The endpoint to use. Defaults to `None`, which uses the server-defined default of `/v1/embeddings`.
 
         Raises:
             pydantic.ValidationError: If `type_` is not a valid value from the `OpenAIType` type.
@@ -438,6 +440,7 @@ class _NamedVectors:
                 type_=type_,
                 vectorizeClassName=vectorize_collection_name,
                 dimensions=dimensions,
+                endpoint=endpoint,
             ),
             vector_index_config=vector_index_config,
         )

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -310,6 +310,7 @@ class _Text2VecMorphConfig(_VectorizerConfigCreate):
     model: Optional[str]
     vectorizeClassName: bool
     baseURL: Optional[AnyHttpUrl]
+    endpoint: Optional[str]
 
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict = super()._to_dict()
@@ -336,6 +337,7 @@ class _Text2VecOpenAIConfig(_VectorizerConfigCreate):
     )
     baseURL: Optional[AnyHttpUrl]
     dimensions: Optional[int]
+    endpoint: Optional[str]
     model: Optional[str]
     modelVersion: Optional[str]
     type_: Optional[OpenAIType]
@@ -1137,6 +1139,7 @@ class _Vectorizer:
         vectorize_collection_name: bool = True,
         base_url: Optional[AnyHttpUrl] = None,
         dimensions: Optional[int] = None,
+        endpoint: Optional[str] = None,
     ) -> _VectorizerConfigCreate:
         """Create a `_Text2VecOpenAIConfigCreate` object for use when vectorizing using the `text2vec-openai` model.
 
@@ -1150,6 +1153,7 @@ class _Vectorizer:
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
             base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default.
             dimensions: Number of dimensions. Applicable to v3 OpenAI models only. Defaults to `None`, which uses the server-defined default.
+            endpoint: The endpoint to use. Defaults to `None`, which uses the server-defined default of `/v1/embeddings`.
 
         Raises:
             pydantic.ValidationError: If `type_` is not a valid value from the `OpenAIType` type.
@@ -1161,6 +1165,7 @@ class _Vectorizer:
             type_=type_,
             vectorizeClassName=vectorize_collection_name,
             dimensions=dimensions,
+            endpoint=endpoint,
         )
 
     @staticmethod

--- a/weaviate/collections/classes/config_vectors.py
+++ b/weaviate/collections/classes/config_vectors.py
@@ -664,6 +664,7 @@ class _Vectors:
         quantizer: Optional[_QuantizerConfigCreate] = None,
         base_url: Optional[AnyHttpUrl] = None,
         model: Optional[str] = None,
+        endpoint: Optional[str] = None,
         source_properties: Optional[List[str]] = None,
         vector_index_config: Optional[_VectorIndexConfigCreate] = None,
         vectorize_collection_name: bool = True,
@@ -678,6 +679,7 @@ class _Vectors:
             quantizer: The quantizer to use for the vector index. If not provided, no quantization will be applied.
             base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default.
             model: The model to use. Defaults to `None`, which uses the server-defined default.
+            endpoint: The endpoint to use. Defaults to `None`, which uses the server-defined default of `/v1/embeddings`.
             source_properties: Which properties should be included when vectorizing. By default all text properties are included.
             vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default
             vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
@@ -688,6 +690,7 @@ class _Vectors:
             vectorizer=_Text2VecMorphConfig(
                 baseURL=base_url,
                 model=model,
+                endpoint=endpoint,
                 vectorizeClassName=vectorize_collection_name,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
@@ -739,6 +742,7 @@ class _Vectors:
         quantizer: Optional[_QuantizerConfigCreate] = None,
         base_url: Optional[AnyHttpUrl] = None,
         dimensions: Optional[int] = None,
+        endpoint: Optional[str] = None,
         model: Optional[Union[OpenAIModel, str]] = None,
         model_version: Optional[str] = None,
         type_: Optional[OpenAIType] = None,
@@ -756,6 +760,7 @@ class _Vectors:
             quantizer: The quantizer to use for the vector index. If not provided, no quantization will be applied.
             base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default.
             dimensions: Number of dimensions. Applicable to v3 OpenAI models only. Defaults to `None`, which uses the server-defined default.
+            endpoint: The endpoint to use. Defaults to `None`, which uses the server-defined default of `/v1/embeddings`.
             model: The model to use. Defaults to `None`, which uses the server-defined default.
             model_version: The model version to use. Defaults to `None`, which uses the server-defined default.
             type_: The type of model to use. Defaults to `None`, which uses the server-defined default.
@@ -776,6 +781,7 @@ class _Vectors:
                 type_=type_,
                 vectorizeClassName=vectorize_collection_name,
                 dimensions=dimensions,
+                endpoint=endpoint,
             ),
             vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
         )


### PR DESCRIPTION
## Summary

Adds an optional `endpoint` argument to `text2vec-openai` and `text2vec-morph` vectorizer configs, mirroring the `endpoint` field already supported by `text2vec-aws`. Defaults to `None`, which uses the server-defined default of `/v1/embeddings`.

Closes #2072.

## Changes

- `weaviate/collections/classes/config_vectorizers.py`: adds `endpoint: Optional[str]` to `_Text2VecOpenAIConfig` and `_Text2VecMorphConfig`, and threads it through `Configure.Vectorizer.text2vec_openai`.
- `weaviate/collections/classes/config_vectors.py`: adds `endpoint` to `Configure.Vectors.text2vec_openai` and `Configure.Vectors.text2vec_morph`.
- `weaviate/collections/classes/config_named_vectors.py`: adds `endpoint` to `Configure.NamedVectors.text2vec_openai` (there is no `text2vec_morph` named-vector factory to update).
- `test/collection/test_config.py`: adds a case per updated factory asserting `endpoint` round-trips into the serialized module config.

## Test plan

- [x] `pytest test/collection/test_config.py` — 194/194 passing
- [x] `ruff check` / `ruff format --check` on all changed files — clean
- [x] `flake8` on all changed files — clean