### PR TITLE
test: cover parse_version_string branches

### DIFF
--- a/test/test_parse_version_string.py
+++ b/test/test_parse_version_string.py
@@ -1,0 +1,30 @@
+import pytest
+
+from weaviate.util import parse_version_string
+
+
+class TestParseVersionString:
+    """`parse_version_string` -> (major, minor), ignoring any patch."""
+
+    @pytest.mark.parametrize(
+        "version,expected",
+        [
+            ("1.18.1", (1, 18)),
+            ("1.18", (1, 18)),
+            ("1.0.0", (1, 0)),
+        ],
+    )
+    def test_major_minor_parsed_and_patch_ignored(self, version, expected):
+        assert parse_version_string(version) == expected
+
+    @pytest.mark.parametrize("version", ["v1.18.2", "v3.4"])
+    def test_leading_v_is_stripped(self, version):
+        assert parse_version_string(version) == parse_version_string(version[1:])
+
+    def test_version_without_minor_defaults_to_zero(self):
+        assert parse_version_string("2") == (2, 0)
+
+    @pytest.mark.parametrize("version", ["abc", ""])
+    def test_unparseable_version_raises_value_error(self, version):
+        with pytest.raises(ValueError):
+            parse_version_string(version)


### PR DESCRIPTION
## Description

`weaviate.util.parse_version_string` turns a version string into a
`(major, minor)` tuple (stripping a leading `v`, defaulting a missing minor to
`0`, ignoring the patch, and raising on unparseable input). The existing suite
only asserted that `v`-prefixed and bare versions parse equal, leaving the
other branches uncovered.

This adds `test/test_parse_version_string.py` covering:

- major/minor parsed with the patch ignored
- a leading `v` being stripped
- a version with no minor defaulting to `0` (e.g. `"2"` -> `(2, 0)`)
- `ValueError` on unparseable / empty input

No source changes.

## Verification

`pytest test/test_parse_version_string.py` - 8 passed. `ruff check` /
`ruff format --check` clean.
