### PR TITLE
fix(collections): re-raise non-404 errors from async Collection.exists() (#2100)

### DIFF
--- a/mock_tests/test_collection.py
+++ b/mock_tests/test_collection.py
@@ -484,6 +484,26 @@ def test_collection_exists(weaviate_mock: HTTPServer) -> None:
             assert e.value.status_code == 500
 
 
+@pytest.mark.asyncio
+async def test_async_collection_exists(weaviate_mock: HTTPServer) -> None:
+    non_existing = "NonExistingCollection"
+    erroring = "ErroringCollection"
+    weaviate_mock.expect_request(f"/v1/schema/{non_existing}").respond_with_json(
+        response_json={"error": [{"message": "collection not found"}]}, status=404
+    )
+    weaviate_mock.expect_request(f"/v1/schema/{erroring}").respond_with_json(
+        response_json={"error": [{"message": "this is an error"}]}, status=500
+    )
+
+    async with weaviate.use_async_with_local(
+        port=MOCK_PORT, host=MOCK_IP, grpc_port=MOCK_PORT_GRPC, skip_init_checks=True
+    ) as client:
+        assert not await client.collections.use(non_existing).exists()
+        with pytest.raises(weaviate.exceptions.UnexpectedStatusCodeError) as e:
+            await client.collections.use(erroring).exists()
+        assert e.value.status_code == 500
+
+
 def test_grpc_client_version_header(
     metadata_capture_collection: tuple[
         weaviate.collections.Collection, MockMetadataCaptureWeaviateService

--- a/weaviate/collections/collection/async_.py
+++ b/weaviate/collections/collection/async_.py
@@ -27,6 +27,7 @@ from weaviate.collections.iterator import _IteratorInputs, _ObjectAIterator
 from weaviate.collections.query import _QueryCollectionAsync
 from weaviate.collections.tenants import _TenantsAsync
 from weaviate.connect.v4 import ConnectionAsync
+from weaviate.exceptions import UnexpectedStatusCodeError
 from weaviate.types import UUID
 
 from .base import _CollectionBase
@@ -183,8 +184,10 @@ class CollectionAsync(Generic[Properties, References], _CollectionBase[Connectio
         try:
             await self.config.get(simple=True)
             return True
-        except Exception:
-            return False
+        except UnexpectedStatusCodeError as e:
+            if e.status_code == 404:
+                return False
+            raise e
 
     async def shards(self) -> List[Shard]:
         """Get the statuses of all the shards of this collection.


### PR DESCRIPTION
Fixes #2100

### Problem

`CollectionAsync.exists()` still had a bare catch-all:

```python
async def exists(self) -> bool:
    try:
        await self.config.get(simple=True)
        return True
    except Exception:
        return False
```

so a connection error, auth failure or timeout is indistinguishable from "collection not found". The common guard

```python
if not await collection.exists():
    await client.collections.create(...)
```

therefore tries to re-create the collection whenever the server is merely unreachable, masking the outage.

#1799 reported exactly this. #1950 fixed the **sync** path in `weaviate/collections/collection/sync.py` but the async counterpart was never updated.

### Change

Mirror the sync implementation exactly — return `False` on 404, re-raise everything else:

```python
except UnexpectedStatusCodeError as e:
    if e.status_code == 404:
        return False
    raise e
```

### Test

Adds `test_async_collection_exists` to `mock_tests/test_collection.py`, following the existing `test_collection_exists` shape and the `use_async_with_local` pattern already used in `mock_tests/test_auth.py`. It asserts both branches: 404 → `False`, 500 → `UnexpectedStatusCodeError` with `status_code == 500`.

Verified locally against the mock server:

| | new test | full `mock_tests/test_collection.py` |
|---|---|---|
| main (`ae327ca`), test only | `FAILED — DID NOT RAISE UnexpectedStatusCodeError` | — |
| with this fix | `passed` | `21 passed` |

`ruff` / `ruff format` (pinned `v0.14.7`) and `flake8` are clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
