### PR TITLE
Fix Sequence[Union[...]] validation only requiring one element to match

### DIFF
--- a/test/collection/test_validator.py
+++ b/test/collection/test_validator.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -32,6 +32,31 @@ from weaviate.validator import _ExtraTypes, _validate_input, _ValidateArgument
     ],
 )
 def test_validator(inputs: Any, expected: List[Any], error: bool) -> None:
+    if error:
+        with pytest.raises(WeaviateInvalidInputError):
+            _validate_input(_ValidateArgument(expected=expected, name="test", value=inputs))
+    else:
+        _validate_input(_ValidateArgument(expected=expected, name="test", value=inputs))
+
+
+@pytest.mark.parametrize(
+    "inputs,expected,error",
+    [
+        # every element matches one of the union members -> valid
+        (["a", 1, "b", 2], [Sequence[Union[str, int]]], False),
+        (["a", "b"], [Sequence[Union[str, int]]], False),
+        ([1, 2], [Sequence[Union[str, int]]], False),
+        # one element (a float) matches neither union member -> must be rejected.
+        # regression test: the old implementation flattened the per-element check
+        # into a single any() across (value, union_arg) pairs, so it only took one
+        # element matching one type to pass the whole sequence, even if other
+        # elements didn't match anything.
+        (["a", 3.14], [Sequence[Union[str, int]]], True),
+        ([3.14, "a"], [Sequence[Union[str, int]]], True),
+        ([1, 3.14], [Sequence[Union[str, int]]], True),
+    ],
+)
+def test_validator_sequence_of_union(inputs: Any, expected: List[Any], error: bool) -> None:
     if error:
         with pytest.raises(WeaviateInvalidInputError):
             _validate_input(_ValidateArgument(expected=expected, name="test", value=inputs))

--- a/weaviate/validator.py
+++ b/weaviate/validator.py
@@ -56,7 +56,9 @@ def _is_valid(expected: Any, value: Any) -> bool:
         if len(args) == 1:
             if get_origin(args[0]) is Union:
                 union_args = get_args(args[0])
-                return any(isinstance(val, union_arg) for val in value for union_arg in union_args)
+                return all(
+                    any(isinstance(val, union_arg) for union_arg in union_args) for val in value
+                )
             else:
                 return all(isinstance(val, args[0]) for val in value)
     # bool is a subclass of int, so isinstance(True, int) is True. Reject a


### PR DESCRIPTION
## Bug

`_is_valid`'s `Sequence[Union[X, Y]]` branch flattens the per-element check into a single `any()` across (value, union_arg) pairs:

```python
return any(isinstance(val, union_arg) for val in value for union_arg in union_args)
```

This means validation passes as soon as **one** element matches **one** type in the union, regardless of whether the other elements match anything at all:

```python
>>> _is_valid(Sequence[Union[str, int]], ["a", 3.14])
True  # should be False - 3.14 is neither str nor int
```

## Where this is user-facing

`weaviate/collections/tenants/executor.py` validates `tenants` against `Sequence[Union[str, Tenant, ...]]` in add/remove/update/upsert. A list mixing a valid tenant name/object with something invalid (an accidental int, a stray dict, etc.) currently passes this validation silently and gets forwarded into request-building instead of failing fast with a clear `WeaviateInvalidInputError` - the exact thing this validation exists to catch.

## Fix

Require every element to match at least one union member: `all(any(...) for val in value)`, matching the existing (correct) logic already used two lines below for the non-Union `Sequence[X]` branch.

## Testing

Added regression tests in `test/collection/test_validator.py`. Verified they fail against the pre-fix code (3 failures, confirming they actually exercise the bug) and pass with the fix. Full `test_validator.py` file: 19/19 passing.