### PR TITLE
Accept string API keys in all connection helpers

### DIFF
--- a/test/test_connect_helpers.py
+++ b/test/test_connect_helpers.py
@@ -1,0 +1,49 @@
+import pytest
+
+from weaviate.auth import AuthApiKey
+from weaviate.client import WeaviateAsyncClient, WeaviateClient
+from weaviate.connect import helpers
+
+
+def _assert_string_api_key(client: WeaviateClient | WeaviateAsyncClient) -> None:
+    assert isinstance(client._connection._auth, AuthApiKey)
+    assert client._connection._auth.api_key == "api-key"
+
+
+def test_connect_to_custom_accepts_string_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(helpers, "__connect", lambda client: client)
+
+    client = helpers.connect_to_custom(
+        http_host="localhost",
+        http_port=8080,
+        http_secure=False,
+        grpc_host="localhost",
+        grpc_port=50051,
+        grpc_secure=False,
+        auth_credentials="api-key",
+    )
+
+    _assert_string_api_key(client)
+
+
+def test_use_async_with_weaviate_cloud_accepts_string_api_key() -> None:
+    client = helpers.use_async_with_weaviate_cloud(
+        cluster_url="example.weaviate.network",
+        auth_credentials="api-key",
+    )
+
+    _assert_string_api_key(client)
+
+
+def test_use_async_with_custom_accepts_string_api_key() -> None:
+    client = helpers.use_async_with_custom(
+        http_host="localhost",
+        http_port=8080,
+        http_secure=False,
+        grpc_host="localhost",
+        grpc_port=50051,
+        grpc_secure=False,
+        auth_credentials="api-key",
+    )
+
+    _assert_string_api_key(client)

--- a/weaviate/connect/helpers.py
+++ b/weaviate/connect/helpers.py
@@ -288,7 +288,7 @@ def connect_to_custom(
     grpc_secure: bool,
     headers: Optional[Dict[str, str]] = None,
     additional_config: Optional[AdditionalConfig] = None,
-    auth_credentials: Optional[AuthCredentials] = None,
+    auth_credentials: Union[str, AuthCredentials, None] = None,
     skip_init_checks: bool = False,
 ) -> WeaviateClient:
     """Connect to a Weaviate instance with custom connection parameters.
@@ -373,7 +373,7 @@ def __connect(client: WeaviateClient) -> WeaviateClient:
 
 def use_async_with_weaviate_cloud(
     cluster_url: str,
-    auth_credentials: Optional[AuthCredentials],
+    auth_credentials: Union[str, AuthCredentials],
     headers: Optional[Dict[str, str]] = None,
     additional_config: Optional[AdditionalConfig] = None,
     skip_init_checks: bool = False,
@@ -585,7 +585,7 @@ def use_async_with_custom(
     grpc_secure: bool,
     headers: Optional[Dict[str, str]] = None,
     additional_config: Optional[AdditionalConfig] = None,
-    auth_credentials: Optional[AuthCredentials] = None,
+    auth_credentials: Union[str, AuthCredentials, None] = None,
     skip_init_checks: bool = False,
 ) -> WeaviateAsyncClient:
     """Create an async client object ready to connect to a Weaviate instance with custom connection parameters.


### PR DESCRIPTION
## Summary
- align the remaining sync and async connection helper annotations with their documented runtime support for string API keys
- cover sync custom, async cloud, and async custom helpers without network access

Fixes #996.

## Validation
- 11 related connection and authentication tests passed
- Ruff passed
- Flake8 passed
- Pyright passed