### PR TITLE
Add pathseer filter strategy for HNSW vector index

### DIFF
--- a/integration/test_collection_config.py
+++ b/integration/test_collection_config.py
@@ -702,6 +702,42 @@ def test_hnsw_with_rq4c(collection_factory: CollectionFactory) -> None:
     assert config.vector_index_config.quantizer.training_limit == 10000
 
 
+def test_hnsw_with_pathseer_filter_strategy(collection_factory: CollectionFactory) -> None:
+    dummy = collection_factory("dummy")
+    if dummy._connection._weaviate_version.is_lower_than(1, 40, 0):
+        pytest.skip(
+            "pathseer filter strategy is not supported in Weaviate versions lower than 1.40.0"
+        )
+
+    collection = collection_factory(
+        vector_index_config=Configure.VectorIndex.hnsw(
+            filter_strategy=wvc.config.VectorFilterStrategy.PATHSEER,
+        ),
+    )
+
+    config = collection.config.get()
+    assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
+    assert config.vector_index_config.filter_strategy == wvc.config.VectorFilterStrategy.PATHSEER
+
+    collection.config.update(
+        vector_index_config=Reconfigure.VectorIndex.hnsw(
+            filter_strategy=wvc.config.VectorFilterStrategy.ACORN,
+        ),
+    )
+    config = collection.config.get()
+    assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
+    assert config.vector_index_config.filter_strategy == wvc.config.VectorFilterStrategy.ACORN
+
+    collection.config.update(
+        vector_index_config=Reconfigure.VectorIndex.hnsw(
+            filter_strategy=wvc.config.VectorFilterStrategy.PATHSEER,
+        ),
+    )
+    config = collection.config.get()
+    assert isinstance(config.vector_index_config, _VectorIndexConfigHNSW)
+    assert config.vector_index_config.filter_strategy == wvc.config.VectorFilterStrategy.PATHSEER
+
+
 @pytest.mark.parametrize(
     "vector_index_config",
     [

--- a/test/collection/test_config.py
+++ b/test/collection/test_config.py
@@ -22,6 +22,7 @@ from weaviate.collections.classes.config import (
     _VectorizerConfigCreate,
     _ReplicationConfigCreate,
     ReplicationDeletionStrategy,
+    VectorFilterStrategy,
 )
 from weaviate.collections.classes.config_named_vectors import _NamedVectorConfigCreate
 from weaviate.collections.classes.config_vectorizers import (
@@ -1662,6 +1663,16 @@ def test_vector_config_hnsw_rq4c() -> None:
     assert vi_dict["rq"]["centering"] is True
     assert vi_dict["rq"]["rescoreLimit"] == 123
     assert vi_dict["rq"]["trainingLimit"] == 5012
+
+
+def test_vector_config_hnsw_pathseer_filter_strategy() -> None:
+    vector_index = Configure.VectorIndex.hnsw(
+        filter_strategy=VectorFilterStrategy.PATHSEER,
+    )
+
+    vi_dict = vector_index._to_dict()
+
+    assert vi_dict["filterStrategy"] == "pathseer"
 
 
 def test_vector_config_flat_pq() -> None:

--- a/weaviate/collections/classes/config_vector_index.py
+++ b/weaviate/collections/classes/config_vector_index.py
@@ -22,10 +22,12 @@ class VectorFilterStrategy(str, Enum):
     Attributes:
         SWEEPING: Do normal ANN search and skip nodes.
         ACORN: Multi-hop search to find new candidates matching the filter.
+        PATHSEER: Adaptive search that decides per query between sweeping and multi-hop candidate discovery.
     """
 
     SWEEPING = "sweeping"
     ACORN = "acorn"
+    PATHSEER = "pathseer"
 
 
 class VectorIndexType(str, Enum):


### PR DESCRIPTION
## Motivation

Weaviate core is adding `pathseer` (weaviate/weaviate#12137, targeting 1.40), a third HNSW filter strategy that adaptively decides per query between sweeping and multi-hop candidate discovery. The client needs to expose it so users can configure it — but more importantly, without the enum value the client cannot even *read* the config of a collection that uses it: `collection.config.get()` deserializes the server response via `VectorFilterStrategy(config["filterStrategy"])` and raises a `ValueError` on the unknown string. This makes the change a forward-compatibility fix as well as a feature enablement.

## Approach

Add `PATHSEER = "pathseer"` to the existing `VectorFilterStrategy` enum in `config_vector_index.py`. No serialization or validation changes are needed — the strategy is passed through as a string and validated server-side, which keeps the client agnostic to strategy semantics (same pattern as `ACORN`).

## Risks and mitigations

- **Older servers rejecting the value**: the client doesn't gate on server version by design; a pre-1.40 server returns a clear validation error. Consistent with how other newer config options are handled.
- Otherwise trivial: additive enum value, no behavior change for existing strategies.

## Testing

- Unit: `Configure.VectorIndex.hnsw(filter_strategy=PATHSEER)` serializes to `"filterStrategy": "pathseer"`.
- Integration (skipped below server 1.40.0): creates a collection with pathseer, reads it back via `config.get()` (exercising the deserialization path that previously would have raised), then round-trips `Reconfigure` updates pathseer → acorn → pathseer to verify the strategy is mutable in both directions. Verified passing against a local `1.40.0-dev` server built from the core branch.
