### PR TITLE
Fix reusable reference filter builders

### DIFF
--- a/test/collection/test_filter.py
+++ b/test/collection/test_filter.py
@@ -163,6 +163,29 @@ def test_auto_capitalize_first_letter_by_ref_multi_target() -> None:
     assert target_collection_stored == "Test"
 
 
+def test_reuse_by_ref_builder_for_independent_filters() -> None:
+    ref = Filter.by_ref("hasCategory")
+
+    name_filter = ref.by_property("name").equal("Electronics")
+    rating_filter = ref.by_property("rating").greater_than(4)
+
+    assert name_filter.target.link_on == "hasCategory"
+    assert name_filter.target.target == "name"
+    assert rating_filter.target.link_on == "hasCategory"
+    assert rating_filter.target.target == "rating"
+    assert name_filter.target is not rating_filter.target
+
+    property_filter = ref.by_property("name")
+    first_value = property_filter.equal("Electronics")
+    second_value = property_filter.equal("Appliances")
+
+    assert first_value.target.link_on == "hasCategory"
+    assert first_value.target.target == "name"
+    assert second_value.target.link_on == "hasCategory"
+    assert second_value.target.target == "name"
+    assert first_value.target is not second_value.target
+
+
 @pytest.mark.parametrize(
     "operator,want",
     [

--- a/weaviate/collections/classes/filters.py
+++ b/weaviate/collections/classes/filters.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Sequence, Union
@@ -159,7 +160,8 @@ class _FilterBase:
             return self._property
 
         # get last element in chain
-        target = self._target
+        target = deepcopy(self._target)
+        target_root = target
         while target.target is not None:
             assert isinstance(target.target, _MultiTargetRef) or isinstance(
                 target.target, _SingleTargetRef
@@ -167,7 +169,7 @@ class _FilterBase:
             target = target.target
 
         target.target = self._property
-        return self._target
+        return target_root
 
 
 class _FilterByProperty(_FilterBase):


### PR DESCRIPTION
Fixes #2143.

Reference filter targets were mutated when a terminal filter operation built its path. Reusing either the root reference builder or a derived property builder could therefore fail or reuse altered state.

Build each target path from a deep copy so independent filters do not share mutations.

Validation:
- test/collection/test_filter.py: 33 passed
- Ruff check and format passed
- compileall and diff checks passed