### PR TITLE
feat(config): add multi2vec-twelvelabs vectorizer support (#2113)

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -2262,6 +2262,28 @@ TEST_CONFIG_WITH_VECTORS_PARAMETERS = [
         },
     ),
     (
+        [
+            Configure.Vectors.multi2vec_twelvelabs(
+                name="test",
+                image_fields=["image"],
+                text_fields=["prop"],
+                model="marengo3.0",
+            )
+        ],
+        {
+            "test": {
+                "vectorizer": {
+                    "multi2vec-twelvelabs": {
+                        "imageFields": ["image"],
+                        "textFields": ["prop"],
+                        "model": "marengo3.0",
+                    }
+                },
+                "vectorIndexType": "hnsw",
+            }
+        },
+    ),
+    (
         [Configure.Vectors.multi2vec_jinaai(name="test", dimensions=256, text_fields=["prop"])],
         {
             "test": {

--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -110,6 +110,7 @@ class Vectorizers(str, Enum):
         MULTI2VEC_BIND: Weaviate module backed by the ImageBind model for images, text, audio, depth, IMU, thermal, and video.
         MULTI2VEC_VOYAGEAI: Weaviate module backed by a Voyage AI multimodal embedding models.
         MULTI2VEC_NVIDIA: Weaviate module backed by NVIDIA multimodal embedding models.
+        MULTI2VEC_TWELVELABS: Weaviate module backed by TwelveLabs multimodal embedding models.
         REF2VEC_CENTROID: Weaviate module backed by a centroid-based model that calculates an object's vectors from its referenced vectors.
     """
 
@@ -144,6 +145,7 @@ class Vectorizers(str, Enum):
     MULTI2VEC_PALM = "multi2vec-palm"  # change to google once 1.27 is the lowest supported version
     MULTI2VEC_VOYAGEAI = "multi2vec-voyageai"
     MULTI2VEC_NVIDIA = "multi2vec-nvidia"
+    MULTI2VEC_TWELVELABS = "multi2vec-twelvelabs"
     REF2VEC_CENTROID = "ref2vec-centroid"
 
 
@@ -611,6 +613,20 @@ class _Multi2VecNvidiaConfig(_Multi2VecBase):
     baseURL: Optional[AnyHttpUrl]
     model: Optional[str]
     truncation: Optional[bool]
+
+    def _to_dict(self) -> Dict[str, Any]:
+        ret_dict = super()._to_dict()
+        if self.baseURL is not None:
+            ret_dict["baseURL"] = self.baseURL.unicode_string()
+        return ret_dict
+
+
+class _Multi2VecTwelvelabsConfig(_Multi2VecBase):
+    vectorizer: Union[Vectorizers, _EnumLikeStr] = Field(
+        default=Vectorizers.MULTI2VEC_TWELVELABS, frozen=True, exclude=True
+    )
+    baseURL: Optional[AnyHttpUrl]
+    model: Optional[str]
 
     def _to_dict(self) -> Dict[str, Any]:
         ret_dict = super()._to_dict()

--- a/weaviate/collections/classes/config_vectors.py
+++ b/weaviate/collections/classes/config_vectors.py
@@ -51,6 +51,7 @@ from weaviate.collections.classes.config_vectorizers import (
     _Multi2VecGoogleConfig,
     _Multi2VecJinaConfig,
     _Multi2VecNvidiaConfig,
+    _Multi2VecTwelvelabsConfig,
     _Multi2VecVoyageaiConfig,
     _Ref2VecCentroidConfig,
     _Text2ColbertJinaAIConfig,
@@ -1305,6 +1306,42 @@ class _Vectors:
                 baseURL=base_url,
                 model=model,
                 truncation=truncation,
+                imageFields=_map_multi2vec_fields(image_fields),
+                textFields=_map_multi2vec_fields(text_fields),
+            ),
+            vector_index_config=_IndexWrappers.single(vector_index_config, quantizer),
+        )
+
+    @staticmethod
+    def multi2vec_twelvelabs(
+        *,
+        name: Optional[str] = None,
+        quantizer: Optional[_QuantizerConfigCreate] = None,
+        base_url: Optional[AnyHttpUrl] = None,
+        image_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
+        model: Optional[str] = None,
+        text_fields: Optional[Union[List[str], List[Multi2VecField]]] = None,
+        vector_index_config: Optional[_VectorIndexConfigCreate] = None,
+    ) -> _VectorConfigCreate:
+        """Create a vector using the `multi2vec-twelvelabs` module.
+
+        See the [documentation](https://weaviate.io/developers/weaviate/model-providers/twelvelabs/embeddings-multimodal)
+        for detailed usage.
+
+        Args:
+            name: The name of the vector.
+            quantizer: The quantizer to use for the vector index. If not provided, no quantization will be applied.
+            base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default.
+            image_fields: The image fields to use in vectorization.
+            model: The model to use. Defaults to `None`, which uses the server-defined default.
+            text_fields: The text fields to use in vectorization.
+            vector_index_config: The configuration for Weaviate's vector index. Use `wvc.config.Configure.VectorIndex` to create a vector index configuration. None by default
+        """
+        return _VectorConfigCreate(
+            name=name,
+            vectorizer=_Multi2VecTwelvelabsConfig(
+                baseURL=base_url,
+                model=model,
                 imageFields=_map_multi2vec_fields(image_fields),
                 textFields=_map_multi2vec_fields(text_fields),
             ),


### PR DESCRIPTION
Closes #2113.

Adds client-side support for the `multi2vec-twelvelabs` vectorizer shipping with Weaviate v1.37+.

### What's here

- `Vectorizers.MULTI2VEC_TWELVELABS` enum member (+ docstring entry)
- `_Multi2VecTwelvelabsConfig` in `config_vectorizers.py` — `baseURL` / `model` on top of `_Multi2VecBase`, with the usual `AnyHttpUrl` → string coercion in `_to_dict()`
- `Configure.Vectors.multi2vec_twelvelabs(...)` in `config_vectors.py`
- A `test_config.py` case asserting the serialized payload

The settings surface matches the issue (`model`, default `marengo3.0`; `baseURL`) and the server module's `class_settings.go`, which registers exactly `textFields` and `imageFields` as its multimodal fields — so no video/audio field parameters are exposed here.

Serialized payload for `multi2vec_twelvelabs(name="t", model="marengo3.0", base_url="https://api.twelvelabs.io/v1.3", image_fields=[Multi2VecField(name="img", weight=0.7)], text_fields=["txt"])`:

```json
{
  "vectorizer": {
    "multi2vec-twelvelabs": {
      "imageFields": ["img"],
      "textFields": ["txt"],
      "baseURL": "https://api.twelvelabs.io/v1.3",
      "model": "marengo3.0",
      "weights": {"imageFields": [0.7]}
    }
  },
  "vectorIndexType": "hnsw"
}
```

### Scope notes

Following the precedent of #1977 (`multi2vec_google_gemini`), this only adds the module to the current `Configure.Vectors` surface — not to the deprecated `Configure.Vectorizer` / `Configure.NamedVectors` surfaces. Happy to add those, an `docs/changelog.rst` entry, or an `integration/test_vectors.py` case if you'd like them in this PR.

### Verification

Ran the unit suite locally against this branch (Python 3.12, Windows):

- `test/collection/test_config.py`: **191 passed** on `main` → **192 passed** with this change (the new case).
- Full `test/`: **373 passed / 13 failed** on `main` → **374 passed / 13 failed** with this change — the same 13 pre-existing failures (`test_util.py` b64 image/file fixtures, `test_timeout.py`, and two input-validation cases), all unrelated to this change and unaffected by it.
- With the source left unpatched, the new test case fails as expected: `AttributeError: type object '_Vectors' has no attribute 'multi2vec_twelvelabs'`.
- `ruff==0.14.7` (repo `ruff.toml`): `format --check` reports 3 files already formatted; `check` passes.
- `flake8==7.3.0` with the pre-commit plugin set (bugbear / comprehensions / builtins / docstrings / pydoclint): clean on both changed source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
