### PR TITLE
feat(generative): expose api_version on Configure.Generative.azure_openai

### DIFF
--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -1059,6 +1059,7 @@ TEST_CONFIG_WITH_GENERATIVE = [
             temperature=0.5,
             top_p=0.5,
             base_url="https://api.openai.com",
+            api_version="2024-06-01",
         ),
         {
             "generative-openai": {
@@ -1070,6 +1071,7 @@ TEST_CONFIG_WITH_GENERATIVE = [
                 "temperature": 0.5,
                 "topP": 0.5,
                 "baseURL": "https://api.openai.com/",
+                "apiVersion": "2024-06-01",
             }
         },
     ),

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -535,6 +535,7 @@ class _GenerativeOpenAIConfig(_GenerativeOpenAIConfigBase):
 class _GenerativeAzureOpenAIConfig(_GenerativeOpenAIConfigBase):
     resourceName: str
     deploymentId: str
+    apiVersion: Optional[str]
 
 
 class _GenerativeCohereConfig(_GenerativeProvider):
@@ -951,6 +952,7 @@ class _Generative:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         base_url: Optional[AnyHttpUrl] = None,
+        api_version: Optional[str] = None,
     ) -> _GenerativeProvider:
         """Create a `_GenerativeAzureOpenAIConfig` object for use when performing AI generation using the `generative-openai` module.
 
@@ -966,8 +968,10 @@ class _Generative:
             temperature: The temperature to use. Defaults to `None`, which uses the server-defined default
             top_p: The top P to use. Defaults to `None`, which uses the server-defined default
             base_url: The base URL where the API request should go. Defaults to `None`, which uses the server-defined default
+            api_version: The Azure OpenAI API version to use. Defaults to `None`, which uses the server-defined default
         """
         return _GenerativeAzureOpenAIConfig(
+            apiVersion=api_version,
             baseURL=base_url,
             deploymentId=deployment_id,
             frequencyPenalty=frequency_penalty,


### PR DESCRIPTION
## What

Adds an `api_version` argument to `Configure.Generative.azure_openai()`, so the Azure OpenAI API version can be stored on the collection instead of only being passed per query.

## Why

`generative-openai` treats `apiVersion` as a class-level module setting: it is read from the collection's `moduleConfig` and validated when the class is created ([`class_settings.go`](https://github.com/weaviate/weaviate/blob/main/modules/generative-openai/config/class_settings.go)):

```go
apiVersionProperty = "apiVersion"
DefaultApiVersion  = "2024-06-01"
...
apiVersion := ic.ApiVersion()
if !ic.validateApiVersion(apiVersion) {
    return errors.Errorf("wrong Azure OpenAI apiVersion, available api versions are: %v", availableApiVersions)
}
```

The runtime side of this client already exposes it — `GenerativeConfig.azure_openai(api_version=...)` in `weaviate/collections/classes/generative.py` — but `Configure.Generative.azure_openai()` had no way to set it. The result is that a deployment pinned to a specific Azure API version has to repeat `api_version` on every generate call; anything written on the collection silently used the server default instead.

This is the same shape as `base_url` / `deployment_id` / `resource_name`: a server-side module setting the collection factory should be able to write.

## Changes

- `_GenerativeAzureOpenAIConfig` gains an `apiVersion: Optional[str]` field.
- `Configure.Generative.azure_openai()` gains an optional `api_version` argument, appended at the end of the signature so existing positional calls are unaffected. Unset stays `None`, which keeps the current behaviour (server-defined default) — nothing is emitted into `moduleConfig`.

## Tests

Extended the existing `azure_openai` case in `test/collection/test_config.py` to pass `api_version="2024-06-01"` and assert `"apiVersion": "2024-06-01"` in the produced `moduleConfig`.

```
test/collection/test_config.py    191 passed
test/                             384 passed, 2 failed, 1 skipped
```

The two failures are in `test/test_timeout.py` and are present on unpatched `main` as well (unrelated to this change). Without the `config.py` change the new test case fails to even collect: `TypeError: _Generative.azure_openai() got an unexpected keyword argument 'api_version'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
