### PR TITLE
fix: reject zero query limits

### DIFF
--- a/test/collection/test_queries.py
+++ b/test/collection/test_queries.py
@@ -3,8 +3,10 @@ from typing import Awaitable
 import pytest
 
 from weaviate.collections.query import _QueryCollectionAsync
+from weaviate.collections.grpc.query import _QueryGRPC
 from weaviate.connect import ConnectionV4
 from weaviate.exceptions import WeaviateInvalidInputError
+from weaviate.util import _ServerVersion
 
 # TODO: re-enable tests once string syntax is re-enabled in the API
 
@@ -86,6 +88,35 @@ from weaviate.exceptions import WeaviateInvalidInputError
 async def _test_query(query: Awaitable) -> None:
     with pytest.raises(WeaviateInvalidInputError):
         await query()
+
+
+def _grpc_query(validate_arguments: bool = True) -> _QueryGRPC:
+    return _QueryGRPC(
+        weaviate_version=_ServerVersion.from_string("1.38.13"),
+        name="Dummy",
+        tenant=None,
+        consistency_level=None,
+        validate_arguments=validate_arguments,
+        uses_125_api=True,
+        uses_127_api=True,
+    )
+
+
+def test_query_limit_zero_is_rejected() -> None:
+    with pytest.raises(WeaviateInvalidInputError, match="limit must be greater than zero"):
+        _grpc_query().get(limit=0)
+
+
+@pytest.mark.parametrize("limit", [None, 1])
+def test_query_limit_boundary_is_accepted(limit: int | None) -> None:
+    request = _grpc_query().get(limit=limit)
+    assert request.limit == (limit or 0)
+
+
+def test_query_limit_zero_keeps_legacy_behavior_without_validation() -> None:
+    zero = _grpc_query(validate_arguments=False).get(limit=0)
+    omitted = _grpc_query(validate_arguments=False).get()
+    assert zero.SerializeToString() == omitted.SerializeToString()
 
 
 @pytest.mark.asyncio

--- a/weaviate/collections/grpc/query.py
+++ b/weaviate/collections/grpc/query.py
@@ -45,6 +45,7 @@ from weaviate.collections.classes.internal import (
 )
 from weaviate.collections.filters import _FilterToGRPC
 from weaviate.collections.grpc.shared import _BaseGRPC
+from weaviate.exceptions import WeaviateInvalidInputError
 from weaviate.proto.v1 import base_search_pb2, search_get_pb2
 from weaviate.types import NUMBER, UUID
 from weaviate.util import _ServerVersion
@@ -470,6 +471,8 @@ class _QueryGRPC(_BaseGRPC):
                     ),
                 ]
             )
+            if limit == 0:
+                raise WeaviateInvalidInputError("Query limit must be greater than zero")
             if isinstance(return_properties, Sequence):
                 for prop in return_properties:
                     _validate_input(


### PR DESCRIPTION
## Summary

Fixes #2150.

Passing `limit=0` currently serializes the value correctly, but the server treats it as an omitted limit and returns its default page size. This is surprising because callers explicitly requested zero results.

This change rejects `limit=0` when client-side argument validation is enabled. It preserves the existing low-level wire behavior when validation is explicitly disabled.

## Tests

Added regression coverage for:

- rejecting `limit=0` with argument validation enabled;
- accepting `limit=None` and positive limits;
- preserving `limit=0` and omitted-limit serialization when validation is disabled.

Validation performed:

- `pytest test/collection/test_queries.py test/collection/test_bm25_operator.py -q` — 8 passed
- Ruff lint and format checks — passed
- Flake8 — passed
- `git diff --check` — passed

## Compatibility

This is an explicit validation behavior change only for clients using the default `validate_arguments=True`. Clients that disable validation retain the existing request serialization.

This change was implemented with AI assistance and validated with the tests listed above.
