### PR TITLE
Document vectorize_collection_name as having no effect on multi2vec factories

### DIFF
--- a/weaviate/collections/classes/config_vectorizers.py
+++ b/weaviate/collections/classes/config_vectorizers.py
@@ -698,7 +698,7 @@ class _Vectorizer:
             image_fields: The image fields to use in vectorization.
             text_fields: The text fields to use in vectorization.
             inference_url: The inference url to use where API requests should go. Defaults to `None`, which uses the server-defined default.
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            vectorize_collection_name: Deprecated, has no effect.
 
         Raises:
             pydantic.ValidationError: If `image_fields` or `text_fields` are not `None` or a `list`.
@@ -745,7 +745,7 @@ class _Vectorizer:
             text_fields: The text fields to use in vectorization.
             thermal_fields: The thermal fields to use in vectorization.
             video_fields: The video fields to use in vectorization.
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            vectorize_collection_name: Deprecated, has no effect.
 
         Raises:
             pydantic.ValidationError: If any of the `*_fields` are not `None` or a `list`.
@@ -926,7 +926,7 @@ class _Vectorizer:
         Args:
             model: The model to use. Defaults to `None`, which uses the server-defined default.
             truncate: The truncation strategy to use. Defaults to `None`, which uses the server-defined default.
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            vectorize_collection_name: Deprecated, has no effect.
             base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default.
             image_fields: The image fields to use in vectorization.
             text_fields: The text fields to use in vectorization.
@@ -1331,7 +1331,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
             dimensions: The number of dimensions to use. Defaults to `None`, which uses the server-defined default.
             model_id: The model ID to use. Defaults to `None`, which uses the server-defined default.
             video_interval_seconds: Length of a video interval. Defaults to `None`, which uses the server-defined default.
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            vectorize_collection_name: Deprecated, has no effect.
 
         Raises:
             pydantic.ValidationError: If `api_endpoint` is not a valid URL.
@@ -1374,7 +1374,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
             video_fields: The video fields to use in vectorization.
             model_id: The model ID to use. Defaults to `None`, which uses the server-defined default.
             video_interval_seconds: Length of a video interval. Defaults to `None`, which uses the server-defined default.
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            vectorize_collection_name: Deprecated, has no effect.
 
         Raises:
             pydantic.ValidationError: If `api_endpoint` is not a valid URL.
@@ -1469,7 +1469,7 @@ This method is deprecated and will be removed in Q2 '25. Please use :meth:`~weav
 
         Args:
             model: The model to use. Defaults to `None`, which uses the server-defined default.
-            vectorize_collection_name: Whether to vectorize the collection name. Defaults to `True`.
+            vectorize_collection_name: Deprecated, has no effect.
             base_url: The base URL to use where API requests should go. Defaults to `None`, which uses the server-defined default.
             dimensions: The number of dimensions for the generated embeddings (only available for some models). Defaults to `None`, which uses the server-defined default.
             image_fields: The image fields to use in vectorization.


### PR DESCRIPTION
All eight `multi2vec_*` factories accept `vectorize_collection_name` and none of them uses it. Each one drops the argument before building its config object, so it never reaches the server. `multi2vec_voyageai` and `multi2vec_nvidia` already document it as "Deprecated, has no effect." This applies that same wording to the other six (clip, bind, cohere, palm, google, jinaai). Docstrings only, no signature or behaviour change.

Right now a caller reads "Whether to vectorize the collection name. Defaults to `True`", passes `False`, and gets neither a change nor a warning.

Server side, no multi2vec module reads the setting either, checked against weaviate/weaviate at e5bee97. The reader is `BaseClassSettings.VectorizeClassName()`, which the multi2vec modules do inherit. Its two production consumers sit on paths those modules never enter. `ValidateIndexState` is reachable only from `BaseClassSettings.Validate`, and every multi2vec module implements its own `Validate()` calling `ValidateMultiModal`. The other, `TextsWithTitleProperty` in `object_texts.go`, is called by text2vec-google, `ObjectVectorizer.Texts` and batchtext. Six multi2vec modules construct an `ObjectVectorizer` and never call a method on it. Across the ten modules' 112 Go files, every occurrence of `VectorizeClassName` is a default constant, not a read.

Verified with the pinned ruff 0.14.7 (check and format both clean), and `test/collection/test_vectorizer.py` plus `test/collection/test_config.py`, 193 passed. No running server was used, so the server half is source-level only.

Low severity. Nothing breaks, it just misleads.

If you would rather warn at runtime than only document it, `Dep029` in `weaviate/warnings.py` is the existing pattern, though it needs the default to become a sentinel so an explicit argument can be told from the default. Happy to do that instead.

Context and the full trace are in #2106, which was opened from our small studio's account (@toolshedlabs-hash). I run that studio, and I'm filing the fix from my personal account.
