### PR TITLE
feat(backup): expose incremental_base_backup_id on BackupListReturn (#2069)

### DIFF
--- a/test/test_backup.py
+++ b/test/test_backup.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict
+
+import pytest
+
+from weaviate.backup.backup import BackupListReturn, BackupStatus
+
+
+def _list_entry(**overrides: Any) -> Dict[str, Any]:
+    """A single item as Weaviate's ``GET /backups/{backend}`` returns it."""
+    entry: Dict[str, Any] = {
+        "id": "my-backup",
+        "classes": ["Article"],
+        "status": "SUCCESS",
+        "startedAt": "2026-08-01T10:00:00.000Z",
+        "completedAt": "2026-08-01T10:05:00.000Z",
+        "size": 1.5,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_list_return_exposes_incremental_base_backup_id() -> None:
+    backup = BackupListReturn(**_list_entry(incremental_base_backup_id="base-backup"))
+
+    assert backup.incremental_base_backup_id == "base-backup"
+    assert backup.backup_id == "my-backup"
+    assert backup.collections == ["Article"]
+    assert backup.status == BackupStatus.SUCCESS
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        pytest.param(_list_entry(), id="field_omitted"),
+        pytest.param(_list_entry(incremental_base_backup_id=None), id="field_null"),
+    ],
+)
+def test_list_return_defaults_incremental_base_backup_id_to_none(entry: Dict[str, Any]) -> None:
+    # The server omits the field for non-incremental backups, and only populates
+    # it for callers it has confirmed as root, so absent must not be an error.
+    assert BackupListReturn(**entry).incremental_base_backup_id is None

--- a/weaviate/backup/backup.py
+++ b/weaviate/backup/backup.py
@@ -104,3 +104,6 @@ class BackupListReturn(BaseModel):
     started_at: Optional[datetime] = Field(alias="startedAt", default=None)
     completed_at: Optional[datetime] = Field(alias="completedAt", default=None)
     size: float = Field(default=0)
+    # None when the backup is not incremental, and also when the server omits the
+    # field: it is only returned to callers Weaviate has confirmed as root.
+    incremental_base_backup_id: Optional[str] = Field(default=None)


### PR DESCRIPTION
Closes #2069.

### Problem

Weaviate's `GET /backups/{backend}` returns `incremental_base_backup_id` on every item — [`BackupListResponseItems0`](https://github.com/weaviate/weaviate/blob/main/entities/models/backup_list_response.go) declares it, and [`Scheduler.List`](https://github.com/weaviate/weaviate/blob/main/usecases/backup/scheduler.go) populates it for callers the handler has confirmed as root.

`BackupListReturn` doesn't declare the field, so `executor.list_backups()` (`BackupListReturn(**entry)`) silently drops it. There is currently no way to tell from `client.backup.list_backups(...)` which base backup an incremental backup was built on — the only alternative is a `get_create_status()` round trip per backup.

### Change

One field on `BackupListReturn`:

```python
incremental_base_backup_id: Optional[str] = Field(default=None)
```

The JSON key is snake_case server-side (`json:"incremental_base_backup_id,omitempty"`), so it matches the field name and needs no alias. `Optional[str]` with `default=None` is deliberate rather than a required field: the server omits the key for non-incremental backups, and also for any caller it has not confirmed as root, so its absence must stay non-fatal.

Nothing else changes — no alias on an existing field is touched, and no other model is affected.

### Verification

`test/test_backup.py` (new, no server or network needed):

- the field is surfaced when the server sends it, alongside the existing fields
- it defaults to `None` both when the key is omitted and when it is explicitly `null`

Run against the real package with only `weaviate/backup/backup.py` swapped:

```
before the change   3 failed   (AttributeError: 'BackupListReturn' object has no attribute 'incremental_base_backup_id')
after the change    3 passed
```

Also confirmed `BackupListReturn(**entry)` still parses an entry that has no `incremental_base_backup_id` key — the pre-existing behaviour is unchanged.

Lint, at the versions pinned in `.pre-commit-config.yaml` / `main.yaml`, over both changed files:

```
ruff 0.14.7 check             All checks passed!
ruff 0.14.7 format --diff     2 files already formatted
flake8 7.3.0 (+bugbear 24.12.12, comprehensions 3.17.0, builtins 3.0.0, docstrings 1.7.0, pydoclint 0.7.3)   clean
```

`test/` is outside the pyright matrix (`weaviate`, `integration`, `integration_embedded`) and is covered by the unit-tests job.

### Note

I left `docs/changelog.rst` alone since it only carries released versions and no `Unreleased` section — happy to add an entry under whichever version you're cutting if you'd prefer it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
