### PR TITLE
feat: Check per-node shard status in wait_for_vector_indexing

### DIFF
--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -17,6 +17,7 @@ from weaviate.collections.classes.config import (
     DataType,
     Property,
     ReferenceProperty,
+    ShardStatus,
 )
 from weaviate.collections.classes.grpc import QueryReference
 from weaviate.collections.classes.internal import (
@@ -524,10 +525,15 @@ def test_add_1000_objects_with_async_indexing_and_wait(
     assert ret.total_count == nr_objects
 
     shards = client.collections.use(name).config.get_shards()
-    if shards[0].status:
-        assert shards[0].status == "READY"
-    elif shards[0].per_node_status:
-        assert all(status == "READY" for status in shards[0].per_node_status.values())
+    assert shard_status_is(shards[0], "READY")
+
+
+def shard_status_is(shard: ShardStatus, want: str) -> bool:
+    if shard.per_node_status:
+        return all(status == want for status in shard.per_node_status.values())
+    elif shard.status:
+        return shard.status == want
+    return False
 
 
 @pytest.mark.skip("Difficult to find numbers that work reliably in the CI")
@@ -547,11 +553,7 @@ def test_add_10000_objects_with_async_indexing_and_dont_wait(
                 vector=[float((j + i) % nr_objects) / nr_objects for j in range(vec_length)],
             )
     shard_status = old_client.schema.get_class_shards(name)
-    if shard_status[0].status:
-        assert shard_status[0].status == "INDEXING"
-    elif shard_status[0].per_node_status:
-        assert all(status == "INDEXING" for status in shard_status[0].per_node_status.values())
-
+    assert shard_status_is(shard_status[0], "INDEXING")
     assert len(client.batch.failed_objects) == 0
 
     ret = client.collections.use(name).aggregate.over_all(total_count=True)
@@ -583,10 +585,7 @@ def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_all(
 
     shards = client.collections.use(name).config.get_shards()
     for shard in shards:
-        if shard.status:
-            assert shard.status == "READY"
-        elif shard.per_node_status:
-            assert all(status == "READY" for status in shard.per_node_status.values())
+        assert shard_status_is(shard, "READY")
 
 
 @pytest.mark.skip("Difficult to find numbers that work reliably in the CI")
@@ -618,10 +617,7 @@ def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_only_one(
     shards = client.collections.use(name).config.get_shards()
     for shard in shards:
         want = "READY" if shard.name == tenants[0].name else "INDEXING"
-        if shard.status:
-            assert shard.status == want
-        elif shard.per_node_status:
-            assert all(status == want for status in shard.per_node_status.values())
+        assert shard_status_is(shard, want)
 
 
 @pytest.mark.parametrize(

--- a/integration/test_batch_v4.py
+++ b/integration/test_batch_v4.py
@@ -524,8 +524,10 @@ def test_add_1000_objects_with_async_indexing_and_wait(
     assert ret.total_count == nr_objects
 
     shards = client.collections.use(name).config.get_shards()
-    assert shards[0].status == "READY"
-    assert shards[0].vector_queue_size == 0
+    if shards[0].status:
+        assert shards[0].status == "READY"
+    elif shards[0].per_node_status:
+        assert all(status == "READY" for status in shards[0].per_node_status.values())
 
 
 @pytest.mark.skip("Difficult to find numbers that work reliably in the CI")
@@ -545,8 +547,10 @@ def test_add_10000_objects_with_async_indexing_and_dont_wait(
                 vector=[float((j + i) % nr_objects) / nr_objects for j in range(vec_length)],
             )
     shard_status = old_client.schema.get_class_shards(name)
-    assert shard_status[0]["status"] == "INDEXING"
-    assert shard_status[0]["vectorQueueSize"] > 0
+    if shard_status[0].status:
+        assert shard_status[0].status == "INDEXING"
+    elif shard_status[0].per_node_status:
+        assert all(status == "INDEXING" for status in shard_status[0].per_node_status.values())
 
     assert len(client.batch.failed_objects) == 0
 
@@ -579,8 +583,10 @@ def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_all(
 
     shards = client.collections.use(name).config.get_shards()
     for shard in shards:
-        assert shard.status == "READY"
-        assert shard.vector_queue_size == 0
+        if shard.status:
+            assert shard.status == "READY"
+        elif shard.per_node_status:
+            assert all(status == "READY" for status in shard.per_node_status.values())
 
 
 @pytest.mark.skip("Difficult to find numbers that work reliably in the CI")
@@ -611,12 +617,11 @@ def test_add_1000_tenant_objects_with_async_indexing_and_wait_for_only_one(
 
     shards = client.collections.use(name).config.get_shards()
     for shard in shards:
-        if shard.name == tenants[0].name:
-            assert shard.status == "READY"
-            assert shard.vector_queue_size == 0
-        else:
-            assert shard.status == "INDEXING"
-            assert shard.vector_queue_size > 0
+        want = "READY" if shard.name == tenants[0].name else "INDEXING"
+        if shard.status:
+            assert shard.status == want
+        elif shard.per_node_status:
+            assert all(status == want for status in shard.per_node_status.values())
 
 
 @pytest.mark.parametrize(

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -787,10 +787,10 @@ def test_collection_config_get_shards(collection_factory: CollectionFactory) -> 
     )
     shards = collection.config.get_shards()
     assert len(shards)
-    if shards[0].status:
-        assert shards[0].status == "READY"
-    elif shards[0].per_node_status:
+    if shards[0].per_node_status:
         assert all(status == "READY" for status in shards[0].per_node_status.values())
+    elif shards[0].status:
+        assert shards[0].status == "READY"
 
 
 def test_collection_update_shards(collection_factory: CollectionFactory) -> None:
@@ -839,10 +839,10 @@ def test_collection_config_get_shards_multi_tenancy(collection_factory: Collecti
     assert len(shards) == 2
 
     for shard in shards:
-        if shard.status:
-            assert shard.status == "READY"
-        elif shard.per_node_status:
+        if shard.per_node_status:
             assert all(status == "READY" for status in shard.per_node_status.values())
+        elif shard.status:
+            assert shard.status == "READY"
 
     assert "tenant1" in [shard.name for shard in shards]
     assert "tenant2" in [shard.name for shard in shards]

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -789,7 +789,7 @@ def test_collection_config_get_shards(collection_factory: CollectionFactory) -> 
     assert len(shards)
     if shards[0].per_node_status:
         assert all(status == "READY" for status in shards[0].per_node_status.values())
-    elif shards[0].status:
+    else:
         assert shards[0].status == "READY"
 
 
@@ -841,7 +841,7 @@ def test_collection_config_get_shards_multi_tenancy(collection_factory: Collecti
     for shard in shards:
         if shard.per_node_status:
             assert all(status == "READY" for status in shard.per_node_status.values())
-        elif shard.status:
+        else:
             assert shard.status == "READY"
 
     assert "tenant1" in [shard.name for shard in shards]

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -787,8 +787,10 @@ def test_collection_config_get_shards(collection_factory: CollectionFactory) -> 
     )
     shards = collection.config.get_shards()
     assert len(shards)
-    assert shards[0].status == "READY"
-    assert shards[0].vector_queue_size == 0
+    if shards[0].status:
+        assert shards[0].status == "READY"
+    elif shards[0].per_node_status:
+        assert all(status == "READY" for status in shards[0].per_node_status.values())
 
 
 def test_collection_update_shards(collection_factory: CollectionFactory) -> None:

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -800,7 +800,12 @@ def test_collection_update_shards(collection_factory: CollectionFactory) -> None
     )
 
     collection.tenants.create([Tenant(name="tenant1"), Tenant(name="tenant2")])
-    assert all(shard.status == "READY" for shard in collection.config.get_shards())
+    assert all(
+        all(per_node == "READY" for per_node in shard.per_node_status)
+        if shard.per_node_status
+        else shard.status == "READY"
+        for shard in collection.config.get_shards()
+    )
 
     # all possibilites of calling the function
     updated_shards = collection.config.update_shards(status="READONLY", shard_names="tenant1")

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -838,11 +838,11 @@ def test_collection_config_get_shards_multi_tenancy(collection_factory: Collecti
     shards = collection.config.get_shards()
     assert len(shards) == 2
 
-    assert shards[0].status == "READY"
-    assert shards[0].vector_queue_size == 0
-
-    assert shards[1].status == "READY"
-    assert shards[1].vector_queue_size == 0
+    for shard in shards:
+        if shard.status:
+            assert shard.status == "READY"
+        elif shard.per_node_status:
+            assert all(status == "READY" for status in shard.per_node_status.values())
 
     assert "tenant1" in [shard.name for shard in shards]
     assert "tenant2" in [shard.name for shard in shards]

--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -789,8 +789,7 @@ def test_collection_config_get_shards(collection_factory: CollectionFactory) -> 
     assert len(shards)
     if shards[0].per_node_status:
         assert all(status == "READY" for status in shards[0].per_node_status.values())
-    else:
-        assert shards[0].status == "READY"
+    assert shards[0].status == "READY"
 
 
 def test_collection_update_shards(collection_factory: CollectionFactory) -> None:
@@ -800,12 +799,10 @@ def test_collection_update_shards(collection_factory: CollectionFactory) -> None
     )
 
     collection.tenants.create([Tenant(name="tenant1"), Tenant(name="tenant2")])
-    assert all(
-        all(per_node == "READY" for per_node in shard.per_node_status)
-        if shard.per_node_status
-        else shard.status == "READY"
-        for shard in collection.config.get_shards()
-    )
+    for shard in collection.config.get_shards():
+        if shard.per_node_status:
+            assert all(per_node == "READY" for per_node in shard.per_node_status)
+        assert shard.status == "READY"
 
     # all possibilites of calling the function
     updated_shards = collection.config.update_shards(status="READONLY", shard_names="tenant1")
@@ -846,8 +843,7 @@ def test_collection_config_get_shards_multi_tenancy(collection_factory: Collecti
     for shard in shards:
         if shard.per_node_status:
             assert all(status == "READY" for status in shard.per_node_status.values())
-        else:
-            assert shard.status == "READY"
+        assert shard.status == "READY"
 
     assert "tenant1" in [shard.name for shard in shards]
     assert "tenant2" in [shard.name for shard in shards]

--- a/weaviate/collections/batch/batch_wrapper.py
+++ b/weaviate/collections/batch/batch_wrapper.py
@@ -98,9 +98,7 @@ class _BatchWrapper:
             (
                 all(
                     status == "READY"
-                    for status in cast(
-                        dict[str, str], shard["per_node_status"]
-                    ).values()
+                    for status in cast(dict[str, str], shard["per_node_status"]).values()
                 )
                 if "per_node_status" in shard
                 else cast(str, shard["status"]) == "READY"
@@ -207,9 +205,7 @@ class _BatchWrapperAsync:
             (
                 all(
                     status == "READY"
-                    for status in cast(
-                        dict[str, str], shard["per_node_status"]
-                    ).values()
+                    for status in cast(dict[str, str], shard["per_node_status"]).values()
                 )
                 if "per_node_status" in shard
                 else cast(str, shard["status"]) == "READY"

--- a/weaviate/collections/batch/batch_wrapper.py
+++ b/weaviate/collections/batch/batch_wrapper.py
@@ -93,9 +93,18 @@ class _BatchWrapper:
 
         res = _decode_json_response_list(response, "Get shards' status")
         assert res is not None
+
         return [
-            (cast(str, shard.get("status")) == "READY")
-            & (cast(int, shard.get("vectorQueueSize")) == 0)
+            (
+                all(
+                    status == "READY"
+                    for status in cast(
+                        dict[str, str], shard["per_node_status"]
+                    ).values()
+                )
+                if "per_node_status" in shard
+                else cast(str, shard["status"]) == "READY"
+            )
             for shard in res
         ]
 
@@ -195,8 +204,16 @@ class _BatchWrapperAsync:
         res = _decode_json_response_list(response, "Get shards' status")
         assert res is not None
         return [
-            (cast(str, shard.get("status")) == "READY")
-            & (cast(int, shard.get("vectorQueueSize")) == 0)
+            (
+                all(
+                    status == "READY"
+                    for status in cast(
+                        dict[str, str], shard["per_node_status"]
+                    ).values()
+                )
+                if "per_node_status" in shard
+                else cast(str, shard["status"]) == "READY"
+            )
             for shard in res
         ]
 

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -2252,7 +2252,7 @@ ShardTypes = Literal["READONLY", "READY", "INDEXING"]
 class _ShardStatus:
     name: str
     status: ShardTypes
-    vector_queue_size: Optional[int]
+    vector_queue_size: int
     per_node_status: Optional[Dict[str, str]]
 
 

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -2251,7 +2251,7 @@ ShardTypes = Literal["READONLY", "READY", "INDEXING"]
 @dataclass
 class _ShardStatus:
     name: str
-    status: Optional[ShardTypes]
+    status: ShardTypes
     vector_queue_size: Optional[int]
     per_node_status: Optional[Dict[str, str]]
 

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -2251,8 +2251,9 @@ ShardTypes = Literal["READONLY", "READY", "INDEXING"]
 @dataclass
 class _ShardStatus:
     name: str
-    status: ShardTypes
-    vector_queue_size: int
+    status: Optional[ShardTypes]
+    vector_queue_size: Optional[int]
+    per_node_status: Optional[Dict[str, str]]
 
 
 ShardStatus = _ShardStatus

--- a/weaviate/collections/config/executor.py
+++ b/weaviate/collections/config/executor.py
@@ -366,7 +366,7 @@ class _ConfigCollectionExecutor(Generic[ConnectionType]):
                 _ShardStatus(
                     name=shard["name"],
                     status=shard.get("status", ""),
-                    vector_queue_size=None,
+                    vector_queue_size=shard["vectorQueueSize"],
                     per_node_status=shard.get("per_node_status"),
                 )
                 for shard in shards

--- a/weaviate/collections/config/executor.py
+++ b/weaviate/collections/config/executor.py
@@ -365,8 +365,9 @@ class _ConfigCollectionExecutor(Generic[ConnectionType]):
             return [
                 _ShardStatus(
                     name=shard["name"],
-                    status=shard["status"],
-                    vector_queue_size=shard["vectorQueueSize"],
+                    status=shard.get("status"),
+                    vector_queue_size=None,
+                    per_node_status=shard.get("per_node_status"),
                 )
                 for shard in shards
             ]

--- a/weaviate/collections/config/executor.py
+++ b/weaviate/collections/config/executor.py
@@ -365,7 +365,7 @@ class _ConfigCollectionExecutor(Generic[ConnectionType]):
             return [
                 _ShardStatus(
                     name=shard["name"],
-                    status=shard.get("status"),
+                    status=shard.get("status", ""),
                     vector_queue_size=None,
                     per_node_status=shard.get("per_node_status"),
                 )


### PR DESCRIPTION
[This PR](https://github.com/weaviate/weaviate/pull/12518) is going to deprecate `shard.status` and `shard.vectorQueueSize` fields and introduce `per_node_status` in its stead. We need to update `wait_for_vector_indexing` to use this information when waiting for shards to get READY.