### PR TITLE
test: add unit tests for BaseEnum membership support

### DIFF
--- a/test/test_str_enum.py
+++ b/test/test_str_enum.py
@@ -1,0 +1,31 @@
+from weaviate.str_enum import BaseEnum
+
+
+class _Color(BaseEnum):
+    RED = "red"
+    GREEN = "green"
+
+
+def test_member_name_string_is_contained():
+    # `in` matches by member *name*, so the uppercase name is found.
+    assert "RED" in _Color
+    assert "GREEN" in _Color
+
+
+def test_unknown_string_is_not_contained():
+    assert "PURPLE" not in _Color
+
+
+def test_member_value_string_is_not_a_membership_match():
+    # The lowercase *value* is not a member name, so it is not contained.
+    assert "red" not in _Color
+
+
+def test_enum_member_is_contained():
+    assert _Color.RED in _Color
+
+
+def test_non_string_non_member_is_not_contained():
+    # A non-string that lacks a ``.name`` falls back to the string check
+    # and is therefore not contained.
+    assert 12345 not in _Color


### PR DESCRIPTION
## Description

`weaviate/str_enum.py` provides `BaseEnum`/`MetaEnum`, which add `in`
support to enums (e.g. `"ALL" in ConsistencyLevel`), but had no dedicated
test. This adds `test/test_str_enum.py` covering:

- a member *name* string being contained
- an unknown string not being contained
- a member *value* string not counting as a membership match
- an enum member being contained
- a non-string (which lacks `.name`) not being contained

No source changes.

## Verification

`pytest test/test_str_enum.py` - 5 passed. `ruff check` / `ruff format
--check` clean.
