### PR TITLE
fix: KeyError 'pq' when updating the quantizer on an HFresh vector index

### DIFF
--- a/test/collection/test_config_update.py
+++ b/test/collection/test_config_update.py
@@ -160,3 +160,73 @@ def test_replication_async_config_reset_all_fields() -> None:
     )
     result = update.merge_with_existing(schema)
     assert result["asyncConfig"] == {}
+
+
+def _hfresh_schema(rescore_limit: int = 20) -> dict:
+    """An HFresh schema, which mandates RQ and so carries no pq/bq/sq blocks."""
+    return {
+        "class": "HFreshRQ",
+        "vectorConfig": {
+            "boi": {
+                "vectorizer": {"text2vec-weaviate": {}},
+                "vectorIndexType": "hfresh",
+                "vectorIndexConfig": {
+                    "distance": "cosine",
+                    "maxPostingSizeKB": 1024,
+                    "searchProbe": 8,
+                    "rq": {"enabled": True, "bits": 1, "rescoreLimit": rescore_limit},
+                },
+            }
+        },
+    }
+
+
+def test_updating_rq_on_hfresh_without_pq_block() -> None:
+    """An HFresh schema has no pq block, so the quantizer check must not subscript it."""
+    schema = _hfresh_schema()
+    update = _CollectionConfigUpdate(
+        vector_config=Reconfigure.Vectors.update(
+            name="boi",
+            vector_index_config=Reconfigure.VectorIndex.hfresh(
+                quantizer=Reconfigure.VectorIndex.Quantizer.rq(rescore_limit=500)
+            ),
+        )
+    )
+
+    new_schema = update.merge_with_existing(schema)
+
+    assert new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["rq"]["rescoreLimit"] == 500
+    assert new_schema["vectorConfig"]["boi"]["vectorIndexConfig"]["rq"]["enabled"]
+
+
+def test_quantizer_check_tolerates_missing_pq_block() -> None:
+    """The rq branch of the quantizer check must tolerate a schema with no pq block."""
+    schema = _hfresh_schema()
+    update = _CollectionConfigUpdate(
+        vector_config=Reconfigure.Vectors.update(
+            name="boi",
+            vector_index_config=Reconfigure.VectorIndex.hfresh(
+                quantizer=Reconfigure.VectorIndex.Quantizer.rq()
+            ),
+        )
+    )
+
+    # No KeyError: rq is the quantizer already in use, so the update is allowed through.
+    update.merge_with_existing(schema)
+
+
+def test_switching_quantizer_still_rejected_when_pq_enabled() -> None:
+    """The guard itself must be unchanged for schemas that do have a pq block."""
+    schema = multi_vector_schema("pq")
+    update = _CollectionConfigUpdate(
+        vectorizer_config=[
+            Reconfigure.NamedVectors.update(
+                name="boi",
+                vector_index_config=Reconfigure.VectorIndex.hnsw(
+                    quantizer=Reconfigure.VectorIndex.Quantizer.rq()
+                ),
+            )
+        ]
+    )
+    with pytest.raises(WeaviateInvalidInputError):
+        update.merge_with_existing(schema)

--- a/weaviate/collections/classes/config.py
+++ b/weaviate/collections/classes/config.py
@@ -1563,7 +1563,7 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
             or (
                 isinstance(quantizer, _BQConfigUpdate)
                 and (
-                    vector_index_config["pq"]["enabled"]
+                    vector_index_config.get("pq", {"enabled": False})["enabled"]
                     or vector_index_config.get("sq", {"enabled": False})["enabled"]
                     or vector_index_config.get("rq", {"enabled": False})["enabled"]
                 )
@@ -1571,7 +1571,7 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
             or (
                 isinstance(quantizer, _SQConfigUpdate)
                 and (
-                    vector_index_config["pq"]["enabled"]
+                    vector_index_config.get("pq", {"enabled": False})["enabled"]
                     or vector_index_config.get("bq", {"enabled": False})["enabled"]
                     or vector_index_config.get("rq", {"enabled": False})["enabled"]
                 )
@@ -1579,7 +1579,7 @@ class _CollectionConfigUpdate(_ConfigUpdateModel):
             or (
                 isinstance(quantizer, _RQConfigUpdate)
                 and (
-                    vector_index_config["pq"]["enabled"]
+                    vector_index_config.get("pq", {"enabled": False})["enabled"]
                     or vector_index_config.get("bq", {"enabled": False})["enabled"]
                     or vector_index_config.get("sq", {"enabled": False})["enabled"]
                 )


### PR DESCRIPTION
You can't change the RQ settings on an HFresh index. Trying to update `rq.rescore_limit` fails straight away with `KeyError: 'pq'`, before the client even talks to the server. The docs say this setting can be changed at runtime, and the server does accept it if you edit the schema directly, so this is a client-side bug.

The cause is in the check that stops you from switching quantizers. When you ask to update RQ, the client first looks at whether PQ, BQ or SQ are currently switched on, since swapping quantizer types means recreating the collection. That check assumes every index has all four quantizer blocks in its schema, which is true for HNSW. HFresh always uses RQ, so its schema only has an `rq` block, and looking up `pq` throws.

Adds tests covering the HFresh case, which fail without the fix, plus one pinning that switching quantizers on HNSW is still rejected. Verified against Weaviate 1.38.7, where `rq.rescore_limit` now updates as expected.