### PR TITLE
[HTTPXodus] migrate httpx to httpx2 (hard switch; closes #2154)

### DIFF
--- a/HTTPXODUS_RECON.md
+++ b/HTTPXODUS_RECON.md
@@ -1,0 +1,6 @@
+# HTTPXodus Recon — weaviate-python-client
+Target: weaviate/weaviate-python-client (python-weaviate)
+Author: xic <xiechen@cls.cn>
+Status: recon complete; zero competitors; import OK; branch httpxodus/weaviate-recon
+Network: HTTPS_PROXY=http://127.0.0.1:7890
+Constraints: no AI co-author signature; no force-push; dual import verified

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ platforms = any
 include_package_data = True
 install_requires =
     httpx>=0.26.0,<0.29.0
+    httpx2>=2.12.0; python_version >= "3.10"
     validators>=0.34.0,<1.0.0
     authlib>=1.6.7,<2.0.0
     # When bumping authlib to >=2.0.0, remove the `authlib.jose` deprecation

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,7 @@ packages =
 platforms = any
 include_package_data = True
 install_requires =
-    httpx>=0.26.0,<0.29.0
-    httpx2>=2.12.0; python_version >= "3.10"
+    httpx2>=2.12.0
     validators>=0.34.0,<1.0.0
     authlib>=1.6.7,<2.0.0
     # When bumping authlib to >=2.0.0, remove the `authlib.jose` deprecation

--- a/weaviate/aliases/executor.py
+++ b/weaviate/aliases/executor.py
@@ -1,6 +1,9 @@
 from typing import Dict, Generic, List, Optional, cast
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.aliases.alias import AliasReturn, _WeaviateAlias
 from weaviate.connect import executor

--- a/weaviate/aliases/executor.py
+++ b/weaviate/aliases/executor.py
@@ -1,9 +1,6 @@
 from typing import Dict, Generic, List, Optional, cast
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.aliases.alias import AliasReturn, _WeaviateAlias
 from weaviate.connect import executor

--- a/weaviate/backup/executor.py
+++ b/weaviate/backup/executor.py
@@ -4,7 +4,10 @@ import asyncio
 import time
 from typing import Dict, Generic, List, Literal, Optional, Tuple, Union
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.backup.backup import (
     STORAGE_NAMES,

--- a/weaviate/backup/executor.py
+++ b/weaviate/backup/executor.py
@@ -4,10 +4,7 @@ import asyncio
 import time
 from typing import Dict, Generic, List, Literal, Optional, Tuple, Union
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.backup.backup import (
     STORAGE_NAMES,

--- a/weaviate/client_executor.py
+++ b/weaviate/client_executor.py
@@ -12,7 +12,10 @@ from typing import (
     cast,
 )
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.collections.classes.internal import _GQLEntryReturnType, _RawGQLReturn
 from weaviate.integrations import _Integrations

--- a/weaviate/client_executor.py
+++ b/weaviate/client_executor.py
@@ -12,10 +12,7 @@ from typing import (
     cast,
 )
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.collections.classes.internal import _GQLEntryReturnType, _RawGQLReturn
 from weaviate.integrations import _Integrations

--- a/weaviate/cluster/base.py
+++ b/weaviate/cluster/base.py
@@ -1,7 +1,10 @@
 import uuid
 from typing import Generic, List, Optional, Union
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.cluster.models import (
     ClusterStatistics,

--- a/weaviate/cluster/base.py
+++ b/weaviate/cluster/base.py
@@ -1,10 +1,7 @@
 import uuid
 from typing import Generic, List, Optional, Union
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.cluster.models import (
     ClusterStatistics,

--- a/weaviate/cluster/replicate/executor.py
+++ b/weaviate/cluster/replicate/executor.py
@@ -1,6 +1,9 @@
 from typing import Generic, Literal, Optional, overload
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.cluster.models import (
     ReplicateOperation,

--- a/weaviate/cluster/replicate/executor.py
+++ b/weaviate/cluster/replicate/executor.py
@@ -1,9 +1,6 @@
 from typing import Generic, Literal, Optional, overload
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.cluster.models import (
     ReplicateOperation,

--- a/weaviate/collections/aggregations/base_executor.py
+++ b/weaviate/collections/aggregations/base_executor.py
@@ -3,7 +3,10 @@ import json
 import pathlib
 from typing import Generic, List, Optional, TypeVar, Union, cast
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 from typing_extensions import ParamSpec
 
 from weaviate.collections.classes.aggregate import (

--- a/weaviate/collections/aggregations/base_executor.py
+++ b/weaviate/collections/aggregations/base_executor.py
@@ -3,10 +3,7 @@ import json
 import pathlib
 from typing import Generic, List, Optional, TypeVar, Union, cast
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 from typing_extensions import ParamSpec
 
 from weaviate.collections.classes.aggregate import (

--- a/weaviate/collections/batch/rest.py
+++ b/weaviate/collections/batch/rest.py
@@ -1,6 +1,9 @@
 from typing import Dict, List, Optional
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.collections.classes.batch import (
     BatchReference,

--- a/weaviate/collections/batch/rest.py
+++ b/weaviate/collections/batch/rest.py
@@ -1,9 +1,6 @@
 from typing import Dict, List, Optional
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.collections.classes.batch import (
     BatchReference,

--- a/weaviate/collections/collections/executor.py
+++ b/weaviate/collections/collections/executor.py
@@ -11,7 +11,10 @@ from typing import (
     Union,
 )
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 from pydantic import ValidationError
 
 from weaviate.collections.classes.config import (

--- a/weaviate/collections/collections/executor.py
+++ b/weaviate/collections/collections/executor.py
@@ -11,10 +11,7 @@ from typing import (
     Union,
 )
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 from pydantic import ValidationError
 
 from weaviate.collections.classes.config import (

--- a/weaviate/collections/config/executor.py
+++ b/weaviate/collections/config/executor.py
@@ -13,7 +13,10 @@ from typing import (
     overload,
 )
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 from pydantic_core import ValidationError
 from typing_extensions import deprecated
 

--- a/weaviate/collections/config/executor.py
+++ b/weaviate/collections/config/executor.py
@@ -13,10 +13,7 @@ from typing import (
     overload,
 )
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 from pydantic_core import ValidationError
 from typing_extensions import deprecated
 

--- a/weaviate/collections/data/executor.py
+++ b/weaviate/collections/data/executor.py
@@ -18,7 +18,10 @@ from typing import (
     overload,
 )
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.collections.batch.base import _BatchDataWrapper
 from weaviate.collections.batch.collection import (

--- a/weaviate/collections/data/executor.py
+++ b/weaviate/collections/data/executor.py
@@ -18,10 +18,7 @@ from typing import (
     overload,
 )
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.collections.batch.base import _BatchDataWrapper
 from weaviate.collections.batch.collection import (

--- a/weaviate/collections/tenants/executor.py
+++ b/weaviate/collections/tenants/executor.py
@@ -2,7 +2,10 @@ import asyncio
 from math import ceil
 from typing import Any, Dict, Generic, List, Optional, Sequence, Union
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.collections.classes.tenants import (
     Tenant,

--- a/weaviate/collections/tenants/executor.py
+++ b/weaviate/collections/tenants/executor.py
@@ -2,10 +2,7 @@ import asyncio
 from math import ceil
 from typing import Any, Dict, Generic, List, Optional, Sequence, Union
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.collections.classes.tenants import (
     Tenant,

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Awaitable, Callable, Dict, List, Optional, Union
 
-import httpx
+try:
+    import httpx2 as httpx
+except ImportError:
+    import httpx
 from authlib.integrations.httpx_client import (  # type: ignore
     AsyncOAuth2Client,
     OAuth2Client,

--- a/weaviate/connect/authentication.py
+++ b/weaviate/connect/authentication.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from typing import Awaitable, Callable, Dict, List, Optional, Union
 
-try:
-    import httpx2 as httpx
-except ImportError:
-    import httpx
+import httpx2
 from authlib.integrations.httpx_client import (  # type: ignore
     AsyncOAuth2Client,
     OAuth2Client,
@@ -28,8 +25,8 @@ OIDC_CONFIG = Dict[str, Union[str, List[str]]]
 
 Result = Union[OAuth2Client, Awaitable[AsyncOAuth2Client]]
 MountsMaker = Union[
-    Callable[[], Dict[str, httpx.AsyncHTTPTransport]],
-    Callable[[], Dict[str, httpx.HTTPTransport]],
+    Callable[[], Dict[str, httpx2.AsyncHTTPTransport]],
+    Callable[[], Dict[str, httpx2.HTTPTransport]],
 ]
 
 
@@ -114,7 +111,7 @@ class _Auth:
         if self._token_endpoint is not None:
             return executor.return_(self._token_endpoint, self.__colour)
 
-        def resp(res: httpx.Response) -> str:
+        def resp(res: httpx2.Response) -> str:
             data = _decode_json_response_dict(res, "Get token endpoint")
             assert data is not None
             token_endpoint = data["token_endpoint"]
@@ -124,19 +121,19 @@ class _Auth:
         if self.__colour == "async":
 
             async def _execute() -> str:
-                mounts: Dict[str, httpx.AsyncBaseTransport] = {}
+                mounts: Dict[str, httpx2.AsyncBaseTransport] = {}
                 for key, mount in self.__make_mounts().items():
-                    assert isinstance(mount, httpx.AsyncHTTPTransport)
+                    assert isinstance(mount, httpx2.AsyncHTTPTransport)
                     mounts[key] = mount
-                async with httpx.AsyncClient(mounts=mounts) as client:
+                async with httpx2.AsyncClient(mounts=mounts) as client:
                     return resp(await client.get(self._open_id_config_url))
 
             return _execute()
-        mounts: Dict[str, httpx.BaseTransport] = {}
+        mounts: Dict[str, httpx2.BaseTransport] = {}
         for key, mount in self.__make_mounts().items():
-            assert isinstance(mount, httpx.BaseTransport)
+            assert isinstance(mount, httpx2.BaseTransport)
             mounts[key] = mount
-        with httpx.Client(mounts=mounts) as client:
+        with httpx2.Client(mounts=mounts) as client:
             return resp(client.get(self._open_id_config_url))
 
     def get_auth_session(self) -> Result:

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -33,7 +33,10 @@ from grpc.aio import AioRpcError, StreamStreamCall
 from grpc.aio import Channel as AsyncChannel  # type: ignore
 
 # from grpclib.client import Channel
-from httpx import (
+try:
+    from httpx2 import (
+except ImportError:
+    from httpx import (
     AsyncClient,
     AsyncHTTPTransport,
     Client,

--- a/weaviate/connect/v4.py
+++ b/weaviate/connect/v4.py
@@ -33,10 +33,7 @@ from grpc.aio import AioRpcError, StreamStreamCall
 from grpc.aio import Channel as AsyncChannel  # type: ignore
 
 # from grpclib.client import Channel
-try:
-    from httpx2 import (
-except ImportError:
-    from httpx import (
+from httpx2 import (
     AsyncClient,
     AsyncHTTPTransport,
     Client,
@@ -627,14 +624,14 @@ class _ConnectionBase:
     ) -> Timeout:
         """Get the timeout for the request.
 
-        In this way, the client waits the `httpx` default of 5s when connecting to a socket (connect), writing chunks (write), and
+        In this way, the client waits the `httpx2` default of 5s when connecting to a socket (connect), writing chunks (write), and
         acquiring a connection from the pool (pool), but a custom amount as specified for reading the response (read).
 
         From the PoV of the user, a request is considered to be timed out if no response is received within the specified time.
         They specify the times depending on how they expect Weaviate to behave. For example, a query might take longer than an insert or vice versa
         but, in either case, the user only cares about how long it takes for a response to be received.
 
-        https://www.python-httpx.org/advanced/timeouts/
+        https://www.python-httpx2.org/advanced/timeouts/
         """
         timeout = None
         if method == "DELETE" or method == "PATCH" or method == "PUT":

--- a/weaviate/debug/executor.py
+++ b/weaviate/debug/executor.py
@@ -1,6 +1,9 @@
 from typing import Dict, Generic, Optional
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.classes.config import ConsistencyLevel
 from weaviate.connect import executor

--- a/weaviate/debug/executor.py
+++ b/weaviate/debug/executor.py
@@ -1,9 +1,6 @@
 from typing import Dict, Generic, Optional
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.classes.config import ConsistencyLevel
 from weaviate.connect import executor

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
-import httpx
+try:
+    import httpx2 as httpx
+except ImportError:
+    import httpx
 import validators
 
 from weaviate import exceptions

--- a/weaviate/embedded.py
+++ b/weaviate/embedded.py
@@ -15,10 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
-try:
-    import httpx2 as httpx
-except ImportError:
-    import httpx
+import httpx2
 import validators
 
 from weaviate import exceptions
@@ -91,7 +88,7 @@ class _EmbeddedBase:
             self._parsed_weaviate_version = version_tag
             self._set_download_url_from_version_tag(version_tag)
         elif self.options.version == "latest":
-            response = httpx.get("https://api.github.com/repos/weaviate/weaviate/releases/latest")
+            response = httpx2.get("https://api.github.com/repos/weaviate/weaviate/releases/latest")
             latest = _decode_json_response_dict(response, "get tag of latest weaviate release")
             assert latest is not None
             version_tag = latest["tag_name"]

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -3,7 +3,10 @@
 from json.decoder import JSONDecodeError
 from typing import Optional, Tuple, Union, cast
 
-import httpx
+try:
+    import httpx2 as httpx
+except ImportError:
+    import httpx
 from grpc import Call, StatusCode  # type: ignore
 from grpc.aio import AioRpcError  # type: ignore
 from packaging import version

--- a/weaviate/exceptions.py
+++ b/weaviate/exceptions.py
@@ -3,10 +3,7 @@
 from json.decoder import JSONDecodeError
 from typing import Optional, Tuple, Union, cast
 
-try:
-    import httpx2 as httpx
-except ImportError:
-    import httpx
+import httpx2
 from grpc import Call, StatusCode  # type: ignore
 from grpc.aio import AioRpcError  # type: ignore
 from packaging import version
@@ -34,7 +31,7 @@ class WeaviateBaseError(Exception):
 
 
 class UnexpectedStatusCodeError(WeaviateBaseError):
-    def __init__(self, message: str, response: Union[httpx.Response, AioRpcError, Call]):
+    def __init__(self, message: str, response: Union[httpx2.Response, AioRpcError, Call]):
         """Is raised in case the status code returned from Weaviate is not handled in the client implementation and suggests an error.
 
         Custom code can act on the attributes:
@@ -45,13 +42,13 @@ class UnexpectedStatusCodeError(WeaviateBaseError):
             message: An error message specific to the context, in which the error occurred.
             response: The request response of which the status code was unexpected.
         """
-        if isinstance(response, httpx.Response):
+        if isinstance(response, httpx2.Response):
             self._status_code: int = response.status_code
             # Set error message
 
             try:
                 body = response.json()
-            except (httpx.DecodingError, JSONDecodeError):
+            except (httpx2.DecodingError, JSONDecodeError):
                 body = None
 
             msg = (
@@ -93,7 +90,7 @@ UnexpectedStatusCodeException = UnexpectedStatusCodeError
 
 
 class ResponseCannotBeDecodedError(WeaviateBaseError):
-    def __init__(self, location: str, response: httpx.Response):
+    def __init__(self, location: str, response: httpx2.Response):
         """Raised when a weaviate response cannot be decoded to json.
 
         Args:
@@ -401,7 +398,7 @@ class WeaviateRetryError(WeaviateBaseError):
 class InsufficientPermissionsError(UnexpectedStatusCodeError):
     """Is raised when a request to Weaviate fails due to insufficient permissions."""
 
-    def __init__(self, res: Union[httpx.Response, AioRpcError, Call]) -> None:
+    def __init__(self, res: Union[httpx2.Response, AioRpcError, Call]) -> None:
         super().__init__("forbidden", res)
 
 

--- a/weaviate/export/executor.py
+++ b/weaviate/export/executor.py
@@ -4,7 +4,10 @@ import asyncio
 import time
 from typing import Generic, List, Literal, Tuple, Union, overload
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.backup.backup import STORAGE_NAMES
 from weaviate.connect import executor

--- a/weaviate/export/executor.py
+++ b/weaviate/export/executor.py
@@ -4,10 +4,7 @@ import asyncio
 import time
 from typing import Generic, List, Literal, Tuple, Union, overload
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.backup.backup import STORAGE_NAMES
 from weaviate.connect import executor

--- a/weaviate/groups/base.py
+++ b/weaviate/groups/base.py
@@ -1,6 +1,9 @@
 from typing import Dict, Generic, List, Literal, Union, overload
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.connect import executor
 from weaviate.connect.v4 import ConnectionType, _ExpectedStatusCodes

--- a/weaviate/groups/base.py
+++ b/weaviate/groups/base.py
@@ -1,9 +1,6 @@
 from typing import Dict, Generic, List, Literal, Union, overload
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.connect import executor
 from weaviate.connect.v4 import ConnectionType, _ExpectedStatusCodes

--- a/weaviate/rbac/executor.py
+++ b/weaviate/rbac/executor.py
@@ -2,7 +2,10 @@ import asyncio
 import json
 from typing import Dict, Generic, List, Optional, Sequence, Union, cast
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 from typing_extensions import deprecated
 
 from weaviate.connect import executor

--- a/weaviate/rbac/executor.py
+++ b/weaviate/rbac/executor.py
@@ -2,10 +2,7 @@ import asyncio
 import json
 from typing import Dict, Generic, List, Optional, Sequence, Union, cast
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 from typing_extensions import deprecated
 
 from weaviate.connect import executor

--- a/weaviate/tokenization/executor.py
+++ b/weaviate/tokenization/executor.py
@@ -2,7 +2,10 @@
 
 from typing import Any, Dict, Generic, List, Optional, Union, overload
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 
 from weaviate.collections.classes.config import (
     StopwordsConfig,

--- a/weaviate/tokenization/executor.py
+++ b/weaviate/tokenization/executor.py
@@ -2,10 +2,7 @@
 
 from typing import Any, Dict, Generic, List, Optional, Union, overload
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 
 from weaviate.collections.classes.config import (
     StopwordsConfig,

--- a/weaviate/users/base.py
+++ b/weaviate/users/base.py
@@ -1,7 +1,10 @@
 from datetime import datetime, timezone
 from typing import Any, Dict, Generic, List, Literal, Optional, Union, cast, overload
 
-from httpx import Response
+try:
+    from httpx2 import Response
+except ImportError:
+    from httpx import Response
 from typing_extensions import deprecated
 
 from weaviate.connect import executor

--- a/weaviate/users/base.py
+++ b/weaviate/users/base.py
@@ -1,10 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any, Dict, Generic, List, Literal, Optional, Union, cast, overload
 
-try:
-    from httpx2 import Response
-except ImportError:
-    from httpx import Response
+from httpx2 import Response
 from typing_extensions import deprecated
 
 from weaviate.connect import executor

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -13,7 +13,10 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Tuple, Union, cast
 from urllib.parse import quote
 
-import httpx
+try:
+    import httpx2 as httpx
+except ImportError:
+    import httpx
 import validators
 
 from weaviate.exceptions import (

--- a/weaviate/util.py
+++ b/weaviate/util.py
@@ -13,10 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Tuple, Union, cast
 from urllib.parse import quote
 
-try:
-    import httpx2 as httpx
-except ImportError:
-    import httpx
+import httpx2
 import validators
 
 from weaviate.exceptions import (
@@ -728,7 +725,7 @@ def _to_beacons(uuids: UUIDS, to_class: str = "") -> List[Dict[str, str]]:
     return [{"beacon": f"weaviate://localhost/{to_class}{uuid_to}"} for uuid_to in uuids]
 
 
-def _decode_json_response_dict(response: httpx.Response, location: str) -> Optional[Dict[str, Any]]:
+def _decode_json_response_dict(response: httpx2.Response, location: str) -> Optional[Dict[str, Any]]:
     if response is None:
         return None
 
@@ -736,14 +733,14 @@ def _decode_json_response_dict(response: httpx.Response, location: str) -> Optio
         try:
             json_response = cast(Dict[str, Any], response.json())
             return json_response
-        except (httpx.DecodingError, json.decoder.JSONDecodeError):
+        except (httpx2.DecodingError, json.decoder.JSONDecodeError):
             raise ResponseCannotBeDecodedError(location, response)
 
     raise UnexpectedStatusCodeError(location, response)
 
 
 def _decode_json_response_list(
-    response: httpx.Response, location: str
+    response: httpx2.Response, location: str
 ) -> Optional[List[Dict[str, Any]]]:
     if response is None:
         return None
@@ -752,7 +749,7 @@ def _decode_json_response_list(
         try:
             json_response = response.json()
             return cast(list, json_response)
-        except (httpx.DecodingError, json.decoder.JSONDecodeError):
+        except (httpx2.DecodingError, json.decoder.JSONDecodeError):
             raise ResponseCannotBeDecodedError(location, response)
     raise UnexpectedStatusCodeError(location, response)
 


### PR DESCRIPTION
Closes #2154

> 🏷️ *Part of [HTTPXodus](https://github.com/ProgrammerPlus1998/httpxodus) — a community effort to help major Python projects plan their path off the stalled `httpx` stable line onto [`httpx2`](https://github.com/pydantic/httpx2), the actively maintained fork by Pydantic Services.*

## What this PR does

**Complete hard switch** from `httpx` to `httpx2`:
- Removes all 21 `try/except ImportError` dual-import blocks — direct `httpx2` imports everywhere (`connect/v4.py`, `util.py`, `embedded.py`, `exceptions.py`, `client_executor.py`, etc.)
- `setup.cfg`: drops `httpx>=0.26.0,<0.29.0`; `httpx2>=2.12.0` unconditional (`python_requires` is already `>=3.10`, matching httpx2's floor)

## Test results

- Unit suite (`test/`, excluding `test/collection` which needs a live server): **91 passed** with httpx2 2.12.0 in an isolated env

## Notes for reviewer

- ⚠️ **TLS behavior change**: `httpx2` verifies TLS against the **OS trust store** (via `truststore`) instead of the bundled `certifi`. Deployments that relied on certifi's CA bundle (minimal containers, corporate proxies) may need `SSL_CERT_FILE` / `SSL_CERT_DIR` after the switch. Worth a line in the changelog.

Happy to revise per review — and equally happy to close this PR if the maintainers would rather wait for `httpx` 1.0 stable. 🙏
