### PR TITLE
ci: run integration tests against Weaviate 1.39.0-rc.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,7 @@ env:
   WEAVIATE_135: 1.35.18
   WEAVIATE_136: 1.36.12
   WEAVIATE_137: 1.37.5-e0fe0d5.amd64
+  WEAVIATE_139: 1.39.0-rc.0-b41225e.amd64
 
 jobs:
   lint-and-format:
@@ -162,11 +163,11 @@ jobs:
       fail-fast: false
       matrix:
         versions: [
-          { py: "3.10", weaviate: $WEAVIATE_136, grpc: "1.59.0"},
-          { py: "3.11", weaviate: $WEAVIATE_136, grpc: "1.66.0"},
-          { py: "3.12", weaviate: $WEAVIATE_136, grpc: "1.70.0"},
-          { py: "3.13", weaviate: $WEAVIATE_136, grpc: "1.72.1"},
-          { py: "3.14", weaviate: $WEAVIATE_136, grpc: "1.76.0"}
+          { py: "3.10", weaviate: $WEAVIATE_139, grpc: "1.59.0"},
+          { py: "3.11", weaviate: $WEAVIATE_139, grpc: "1.66.0"},
+          { py: "3.12", weaviate: $WEAVIATE_139, grpc: "1.70.0"},
+          { py: "3.13", weaviate: $WEAVIATE_139, grpc: "1.72.1"},
+          { py: "3.14", weaviate: $WEAVIATE_139, grpc: "1.76.0"}
         ]
         optional_dependencies: [false]
     steps:
@@ -320,7 +321,8 @@ jobs:
           $WEAVIATE_134,
           $WEAVIATE_135,
           $WEAVIATE_136,
-          $WEAVIATE_137
+          $WEAVIATE_137,
+          $WEAVIATE_139
         ]
     steps:
       - name: Checkout

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -48,6 +48,19 @@ from weaviate.exceptions import (
     WeaviateUnsupportedFeatureError,
 )
 from integration.conftest import retry_on_http_error
+from weaviate.util import _ServerVersion
+
+
+def _expected_async_enabled(version: _ServerVersion, factor: int) -> bool:
+    """Whether the server reports async replication as enabled for a collection.
+
+    Up to 1.38 the server stores whatever `async_enabled` the collection was created with. From
+    1.39 it ignores that and derives the field as `factor > 1 and not globally disabled` instead,
+    so a collection with a single replica always reports `False`.
+    """
+    if version.is_at_least(1, 39, 0):
+        return factor > 1
+    return version.is_at_least(1, 26, 0)
 
 
 @pytest.fixture(scope="module")
@@ -353,10 +366,9 @@ def test_collection_config_full(collection_factory: CollectionFactory) -> None:
         assert config.multi_tenancy_config.auto_tenant_creation is False
 
     assert config.replication_config.factor == 1
-    if collection._connection._weaviate_version.is_at_least(1, 26, 0):
-        assert config.replication_config.async_enabled is True
-    else:
-        assert config.replication_config.async_enabled is False
+    assert config.replication_config.async_enabled is _expected_async_enabled(
+        collection._connection._weaviate_version, factor=1
+    )
 
     if collection._connection._weaviate_version.is_at_least(1, 24, 25):
         assert (
@@ -1605,7 +1617,9 @@ def test_replication_config_with_async_config(collection_factory: CollectionFact
     )
     config = collection.config.get()
     assert config.replication_config.factor == 1
-    assert config.replication_config.async_enabled is True
+    assert config.replication_config.async_enabled is _expected_async_enabled(
+        collection._connection._weaviate_version, factor=1
+    )
     assert config.replication_config.async_config is not None
     ac = config.replication_config.async_config
     assert ac.propagation_concurrency == 4
@@ -1672,7 +1686,9 @@ def test_replication_config_remove_async_config(collection_factory: CollectionFa
         ),
     )
     config = collection.config.get()
-    assert config.replication_config.async_enabled is True
+    assert config.replication_config.async_enabled is _expected_async_enabled(
+        collection._connection._weaviate_version, factor=1
+    )
     assert config.replication_config.async_config is None
     assert config.replication_config.factor == 1
 


### PR DESCRIPTION
## Summary

Moves the integration-test matrix from `$WEAVIATE_136` (1.36.12) to a new `$WEAVIATE_139` (1.39.0-rc.0) and adds the version to the `test-package` matrix.

This is split out of #1991 so that the version bump and its fallout can be reviewed on their own, rather than mixed into the alter-schema drop-vector-index feature. #1991 is stacked on top of this branch.

## Why now

The drop-vector-index endpoint only exists from 1.39, so its tests cannot run in CI until the matrix moves. Independently, the matrix has been sitting on 1.36.x while `$WEAVIATE_137` was already defined, so a range of version-gated tests never actually executed — 56 more tests run at 1.39 than at 1.36.12 (1072 passed vs 1016).

## Pinned tag

There is no plain `1.39.0-rc.0` tag on Docker Hub yet, only commit-suffixed builds, so the newest one is pinned following the existing `WEAVIATE_137` convention. Worth swapping for the clean tag once the RC is published.

## Test change

One existing test needed adapting to an intentional server change. From 1.39 `asyncEnabled` is no longer stored per class but derived server-side as `factor > 1 && !globallyDisabled` (`adapters/handlers/rest/restcompat/wrappers.go`). Three assertion sites use a replication factor of 1 and therefore now expect `False`.

Rather than sprinkling version checks, the scattered `is_at_least(1, 26, 0)` branches are replaced by one `_expected_async_enabled(version, factor)` helper that encodes both the old and new server behaviour. The two sites using `factor=2` are unaffected — `factor > 1` still yields `True` there — and are left alone.

No coverage is removed: the pre-1.39 expectations remain asserted on older servers.

## Verification

The full integration suite was run against 1.36.12 and against 1.39.0-rc.0 on an otherwise identical local stack built from `ci/docker-compose.yml`. Both produce **identical failure sets** (109 entries, all from compose instances not available locally), so the bump introduces no regressions in the ~1000 tests that environment can exercise.

Two caveats for reviewers:
- Tests requiring the other compose instances (RBAC, cluster, proxy, okta, backup, namespaces) failed identically at both versions and were effectively not compared. CI is the first real check on those.
- The comparison was run on ARM using the `.arm64` image variants; CI uses the `.amd64` tags pinned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)