### PR TITLE
test: add unit tests for _Warnings warning helpers

### DIFF
--- a/test/test_warnings.py
+++ b/test/test_warnings.py
@@ -1,0 +1,51 @@
+import warnings
+
+import pytest
+
+from weaviate.warnings import _Warnings
+
+
+def _capture(func, *args):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        func(*args)
+    assert len(caught) == 1
+    return caught[0]
+
+
+def test_auth_with_anon_weaviate_emits_user_warning():
+    record = _capture(_Warnings.auth_with_anon_weaviate)
+    assert issubclass(record.category, UserWarning)
+    assert "Auth001" in str(record.message)
+
+
+def test_auth_negative_expiration_time_includes_value():
+    record = _capture(_Warnings.auth_negative_expiration_time, 30)
+    assert issubclass(record.category, UserWarning)
+    assert "Auth003" in str(record.message)
+    assert "30" in str(record.message)
+
+
+def test_auth_no_refresh_token_without_length():
+    record = _capture(_Warnings.auth_no_refresh_token)
+    assert "Auth002" in str(record.message)
+    assert "no expiration time" in str(record.message)
+
+
+def test_auth_no_refresh_token_with_length():
+    record = _capture(_Warnings.auth_no_refresh_token, 60)
+    assert "Auth002" in str(record.message)
+    assert "only valid for 60s" in str(record.message)
+
+
+@pytest.mark.parametrize(
+    "func, args, code",
+    [
+        (_Warnings.sharding_actual_count_is_deprecated, ("actualCount",), "Dep018"),
+        (_Warnings.deprecated_tenant_type, ("HOT", "ACTIVE"), "Dep021"),
+    ],
+)
+def test_deprecation_warnings(func, args, code):
+    record = _capture(func, *args)
+    assert issubclass(record.category, DeprecationWarning)
+    assert code in str(record.message)


### PR DESCRIPTION
## Description

`weaviate/warnings.py` (`_Warnings`) had no dedicated test module. This adds `test/test_warnings.py` covering a representative subset:

- `auth_with_anon_weaviate` and `auth_negative_expiration_time` emitting `UserWarning` with the right code (and the value interpolated)
- `auth_no_refresh_token` with and without an expiration length
- two deprecation helpers emitting `DeprecationWarning` with their `DepNNN` codes

No source changes.

## Verification

`pytest test/test_warnings.py` - 6 passed. `ruff check` / `ruff format --check` clean.
