### PR TITLE
Fix batch rate-limit scheduling for partial batches

### DIFF
--- a/test/collection/test_batch.py
+++ b/test/collection/test_batch.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 
+from weaviate.collections.batch.base import _RateLimitedBatching
 from weaviate.collections.batch.grpc_batch import _validate_props
 from weaviate.collections.classes.batch import (
     MAX_STORED_RESULTS,
@@ -33,6 +34,29 @@ def _error_reference(index: int) -> ErrorReference:
             index=index,
         ),
     )
+
+
+@pytest.mark.parametrize(
+    ("number_objects", "elapsed_time", "expected_sleep_time"),
+    [
+        (500, 0, 31),
+        (100, 0, 6.2),
+        (100, 2, 4.2),
+        (100, -62, 68.2),
+        (100, 7, 0),
+        (0, 0, 0),
+    ],
+)
+def test_rate_limited_batching_sleep_time_uses_previous_batch_size(
+    number_objects: int, elapsed_time: float, expected_sleep_time: float
+) -> None:
+    batching = _RateLimitedBatching(requests_per_minute=1000)
+
+    assert batching.get_sleep_time(
+        number_objects=number_objects,
+        elapsed_time=elapsed_time,
+        base_time=62,
+    ) == pytest.approx(expected_sleep_time)
 
 
 def test_batch_object_return_add() -> None:

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -257,6 +257,10 @@ class _FixedSizeBatching:
 class _RateLimitedBatching:
     requests_per_minute: int
 
+    def get_sleep_time(self, number_objects: int, elapsed_time: float, base_time: float) -> float:
+        batch_interval = base_time * number_objects / self.requests_per_minute
+        return max(batch_interval - elapsed_time, 0)
+
 
 @dataclass
 class _ServerSideBatching:
@@ -346,6 +350,7 @@ class _BatchBase:
 
         # fixed rate batching
         self.__time_stamp_last_request: float = 0
+        self.__num_objects_in_previous_batch: int = 0
         # do 62 secs to give us some buffer to the "per-minute" calculation
         self.__fix_rate_batching_base_time = 62
 
@@ -395,11 +400,13 @@ class _BatchBase:
             and not self.__shut_background_thread_down.is_set()
         ):
             if isinstance(self.__batching_mode, _RateLimitedBatching):
-                if (
-                    time.time() - self.__time_stamp_last_request
-                    < self.__fix_rate_batching_base_time // self.__concurrent_requests
-                ):
-                    time.sleep(1)
+                sleep_time = self.__batching_mode.get_sleep_time(
+                    number_objects=self.__num_objects_in_previous_batch,
+                    elapsed_time=time.time() - self.__time_stamp_last_request,
+                    base_time=self.__fix_rate_batching_base_time,
+                )
+                if sleep_time > 0:
+                    time.sleep(min(sleep_time, 1))
                     continue
                 refresh_time = 0
             elif isinstance(self.__batching_mode, _DynamicBatching) and self.__vectorizer_batching:
@@ -415,7 +422,8 @@ class _BatchBase:
                 self.__active_requests < self.__concurrent_requests
                 and len(self.__batch_objects) + len(self.__batch_references) > 0
             ):
-                self.__time_stamp_last_request = time.time()
+                if not isinstance(self.__batching_mode, _RateLimitedBatching):
+                    self.__time_stamp_last_request = time.time()
 
                 self._batch_send = True
                 with self.__active_requests_lock:
@@ -444,6 +452,12 @@ class _BatchBase:
                     self.__recommended_num_refs,
                     uuid_lookup=self.__uuid_lookup,
                 )
+                if isinstance(self.__batching_mode, _RateLimitedBatching):
+                    # Preserve a future timestamp set by a concurrent rate-limit retry.
+                    self.__time_stamp_last_request = max(
+                        self.__time_stamp_last_request, time.time()
+                    )
+                    self.__num_objects_in_previous_batch = len(objs)
                 # do not block the thread - the results are written to a central (locked) list and we want to have multiple concurrent batch-requests
                 ctx = contextvars.copy_context()
                 self.__executor.submit(

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -350,6 +350,7 @@ class _BatchBase:
 
         # fixed rate batching
         self.__time_stamp_last_request: float = 0
+        # No previous batch exists yet, so zero lets the first batch dispatch immediately.
         self.__num_objects_in_previous_batch: int = 0
         # do 62 secs to give us some buffer to the "per-minute" calculation
         self.__fix_rate_batching_base_time = 62

--- a/weaviate/collections/batch/base.py
+++ b/weaviate/collections/batch/base.py
@@ -41,6 +41,7 @@ from weaviate.connect.v4 import ConnectionAsync, ConnectionSync
 from weaviate.exceptions import (
     EmptyResponseException,
     WeaviateBatchValidationError,
+    WeaviateInvalidInputError,
 )
 from weaviate.logger import logger
 from weaviate.proto.v1 import batch_pb2
@@ -256,6 +257,12 @@ class _FixedSizeBatching:
 @dataclass
 class _RateLimitedBatching:
     requests_per_minute: int
+
+    def __post_init__(self) -> None:
+        if self.requests_per_minute < 1:
+            raise WeaviateInvalidInputError(
+                f"requests_per_minute must be a positive integer, got {self.requests_per_minute}"
+            )
 
     def get_sleep_time(self, number_objects: int, elapsed_time: float, base_time: float) -> float:
         batch_interval = base_time * number_objects / self.requests_per_minute

--- a/weaviate/collections/batch/client.py
+++ b/weaviate/collections/batch/client.py
@@ -252,7 +252,8 @@ class _BatchClientWrapper(_BatchWrapper):
         When you exit the context manager, the final batch will be sent automatically.
 
         Args:
-            requests_per_minute: The number of requests that the vectorizer can process per minute.
+            requests_per_minute: The number of objects to send to Weaviate per minute,
+                used to avoid exceeding the vectorizer's rate limit.
             consistency_level: The consistency level to be used to send batches. If not provided, the default value is `None`.
         """
         self._batch_mode = _RateLimitedBatching(requests_per_minute)

--- a/weaviate/collections/batch/client.py
+++ b/weaviate/collections/batch/client.py
@@ -253,7 +253,7 @@ class _BatchClientWrapper(_BatchWrapper):
 
         Args:
             requests_per_minute: The number of objects to send to Weaviate per minute,
-                used to avoid exceeding the vectorizer's rate limit.
+                used to avoid exceeding the vectorizer's rate limit. Must be a positive integer.
             consistency_level: The consistency level to be used to send batches. If not provided, the default value is `None`.
         """
         self._batch_mode = _RateLimitedBatching(requests_per_minute)

--- a/weaviate/collections/batch/collection.py
+++ b/weaviate/collections/batch/collection.py
@@ -281,7 +281,8 @@ class _BatchCollectionWrapper(Generic[Properties], _BatchWrapper):
         When you exit the context manager, the final batch will be sent automatically.
 
         Args:
-            requests_per_minute: The number of requests that the vectorizer can process per minute.
+            requests_per_minute: The number of objects to send to Weaviate per minute,
+                used to avoid exceeding the vectorizer's rate limit.
         """
         self._batch_mode = _RateLimitedBatching(requests_per_minute)
         return self.__create_batch_and_reset(_BatchCollection)

--- a/weaviate/collections/batch/collection.py
+++ b/weaviate/collections/batch/collection.py
@@ -282,7 +282,7 @@ class _BatchCollectionWrapper(Generic[Properties], _BatchWrapper):
 
         Args:
             requests_per_minute: The number of objects to send to Weaviate per minute,
-                used to avoid exceeding the vectorizer's rate limit.
+                used to avoid exceeding the vectorizer's rate limit. Must be a positive integer.
         """
         self._batch_mode = _RateLimitedBatching(requests_per_minute)
         return self.__create_batch_and_reset(_BatchCollection)


### PR DESCRIPTION
## Summary

- calculate rate-limit spacing from the number of objects actually sent in the previous batch
- record the timestamp when a rate-limited batch is dispatched, after the scheduler finishes filling it
- preserve future timestamps set by concurrent rate-limit retries
- add focused coverage for full, partial, elapsed, retry-backoff, and empty batches

## Root cause

Rate-limited batching used a fixed interval derived from the configured concurrency. A partial batch therefore incurred the same delay as a full batch, which unnecessarily reduced throughput. The request timestamp was also recorded before the scheduler's batch-filling wait.

The new interval is proportional to the previous batch's actual object count:

`base_time * objects_sent / requests_per_minute`

Full batches retain their existing spacing, while partial batches can proceed sooner without exceeding the configured object rate.

## Validation

- `pytest test/collection/test_batch.py -q` — 16 passed
- `pytest test --ignore=test/test_timeout.py -q` — 414 passed, 1 skipped
- `pytest mock_tests -q` — 56 passed
- `ruff check weaviate test mock_tests integration` — passed
- `ruff format --check weaviate test mock_tests integration` — passed
- `flake8 weaviate test mock_tests integration` — passed
- `pyright weaviate/collections/batch/base.py` — passed
- package build and `twine check` — passed
- `pytest integration/test_batch_v4.py::test_add_objects_in_multiple_batches -vv` against Weaviate 1.39.0 — passed
- live two-partial-batch probe against Weaviate 1.39.0 — 2 objects imported; second batch completed in 1.187 seconds instead of the previous approximately 62-second delay
- remaining default-server batch integration coverage — 63 passed, 3 skipped

Two async-indexing integration cases could not run locally because Windows reserves the repository's configured host port 50061. Two unrelated subprocess timeout-harness tests were excluded locally because Windows xdist termination does not forward their expected stderr text; the remaining unit suite passed.

Fixes #1100
